### PR TITLE
Extend size of the Variable::cse_scope member with some reshuffling

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -91,15 +91,17 @@ uint32_t jit_cse_scope(JitBackend backend) {
     return thread_state(backend)->cse_scope;
 }
 
-void jit_set_cse_scope(JitBackend backend, uint32_t domain) {
+void jit_set_cse_scope(JitBackend backend, uint32_t scope_id) {
     lock_guard guard(state.lock);
-    thread_state(backend)->cse_scope = domain;
+    jitc_trace("jit_set_cse_scope(%u)", scope_id);
+    thread_state(backend)->cse_scope = scope_id;
 }
 
 void jit_new_cse_scope(JitBackend backend) {
     lock_guard guard(state.lock);
     ThreadState *ts = thread_state(backend);
     ts->cse_scope = ++state.cse_scope_ctr;
+    jitc_trace("jit_new_cse_scope(%u)", ts->cse_scope);
 }
 
 void jit_set_log_level_stderr(LogLevel level) {

--- a/src/log.h
+++ b/src/log.h
@@ -15,7 +15,7 @@
 
 #define ENOKI_DISABLE_TRACE 1
 
-#if defined(ENOKI_DISABLE_TRACE)
+#if ENOKI_DISABLE_TRACE
 #  define jitc_trace(...) do { } while (0)
 #else
 #  define jitc_trace(...) jitc_log(Trace, __VA_ARGS__)

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -402,8 +402,15 @@ uint32_t jitc_var_new(Variable &v, bool disable_cse) {
         do {
             index = state.variable_index++;
 
-            if (unlikely(index == 0)) // overflow
+            if (unlikely(index == 0)) { // overflow
+                jitc_fail(
+                    "Enoki-JIT has created more than 2^32 (4 billion) "
+                    "variables, which is currently the limit. Bug Wenzel to "
+                    "fix this (it will involve sorting scheduled variables by "
+                    "scope ID instead of variable ID and making the counter "
+                    "big enough that it will never overflow..).");
                 index = state.variable_index++;
+            }
 
             std::tie(var_it, var_inserted) =
                 state.variables.try_emplace(index, v);


### PR DESCRIPTION
The 'cse_scope' variable was too small at 13 bits, and it turns out that
we ran into overflows during larger runs. This commit increases the size
to 24 bits, which ought to be enough for everyone :-)..
(it goes from 8K -> 16M).