### PR TITLE
Remove masking from hardware texture operations

### DIFF
--- a/include/drjit-core/texture.h
+++ b/include/drjit-core/texture.h
@@ -102,7 +102,7 @@ extern JIT_EXPORT void jit_cuda_tex_memcpy_t2d(size_t ndim, const size_t *shape,
  */
 extern JIT_EXPORT void jit_cuda_tex_lookup(size_t ndim,
                                            const void *texture_handle,
-                                           const uint32_t *pos, uint32_t mask,
+                                           const uint32_t *pos,
                                            uint32_t *out);
 
 /**
@@ -130,7 +130,7 @@ extern JIT_EXPORT void jit_cuda_tex_lookup(size_t ndim,
 extern JIT_EXPORT void jit_cuda_tex_bilerp_fetch(size_t ndim,
                                                  const void *texture_handle,
                                                  const uint32_t *pos,
-                                                 uint32_t mask, uint32_t *out);
+                                                 uint32_t *out);
 
 /// Destroys the provided texture handle
 extern JIT_EXPORT void jit_cuda_tex_destroy(void *texture_handle);

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -939,16 +939,15 @@ void jit_cuda_tex_memcpy_t2d(size_t ndim, const size_t *shape,
 }
 
 void jit_cuda_tex_lookup(size_t ndim, const void *texture_handle,
-                         const uint32_t *pos, uint32_t mask, uint32_t *out) {
+                         const uint32_t *pos, uint32_t *out) {
     lock_guard guard(state.lock);
-    jitc_cuda_tex_lookup(ndim, texture_handle, pos, mask, out);
+    jitc_cuda_tex_lookup(ndim, texture_handle, pos, out);
 }
 
 void jit_cuda_tex_bilerp_fetch(size_t ndim, const void *texture_handle,
-                               const uint32_t *pos, uint32_t mask,
-                               uint32_t *out) {
+                               const uint32_t *pos, uint32_t *out) {
     lock_guard guard(state.lock);
-    jitc_cuda_tex_bilerp_fetch(ndim, texture_handle, pos, mask, out);
+    jitc_cuda_tex_bilerp_fetch(ndim, texture_handle, pos, out);
 }
 
 void jit_cuda_tex_destroy(void *texture) {

--- a/src/cuda_tex.h
+++ b/src/cuda_tex.h
@@ -143,9 +143,7 @@ extern void jitc_cuda_tex_memcpy_t2d(size_t ndim, const size_t *shape,
                                      const void *src_texture_handle,
                                      void *dst_ptr);
 extern void jitc_cuda_tex_lookup(size_t ndim, const void *texture_handle,
-                                 const uint32_t *pos, uint32_t mask,
-                                 uint32_t *out);
+                                 const uint32_t *pos, uint32_t *out);
 extern void jitc_cuda_tex_bilerp_fetch(size_t ndim, const void *texture_handle,
-                                       const uint32_t *pos, uint32_t mask,
-                                       uint32_t *out);
+                                       const uint32_t *pos, uint32_t *out);
 extern void jitc_cuda_tex_destroy(void *texture_handle);


### PR DESCRIPTION
The functions `jit_cuda_tex_lookup` and `jitc_cuda_tex_bilerp_fetch` would previously take a mask as an argument which was used to fill the result with zeros at the masked indices. This PR removes the `mask` arguments entirely.

The output variables for both functions are always new JIT variables, users can still zero-out certain indices if they need to with a second operation. Additionally, because there is always a wrapping feature on a texture, there will never be invalid lookup coordinates (NaNs and infinites are supported too).
Masking at this level was therefore unnecessary.