### PR TITLE
Remove deallocation of input statement

### DIFF
--- a/src/var.cpp
+++ b/src/var.cpp
@@ -626,8 +626,6 @@ uint32_t jitc_var_new_stmt(JitBackend backend, VarType vt, const char *stmt,
     }
 
     if (unlikely(size == 0)) {
-        if (!stmt_static)
-            free((char *) stmt);
         return 0;
     } else if (unlikely(uninitialized)) {
         jitc_raise("jit_var_new_stmt(): arithmetic involving an "


### PR DESCRIPTION
This PR remove a string deallocation in `var.cpp`.

The current deallocation causes warnings with GCC, as it might lead to deallocation attempts of stack-allocated variables like in [this case](
https://github.com/mitsuba-renderer/drjit-core/blob/master/src/optix_api.cpp#L752-L755).

For API consistency, I think that it is nicer to entirely remove this deallocation. In a "normal" use case, when the input statement is not in the data segment of the executable (`stmt_static == 0`) the statement is [duplicated and never deallocated](https://github.com/mitsuba-renderer/drjit-core/blob/master/src/var.cpp#L660-L667), we should apply this same behavior in the case affected by this PR.

Note: We currently don't have a single caller of `jit(c)_var_new_stmt` that uses heap-allocated statements, hence no other code changes are necesary.