### PR TITLE
Expose new functions to manually push/pop CUDA contexts

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -200,6 +200,12 @@ extern JIT_EXPORT void* jit_cuda_stream();
 /// Return the CUDA context associated with the current thread
 extern JIT_EXPORT void* jit_cuda_context();
 
+/// Push a new CUDA context to be associated with the current thread
+extern JIT_EXPORT void jit_cuda_push_context(void *);
+
+/// Pop the CUDA context associated to the current thread and return it
+extern JIT_EXPORT void* jit_cuda_pop_context();
+
 /// Query the compute capability of the current device (e.g. '52')
 extern JIT_EXPORT int jit_cuda_compute_capability();
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -221,6 +221,16 @@ void* jit_cuda_context() {
     return jitc_cuda_context();
 }
 
+void jit_cuda_push_context(void* ctx) {
+    lock_guard guard(state.lock);
+    jitc_cuda_push_context(ctx);
+}
+
+void* jit_cuda_pop_context() {
+    lock_guard guard(state.lock);
+    return jitc_cuda_pop_context();
+}
+
 int jit_cuda_device_count() {
     lock_guard guard(state.lock);
     return (int) state.devices.size();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -210,6 +210,16 @@ void* jitc_cuda_context() {
     return (void*) thread_state(JitBackend::CUDA)->context;
 }
 
+void jitc_cuda_push_context(void* ctx) {
+    cuda_check(cuCtxPushCurrent((CUcontext) ctx));
+}
+
+void* jitc_cuda_pop_context() {
+    CUcontext out;
+    cuda_check(cuCtxPopCurrent(&out));
+    return out;
+}
+
 /// Release all resources used by the JIT compiler, and report reference leaks.
 void jitc_shutdown(int light) {
     // Synchronize with everything

--- a/src/internal.h
+++ b/src/internal.h
@@ -844,6 +844,12 @@ extern void* jitc_cuda_stream();
 /// Return a pointer to the CUDA context associated with the currently active device
 extern void* jitc_cuda_context();
 
+/// Push a new CUDA context to the currently active device
+extern void jitc_cuda_push_context(void *);
+
+/// Pop the current CUDA context and return it
+extern void* jitc_cuda_pop_context();
+
 extern void jitc_set_flags(uint32_t flags);
 
 extern uint32_t jitc_flags();


### PR DESCRIPTION
This PR adds helpers to switch CUDA contexts.

For OptiX, we expose a `OptixDeviceContext` throught `jit_optix_context()`. This context depends on a CUDA context and if users want to re-use it for other OptiX computations outside of Dr.Jit they cannot do it without setting the same CUDA context.
These new helpers will allow users to do exactly this or, more generally, scope any other CUDA computations they might want to do without Dr.Jit.