### PR TITLE
Optix pipeline and SBT management refactoring

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -858,19 +858,23 @@ void *jit_optix_lookup(const char *name) {
     return jitc_optix_lookup(name);
 }
 
-uint32_t jit_optix_configure(const OptixPipelineCompileOptions *pco,
-                             OptixModule module,
-                             const OptixShaderBindingTable *sbt,
-                             const OptixProgramGroup *pg,
-                             uint32_t pg_count) {
+uint32_t jit_optix_configure_pipeline(const OptixPipelineCompileOptions *pco,
+                                      OptixModule module,
+                                      const OptixProgramGroup *pg,
+                                      uint32_t pg_count) {
     lock_guard guard(state.lock);
-    return jitc_optix_configure(pco, module, sbt, pg, pg_count);
+    return jitc_optix_configure_pipeline(pco, module, pg, pg_count);
+}
+
+uint32_t jit_optix_configure_sbt(const OptixShaderBindingTable *sbt, uint32_t pipeline) {
+    lock_guard guard(state.lock);
+    return jitc_optix_configure_sbt(sbt, pipeline);
 }
 
 void jit_optix_ray_trace(uint32_t nargs, uint32_t *args, uint32_t mask,
-                         uint32_t pipeline) {
+                         uint32_t pipeline, uint32_t sbt) {
     lock_guard guard(state.lock);
-    jitc_optix_ray_trace(nargs, args, mask, pipeline);
+    jitc_optix_ray_trace(nargs, args, mask, pipeline, sbt);
 }
 
 void jit_optix_mark(uint32_t index) {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -246,8 +246,7 @@ int jit_cuda_compute_capability() {
     return state.devices[thread_state(JitBackend::CUDA)->device].compute_capability;
 }
 
-void jit_cuda_set_target(uint32_t ptx_version,
-                          uint32_t compute_capability) {
+void jit_cuda_set_target(uint32_t ptx_version, uint32_t compute_capability) {
     lock_guard guard(state.lock);
     ThreadState *ts = thread_state(JitBackend::CUDA);
     ts->ptx_version = ptx_version;
@@ -859,17 +858,19 @@ void *jit_optix_lookup(const char *name) {
     return jitc_optix_lookup(name);
 }
 
-void jit_optix_configure(const OptixPipelineCompileOptions *pco,
-                          const OptixShaderBindingTable *sbt,
-                          const OptixProgramGroup *pg,
-                          uint32_t pg_count) {
+uint32_t jit_optix_configure(const OptixPipelineCompileOptions *pco,
+                             OptixModule module,
+                             const OptixShaderBindingTable *sbt,
+                             const OptixProgramGroup *pg,
+                             uint32_t pg_count) {
     lock_guard guard(state.lock);
-    jitc_optix_configure(pco, sbt, pg, pg_count);
+    return jitc_optix_configure(pco, module, sbt, pg, pg_count);
 }
 
-void jit_optix_ray_trace(uint32_t nargs, uint32_t *args, uint32_t mask) {
+void jit_optix_ray_trace(uint32_t nargs, uint32_t *args, uint32_t mask,
+                         uint32_t pipeline) {
     lock_guard guard(state.lock);
-    jitc_optix_ray_trace(nargs, args, mask);
+    jitc_optix_ray_trace(nargs, args, mask, pipeline);
 }
 
 void jit_optix_mark(uint32_t index) {

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -329,8 +329,7 @@ Task *jitc_run(ThreadState *ts, ScheduledGroup group) {
 
 #if defined(DRJIT_ENABLE_OPTIX)
     if (uses_optix) {
-        const OptixPipelineCompileOptions &pco =
-            ts->optix_pipeline_compile_options;
+        const OptixPipelineCompileOptions &pco = ts->optix_pipeline->compile_options;
         flags =
             ((uint64_t) pco.numAttributeValues << 0)      + // 4 bit
             ((uint64_t) pco.numPayloadValues   << 4)      + // 4 bit

--- a/src/eval_cuda.cpp
+++ b/src/eval_cuda.cpp
@@ -13,6 +13,11 @@ void jitc_assemble_cuda(ThreadState *ts, ScheduledGroup group,
                                  state.log_level_callback) >= LogLevel::Trace ||
                         (jitc_flags() & (uint32_t) JitFlag::PrintIR);
 
+    // If use optix and the kernel contains no ray tracing operations, fallback
+    // to the default OptiX pipeline.
+    if (uses_optix)
+        ts->optix_pipeline = state.optix_default_pipeline;
+
     /* Special registers:
 
          %r0   :  Index

--- a/src/eval_cuda.cpp
+++ b/src/eval_cuda.cpp
@@ -14,9 +14,11 @@ void jitc_assemble_cuda(ThreadState *ts, ScheduledGroup group,
                         (jitc_flags() & (uint32_t) JitFlag::PrintIR);
 
     // If use optix and the kernel contains no ray tracing operations, fallback
-    // to the default OptiX pipeline.
-    if (uses_optix)
+    // to the default OptiX pipeline and shader binding table.
+    if (uses_optix) {
         ts->optix_pipeline = state.optix_default_pipeline;
+        ts->optix_sbt = state.optix_default_sbt;
+    }
 
     /* Special registers:
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -258,6 +258,12 @@ void jitc_shutdown(int light) {
         }
     }
 
+#if defined(DRJIT_ENABLE_OPTIX)
+        // OptiX: free the default OptiX pipeline
+        if (state.optix_default_pipeline)
+            jitc_var_dec_ref_ext(state.optix_default_pipeline->index);
+#endif
+
     if (!state.tss.empty()) {
         jitc_log(Info, "jit_shutdown(): releasing %zu thread state%s ..",
                 state.tss.size(), state.tss.size() > 1 ? "s" : "");
@@ -270,9 +276,6 @@ void jitc_shutdown(int light) {
             jitc_free_flush(ts);
             if (ts->backend == JitBackend::CUDA) {
                 scoped_set_context guard(ts->context);
-#if defined(DRJIT_ENABLE_OPTIX)
-                jitc_optix_context_destroy_ts(ts);
-#endif
                 cuda_check(cuEventDestroy(ts->event));
                 cuda_check(cuStreamSynchronize(ts->stream));
                 cuda_check(cuStreamDestroy(ts->stream));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -259,9 +259,9 @@ void jitc_shutdown(int light) {
     }
 
 #if defined(DRJIT_ENABLE_OPTIX)
-        // OptiX: free the default OptiX pipeline
-        if (state.optix_default_pipeline)
-            jitc_var_dec_ref_ext(state.optix_default_pipeline->index);
+    // Free the default OptiX shader binding table and pipeline (ref counting)
+    if (state.optix_default_sbt_index)
+        jitc_var_dec_ref_ext(state.optix_default_sbt_index);
 #endif
 
     if (!state.tss.empty()) {

--- a/src/internal.h
+++ b/src/internal.h
@@ -304,10 +304,7 @@ struct OptixPipelineCompileOptions {
 struct OptixPipelineData {
     OptixPipelineCompileOptions compile_options;
     OptixModule module;
-    OptixShaderBindingTable shader_binding_table;
     std::vector<OptixProgramGroup> program_groups;
-    // Index of the JIT variable responsible for the lifetime of this pipeline
-    uint32_t index;
 };
 #endif
 
@@ -393,8 +390,9 @@ struct ThreadState {
     uint32_t ptx_version = 60;
 
 #if defined(DRJIT_ENABLE_OPTIX)
-    /// OptiX pipeline associated to the next kernel launch
+    /// OptiX pipeline associated with the next kernel launch
     OptixPipelineData *optix_pipeline;
+    OptixShaderBindingTable *optix_sbt;
 #endif
 };
 
@@ -619,6 +617,10 @@ struct State {
 #if defined(DRJIT_ENABLE_OPTIX)
     /// Default OptiX pipeline for testcases etc.
     OptixPipelineData *optix_default_pipeline = 0;
+    /// Default OptiX Shader Binding Table for testcases etc.
+    OptixShaderBindingTable *optix_default_sbt = 0;
+    /// Index of the JIT variable handling the lifetime of the default Optix SBT
+    uint32_t optix_default_sbt_index;
 #endif
 
     /// Return a pointer to the registry corresponding to the specified backend

--- a/src/optix_api.h
+++ b/src/optix_api.h
@@ -34,15 +34,18 @@ extern void *jitc_optix_lookup(const char *name);
 extern void jitc_optix_shutdown();
 
 /// Inform Dr.Jit about a partially created OptiX pipeline
-extern uint32_t jitc_optix_configure(const OptixPipelineCompileOptions *pco,
-                                     OptixModule module,
-                                     const OptixShaderBindingTable *sbt,
-                                     const OptixProgramGroup *pg,
-                                     uint32_t pg_count);
+extern uint32_t jitc_optix_configure_pipeline(const OptixPipelineCompileOptions *pco,
+                                              OptixModule module,
+                                              const OptixProgramGroup *pg,
+                                              uint32_t pg_count);
+
+/// Inform Dr.Jit about an OptiX Shader Binding Table
+extern uint32_t jitc_optix_configure_sbt(const OptixShaderBindingTable *sbt,
+                                         uint32_t pipeline);
 
 /// Insert a function call to optixTrace into the program
 extern void jitc_optix_ray_trace(uint32_t nargs, uint32_t *args, uint32_t mask,
-                                 uint32_t pipeline);
+                                 uint32_t pipeline, uint32_t sbt);
 
 /// Compile an OptiX kernel
 extern bool jitc_optix_compile(ThreadState *ts, const char *buffer,
@@ -53,8 +56,8 @@ extern bool jitc_optix_compile(ThreadState *ts, const char *buffer,
 extern void jitc_optix_free(const Kernel &kernel);
 
 /// Perform an OptiX kernel launch
-extern void jitc_optix_launch(ThreadState *ts, const Kernel &kernel, uint32_t size,
-                              const void *args, uint32_t n_args);
+extern void jitc_optix_launch(ThreadState *ts, const Kernel &kernel,
+                              uint32_t size, const void *args, uint32_t n_args);
 
 /// Mark a variable as an expression requiring compilation via OptiX
 extern void jitc_optix_mark(uint32_t index);

--- a/src/optix_api.h
+++ b/src/optix_api.h
@@ -13,16 +13,18 @@
 
 using OptixDeviceContext = void *;
 using OptixProgramGroup = void*;
+using OptixModule = void*;
 struct OptixPipelineCompileOptions;
 struct OptixShaderBindingTable;
 struct ThreadState;
+
+struct OptixPipelineData;
 
 /// Create an OptiX device context on the current ThreadState
 extern OptixDeviceContext jitc_optix_context();
 
 /// Destroy an OptiX device context
 struct Device;
-extern void jitc_optix_context_destroy_ts(ThreadState *ts);
 extern void jitc_optix_context_destroy(Device &d);
 
 /// Look up an OptiX function by name
@@ -32,13 +34,15 @@ extern void *jitc_optix_lookup(const char *name);
 extern void jitc_optix_shutdown();
 
 /// Inform Dr.Jit about a partially created OptiX pipeline
-extern void jitc_optix_configure(const OptixPipelineCompileOptions *pco,
-                                 const OptixShaderBindingTable *sbt,
-                                 const OptixProgramGroup *pg,
-                                 uint32_t pg_count);
+extern uint32_t jitc_optix_configure(const OptixPipelineCompileOptions *pco,
+                                     OptixModule module,
+                                     const OptixShaderBindingTable *sbt,
+                                     const OptixProgramGroup *pg,
+                                     uint32_t pg_count);
 
 /// Insert a function call to optixTrace into the program
-extern void jitc_optix_ray_trace(uint32_t nargs, uint32_t *args, uint32_t mask);
+extern void jitc_optix_ray_trace(uint32_t nargs, uint32_t *args, uint32_t mask,
+                                 uint32_t pipeline);
 
 /// Compile an OptiX kernel
 extern bool jitc_optix_compile(ThreadState *ts, const char *buffer,

--- a/tests/triangle.cpp
+++ b/tests/triangle.cpp
@@ -193,11 +193,15 @@ void demo() {
     // Let Dr.Jit know about all of this
     // =====================================================
 
-    UInt32 config_handle = UInt32::steal(jit_optix_configure(
+    UInt32 pipeline_handle = UInt32::steal(jit_optix_configure_pipeline(
         &pipeline_compile_options, // <-- these pointers must stay
         mod,
-        &sbt,                      //     alive while Dr.Jit runs
         pg, 2
+    ));
+
+    UInt32 sbt_handle = UInt32::steal(jit_optix_configure_sbt(
+        &sbt, //     alive while Dr.Jit runs
+        pipeline_handle.index()
     ));
 
     // Do four times to verify caching, with mask in it. 3 + 4
@@ -241,7 +245,7 @@ void demo() {
         };
 
         jit_optix_ray_trace(sizeof(trace_args) / sizeof(uint32_t), trace_args,
-                            mask.index(), config_handle.index());
+                            mask.index(), pipeline_handle.index(), sbt_handle.index());
 
         payload_0 = UInt32::steal(trace_args[15]);
 

--- a/tests/triangle.cpp
+++ b/tests/triangle.cpp
@@ -193,11 +193,12 @@ void demo() {
     // Let Dr.Jit know about all of this
     // =====================================================
 
-    jit_optix_configure(
+    UInt32 config_handle = UInt32::steal(jit_optix_configure(
         &pipeline_compile_options, // <-- these pointers must stay
+        mod,
         &sbt,                      //     alive while Dr.Jit runs
         pg, 2
-    );
+    ));
 
     // Do four times to verify caching, with mask in it. 3 + 4
     for (int i = 0; i < 2; ++i) {
@@ -239,7 +240,8 @@ void demo() {
             miss_sbt_index.index(), payload_0.index()
         };
 
-        jit_optix_ray_trace(sizeof(trace_args) / sizeof(uint32_t), trace_args, mask.index());
+        jit_optix_ray_trace(sizeof(trace_args) / sizeof(uint32_t), trace_args,
+                            mask.index(), config_handle.index());
 
         payload_0 = UInt32::steal(trace_args[15]);
 
@@ -262,11 +264,6 @@ void demo() {
     // =====================================================
 
     jit_free(d_gas);
-    jit_free(sbt.missRecordBase);
-    jit_free(sbt.hitgroupRecordBase);
-    jit_optix_check(optixProgramGroupDestroy(pg[0]));
-    jit_optix_check(optixProgramGroupDestroy(pg[1]));
-    jit_optix_check(optixModuleDestroy(mod));
 }
 
 int main(int, char **) {


### PR DESCRIPTION
## Overview

This PR addresses long standing issues with the management of Optix pipelines and SBT in Dr.Jit:

- OptiX pipeline and SBT lifetime was left to the caller's responsability, although it couldn't be aware of pending raytracing operations in un-evaluated kernels.

- OptiX pipeline and SBT was configured per thread, stored in the `ThreadState`, making it impossible to evaluate a kernel containing ray tracing operations traced in another thread.

- `jit_optix_configure()` had to be called before every call to `jit_optix_ray_trace()` to copy the pipeline and SBT data. This caused unecessary `memcpy` and didn't work reliably when multiple pipelines and SBT would be used simultaneously on the same thread.

## Solution

This patch associated an Optix pipeline and an Optix SBT to every ray tracing operation. To achieve this, we create two special JIT variables responsible for the management of those resources:
- `jit_optix_configure_pipeline()` creates a JIT variable responsible for the `OptixModule` and program groups. 
- `jit_optix_configure_sbt()` creates a JIT variable responsible for the SBT.

The special JIT variable created in `jit_optix_ray_trace()` will now depend on those two JIT variables, ensure the lifetime of those resources goes beyond the one of the ray tracing operations. The creator of those variables should also keep a reference of those on his own.

Those two variables define custom callbacks for `extra.assemble` and `extra.callback` in order to properly setup the pipeline and SBT when assembling the kernel, and release the resources when the variable is freed.
