### PR TITLE
Fix unreported cause of optix_initialize failure

### DIFF
--- a/src/optix_api.cpp
+++ b/src/optix_api.cpp
@@ -264,7 +264,7 @@ bool jitc_optix_init() {
 #endif
 
         if (!jitc_optix_handle) {
-            jitc_log(Warn, "jit_optix_init(): %s could not be loaded -- "
+            jitc_log(Error, "jit_optix_init(): %s could not be loaded -- "
                           "disabling OptiX backend! Set the DRJIT_LIBOPTIX_PATH "
                           "environment variable to specify its path.", optix_fname);
             return false;
@@ -276,14 +276,14 @@ bool jitc_optix_init() {
         dlsym(jitc_optix_handle, "optixQueryFunctionTable"));
 
     if (!optixQueryFunctionTable) {
-        jitc_log(Warn, "jit_optix_init(): could not find symbol optixQueryFunctionTable");
+        jitc_log(Error, "jit_optix_init(): could not find symbol optixQueryFunctionTable");
         return false;
     }
 
     int rv = optixQueryFunctionTable(OPTIX_ABI_VERSION, 0, 0, 0,
                                      &jitc_optix_table, sizeof(jitc_optix_table));
     if (rv) {
-        jitc_log(Warn,
+        jitc_log(Error,
                 "jit_optix_init(): Failed to load OptiX library! Very likely, "
                 "your NVIDIA graphics driver is too old and not compatible "
                 "with the version of OptiX that is being used. In particular, "


### PR DESCRIPTION
When running mitsuba3 for **cuda_rgb** I got the following error:

```
robin@ray:~/src/mitsuba3$ ./build/mitsuba -t 1 -m cuda_rgb resources/data/scenes/cbox/cbox-rgb.xml   -o test
2022-08-15 11:03:31 INFO  main  [mitsuba.cpp:341] Mitsuba version 3.0.1 (robin/upgrade-mitsuba3[64e8b42a], Linux, 64bit, 1 thread, 8-wide SIMD)
2022-08-15 11:03:31 INFO  main  [mitsuba.cpp:342] Copyright 2022, Realistic Graphics Lab, EPFL
2022-08-15 11:03:31 INFO  main  [mitsuba.cpp:343] Enabled processor features: cuda llvm avx2 avx fma f16c sse4.2 x86_64
2022-08-15 11:03:31 INFO  main  [xml.cpp:1393] Loading XML file "resources/data/scenes/cbox/cbox-rgb.xml" with variant "cuda_rgb"..
2022-08-15 11:03:31 INFO  main  [xml.cpp:668] Loading included XML file "resources/data/scenes/cbox/fragments/base.xml" ..
2022-08-15 11:03:31 INFO  main  [xml.cpp:668] Loading included XML file "resources/data/scenes/cbox/fragments/bsdfs-rgb.xml" ..
2022-08-15 11:03:31 INFO  main  [xml.cpp:668] Loading included XML file "resources/data/scenes/cbox/fragments/shapes.xml" ..
2022-08-15 11:03:31 INFO  main  [Scene] Building scene in OptiX ..

Caught a critical exception: [xml.cpp:1117] Error while loading "resources/data/scenes/cbox/cbox-rgb.xml" (near line 1, col 1): could not instantiate scene plugin of type "scene": Could not initialize OptiX!
```

The cause of the error is actually:
```
jit_optix_init(): Failed to load OptiX library! Very likely, your NVIDIA graphics driver is too old and not compatible with the version of OptiX that is being used. In particular, OptiX 7.4 requires driver revision R495.89 or newer.
```
..but it is not actually written (and hence hard to fix) because the log level of this message in optix_api.cpp is too low (Warn instead of Error)

I fix this by changing the log level for these messages. I guess one could also fix this by setting a new state log level threshold but I leave this to you what to decide.