### PR TITLE
Do not evaluate the default mask on LLVM

### DIFF
--- a/src/var.cpp
+++ b/src/var.cpp
@@ -848,7 +848,6 @@ void *jitc_var_ptr(uint32_t index) {
     if (!ptr)
         jitc_raise("jit_var_ptr(r%u): variable could not be evaluated!", index);
 
-
     return ptr;
 }
 


### PR DESCRIPTION
On the LLVM backend, a special variable ("default mask") disables memory operations on some SIMD lanes when the wavefronts isn't an exact multiple of the platform's vectorization width.

A pathological issue that Ziyi ran into is that that mask variable can be evaluated and stored in memory. That's not good because the contents of this (scalar) variable depend on the evaluation context.

There are two possible ways of fixing this issue:

1. Construct the mask variable so that it has the necessary size. I first tried to go this route, but it's tricky. In some places we create the mask but don't yet know what the eventual wavefront size will be.

2. Ignore calls to jit_var_[schedule, eval](default masks). Raise an error message when calling jit_var_ptr(default mask).

This commit implements approach 2 for now so that there is at least a more actionable error message instead of undefined behavior.