### PR TITLE
Disable constant propagation on operations involving the default mask

### DIFF
--- a/src/op.cpp
+++ b/src/op.cpp
@@ -459,6 +459,13 @@ uint32_t jitc_var_new_op(JitOp op, uint32_t n_dep, const uint32_t *dep) {
     if (unlikely(n_dep == 0 || n_dep > 4))
         jitc_fail("jit_var_new_op(): 1-4 dependent variables supported!");
 
+    /* Disable constant propagation when one of the operands is the default
+     * mask. This guarantees that operations involving the default mask will
+     * return a variable that no longer is the default mask. */
+    for (uint32_t i = 0; i < n_dep; ++i)
+        if (likely(dep[i]))
+            const_prop &= !jitc_var_mask_is_default(dep[i]);
+
     for (uint32_t i = 0; i < n_dep; ++i) {
         if (likely(dep[i])) {
             Variable *vi = jitc_var(dep[i]);

--- a/src/var.h
+++ b/src/var.h
@@ -177,6 +177,9 @@ extern size_t jitc_var_mask_size(JitBackend backend);
 /// Return the default mask
 extern uint32_t jitc_var_mask_default(JitBackend backend);
 
+/// Return whether or not the given variable is the default mask
+extern bool jitc_var_mask_is_default(uint32_t index);
+
 /// Reduce (And) a boolean array to a single value, synchronizes.
 extern bool jitc_var_all(uint32_t index);
 


### PR DESCRIPTION
This PR disables constant propagation on operations involving the default mask. This fixes cases where we **need** to evaluate a JIT variable that happens also to be the default mask because of constant propagation. (follow-up to https://github.com/mitsuba-renderer/drjit-core/pull/25).

For example, in wavefront loops the condition must be evaluated on the first iteration. It often is the case that the loop condition is simply a literal evaluating to true at the first iteration. Hence the operation which mixes the condition and the mask ([here](https://github.com/mitsuba-renderer/drjit/blob/master/include/drjit/loop.h#L221)) will simply return the mask.