### PR TITLE
Fix raytracing operation in virtual function calls

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1737,7 +1737,7 @@ extern JIT_EXPORT void jit_block_sum(JIT_ENUM JitBackend backend, JIT_ENUM VarTy
  * </tt>.
  */
 extern JIT_EXPORT void jit_llvm_ray_trace(uint32_t func, uint32_t scene,
-                                          int occluded, const uint32_t *in,
+                                          int shadow_ray, const uint32_t *in,
                                           uint32_t *out);
 
 /**

--- a/include/drjit-core/optix.h
+++ b/include/drjit-core/optix.h
@@ -69,6 +69,18 @@ extern JIT_EXPORT uint32_t
 jit_optix_configure_sbt(const OptixShaderBindingTable *sbt, uint32_t pipeline);
 
 /**
+ * \brief  Update existing OptiX Shader Binding Table data
+ *
+ * This function updates the Shader Binding Table data held by the JIT
+ * variable \c index previously created using \c jit_optix_configure_sbt. This
+ * update is necessary when adding more geometry to an existing scene or when
+ * sharing the OptiX pipeline and SBT across multiple scenes (e.g. ray tracing
+ * against different scenes within the same megakernel).
+ */
+extern JIT_EXPORT void
+jit_optix_update_sbt(uint32_t index, const OptixShaderBindingTable *sbt);
+
+/**
   * \brief Insert a function call to optixTrace into the program
   *
   * The \c args list should contain a list of variable indices corresponding to

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -185,7 +185,6 @@ uint32_t jit_record_checkpoint(JitBackend backend) {
     if (jit_flag(JitFlag::Recording))
         result |= 0x80000000u;
     return result;
-
 }
 
 uint32_t jit_record_begin(JitBackend backend) {
@@ -871,6 +870,11 @@ uint32_t jit_optix_configure_sbt(const OptixShaderBindingTable *sbt, uint32_t pi
     return jitc_optix_configure_sbt(sbt, pipeline);
 }
 
+void jit_optix_update_sbt(uint32_t index, const OptixShaderBindingTable *sbt) {
+    lock_guard guard(state.lock);
+    jitc_optix_update_sbt(index, sbt);
+}
+
 void jit_optix_ray_trace(uint32_t nargs, uint32_t *args, uint32_t mask,
                          uint32_t pipeline, uint32_t sbt) {
     lock_guard guard(state.lock);
@@ -884,10 +888,10 @@ void jit_optix_mark(uint32_t index) {
 
 #endif
 
-void jit_llvm_ray_trace(uint32_t func, uint32_t scene, int occluded,
+void jit_llvm_ray_trace(uint32_t func, uint32_t scene, int shadow_ray,
                         const uint32_t *in, uint32_t *out) {
     lock_guard guard(state.lock);
-    jitc_llvm_ray_trace(func, scene, occluded, in, out);
+    jitc_llvm_ray_trace(func, scene, shadow_ray, in, out);
 }
 
 void *jit_cuda_tex_create(size_t ndim, const size_t *shape, size_t n_channels,

--- a/src/llvm_api.h
+++ b/src/llvm_api.h
@@ -56,5 +56,5 @@ extern int jitc_llvm_if_at_least(uint32_t vector_width,
                                  const char *feature);
 
 /// Insert a ray tracing function call into the LLVM program
-extern void jitc_llvm_ray_trace(uint32_t func, uint32_t scene, int occlude,
+extern void jitc_llvm_ray_trace(uint32_t func, uint32_t scene, int shadow_ray,
                                 const uint32_t *in, uint32_t *out);

--- a/src/optix_api.h
+++ b/src/optix_api.h
@@ -43,6 +43,9 @@ extern uint32_t jitc_optix_configure_pipeline(const OptixPipelineCompileOptions 
 extern uint32_t jitc_optix_configure_sbt(const OptixShaderBindingTable *sbt,
                                          uint32_t pipeline);
 
+/// Overwrite existing OptiX Shader Binding Table given an index
+extern void jitc_optix_update_sbt(uint32_t index, const OptixShaderBindingTable *sbt);
+
 /// Insert a function call to optixTrace into the program
 extern void jitc_optix_ray_trace(uint32_t nargs, uint32_t *args, uint32_t mask,
                                  uint32_t pipeline, uint32_t sbt);


### PR DESCRIPTION
This PR attempts to fix raytracing operation in virtual function calls and add the ability to ray trace multiple scenes within a single OptiX megakernel. This implies that those scenes share the same SBT, which requires the implementation of `jit_optix_update_sbt()`. 

This PR also disables the OptiX validation mode by default as it isn't reliable in current OptiX versions.