### PR TITLE
Auto opaque vcall  - 3rd attempt

### DIFF
--- a/src/eval_cuda.cpp
+++ b/src/eval_cuda.cpp
@@ -311,7 +311,7 @@ void jitc_assemble_cuda_func(const char *name, uint32_t inst_id,
             }
         }
 
-        if (v->vcall_iface) {
+        if (v->vcall_iface && !v->literal) {
             if (vt != VarType::Bool) {
                 buffer.fmt("    ld.param.%s %s%u, [params+%u];\n",
                            type_name_ptx[vti], type_prefix[vti],

--- a/src/eval_llvm.cpp
+++ b/src/eval_llvm.cpp
@@ -256,7 +256,7 @@ void jitc_assemble_llvm_func(const char *name, uint32_t inst_id,
             }
         }
 
-        if (v->vcall_iface) {
+        if (v->vcall_iface && !v->literal) {
             buffer.fmt("    %s%u_i0 = getelementptr inbounds i8, i8* %%params, i64 %u\n"
                        "    %s%u_i1 = bitcast i8* %s%u_i0 to <%u x %s>*\n"
                        "    %s%u%s = load <%u x %s>, <%u x %s>* %s%u_i1, align %u\n",

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -583,8 +583,11 @@ uint32_t jitc_var_wrap_vcall(uint32_t index) {
                    "uninitialized variable!");
 
     const Variable *v = jitc_var(index);
-    if (v->literal && (jitc_flags() & (uint32_t) JitFlag::VCallOptimize))
-        return jitc_var_resize(index, 1);
+    if (v->literal && (jitc_flags() & (uint32_t) JitFlag::VCallOptimize)) {
+        uint32_t index2 = jitc_var_resize(index, 1);
+        jitc_var(index2)->vcall_iface = true;
+        return index2;
+    }
 
     Variable v2;
     v2.stmt = (char *) (((JitBackend) v->backend == JitBackend::CUDA)

--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -184,7 +184,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask,
 
     for (uint32_t i = 0; i < n_in; ++i) {
         const Variable *v = jitc_var(in[i]);
-        if (v->vcall_iface) {
+        if (v->vcall_iface && !v->literal) {
             if (!v->dep[0])
                 jitc_raise("jit_var_vcall(): placeholder variable r%u does not "
                            "reference another input!", in[i]);
@@ -240,7 +240,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask,
         dirty = jitc_var(self)->ref_count_se;
         for (uint32_t i = 0; i < n_in; ++i) {
             const Variable *v = jitc_var(in[i]);
-            if (v->vcall_iface)
+            if (v->vcall_iface && !v->literal)
                 dirty |= (bool) jitc_var(v->dep[0])->ref_count_se;
         }
 
@@ -558,7 +558,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask,
     for (uint32_t i = 0; i < n_in; ++i) {
         uint32_t index = in[i];
         Variable *v = jitc_var(index);
-        if (!v->vcall_iface)
+        if (!v->vcall_iface || v->literal)
             continue;
 
         // Ignore unreferenced inputs
@@ -1330,8 +1330,13 @@ void jitc_var_vcall_collect_data(tsl::robin_map<uint64_t, uint32_t, UInt64Hasher
     ThreadState *ts = thread_state(v->backend);
 
     /* Scalar literals created outside of this virtual function call should be
-       considered as data to avoid baking them inside of the kernel IR. */
-    bool ext_literal = v->literal && index < ts->vcall_bound_index;
+       considered as data to avoid baking them inside of the kernel IR. This rule
+       shouldn't be applied to input literal arguments of the virtual function
+       call or masks. */
+    bool ext_literal = v->literal &&
+                       !v->vcall_iface &&
+                       (VarType) v->type != VarType::Bool &&
+                       index < ts->vcall_bound_index;
 
     if (!v->literal && v->stmt && strstr(v->stmt, "self"))
         use_self = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ if (NOT TARGET check)
   )
 endif()
 
+set_property(TARGET test_basics PROPERTY CXX_STANDARD 17)
 set_property(TARGET test_vcall PROPERTY CXX_STANDARD 17)
 set_property(TARGET test_loop PROPERTY CXX_STANDARD 17)
 

--- a/tests/basics.cpp
+++ b/tests/basics.cpp
@@ -145,8 +145,10 @@ template <typename T> bool test_const_prop() {
     for (uint32_t i = 0; i < Size2; ++i) {
         int j = i % Size;
         values[i] = (Value) ((IsMask || !IsSigned) ? j : (j - 4));
-        if (IsFloat && (values[i] < Value(-1) || values[i] > Value(1)))
-            values[i] = (Value) (1.1f * values[i]);
+        if constexpr (IsFloat) {
+            if (values[i] < Value(-1) || values[i] > Value(1))
+                values[i] = (Value) (1.1f * values[i]);
+        }
     }
 
     uint32_t in[Size2] { }, out[Size2 * Size2 * Size2] { };
@@ -331,8 +333,10 @@ template <typename T> bool test_const_prop() {
     for (uint32_t i = 0; i < Small2; ++i) {
         int j = i % Small;
         values[i] = (Value) ((IsMask || !IsSigned) ? j : (j - 2));
-        if (IsFloat && (values[i] < Value(-1) || values[i] > Value(1)))
-            values[i] = (Value) (1.1f * values[i]);
+        if constexpr (IsFloat) {
+            if (values[i] < Value(-1) || values[i] > Value(1))
+                values[i] = (Value) (1.1f * values[i]);
+        }
     }
 
     for (JitOp op : { JitOp::Fmadd, JitOp::Select }) {

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -687,6 +687,9 @@ TEST_BOTH(09_big) {
     uint32_t i1[n1];
     uint32_t i2[n2];
 
+    (void) i1;
+    (void) i2;
+
     for (int i = 0; i < n1; ++i) {
         v1[i].v = i;
         i1[i] = jit_registry_put(Backend, "Base1", &v1[i]);


### PR DESCRIPTION
Here is my 3rd attempt at implementing the handling of external literal in recorded virtual function calls.

The previous patch wasn't optimal as it would prevent the constant propagation of literal arguments through virtual function calls. While de-virtualization was working properly, it still meant that large data-structure arguments with a lot of zero-members would generate a lot of un-necessary "opaque" IR that would turn out to yield zeros.

This is especially important for automatic differentiation when only a subset of the input arguments will have non-zero gradients.

Looking back at the original purpose of those changes, we are only interested in "un-baking"  literal variables created before tracing the VCalls that are directly accessible within the functions (e.g. plugin parameters). With this in mind, it should be enough to ignore the input arguments.

**Moreover**, this patch also ignores `Bool` variables in this process. This is to avoid un-baking masks (e.g. disabling constant propagation) that are computed in between / after virtual function tracing. Also, it is very unlikely for a plugin parameter to use the `Mask` type, hence this seems like a reasonable solution.

