### PR TITLE
Fix jit_var(r0): unknown variable when recording virtual calls

### DIFF
--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -1319,10 +1319,6 @@ static void jitc_var_vcall_assemble_llvm(
 void jitc_var_vcall_collect_data(tsl::robin_map<uint64_t, uint32_t, UInt64Hasher> &data_map,
                                  uint32_t &data_offset, uint32_t inst_id,
                                  uint32_t index, bool &use_self) {
-    // Skip if `index` refers to an invalid variable.
-    // NOTE: index should be refactored to something like `id`.
-    if (index == 0)
-        return;
     uint64_t key = (uint64_t) index + (((uint64_t) inst_id) << 32);
     auto it_and_status = data_map.emplace(key, (uint32_t) -1);
     if (!it_and_status.second)
@@ -1367,6 +1363,8 @@ void jitc_var_vcall_collect_data(tsl::robin_map<uint64_t, uint32_t, UInt64Hasher
             const Extra &extra = it->second;
             for (uint32_t i = 0; i < extra.n_dep; ++i) {
                 uint32_t index_2 = extra.dep[i];
+                if (index_2 == 0)
+                    continue; // not break
                 jitc_var_vcall_collect_data(data_map, data_offset,
                                             inst_id, index_2, use_self);
             }

--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -1319,6 +1319,10 @@ static void jitc_var_vcall_assemble_llvm(
 void jitc_var_vcall_collect_data(tsl::robin_map<uint64_t, uint32_t, UInt64Hasher> &data_map,
                                  uint32_t &data_offset, uint32_t inst_id,
                                  uint32_t index, bool &use_self) {
+    // Skip if `index` refers to an invalid variable.
+    // NOTE: index should be refactored to something like `id`.
+    if (index == 0)
+        return;
     uint64_t key = (uint64_t) index + (((uint64_t) inst_id) << 32);
     auto it_and_status = data_map.emplace(key, (uint32_t) -1);
     if (!it_and_status.second)


### PR DESCRIPTION
This is a fix for mitsuba-renderer/mitsuba3#356.

When a loop gets recorded and some of the dependent input/output variables are optimized out, the respective `indices` referenced in `Extra::dep` get replaced by `0` entries in [`jitc_var_loop()`](https://github.com/tomix1024/drjit-core/blob/044f04b54fce4af81fd841352fed594889e6b608/src/loop.cpp#L210).

When this loop is then part of a `jitc_var_vcall_collect_data()` traversal, a variable with an id (`index`) of `0` is referenced that does not exist and an exception is raised.

A simple check if the index of the dependent variable is zero before calling `jitc_var_vcall_collect_data()` recursively fixes the problem.
