### PR TITLE
Mask stack improvements

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1530,27 +1530,31 @@ extern JIT_EXPORT uint32_t jit_var_loop(const char *name, uint32_t loop_init,
  * In advanced usage of Dr.Jit (e.g. recorded loops, virtual function calls,
  * etc.), it may be necessary to mask scatter and gather operations to prevent
  * undefined behavior and crashes. This function can be used to push a mask
- * onto a mask stack. The top of the stack will be combined with the mask
- * argument supplied to subsequent \ref jit_var_new_gather() and \ref
- * jit_var_new_scatter() operations. While on the stack, Dr.Jit will hold an
- * internal reference to \c index to keep it from being freed. When \combine is
- * nonzero, the mask will be combined with the current top element of the
- * stack.
+ * onto a mask stack.  While on the stack, Dr.Jit will hold an internal
+ * reference to \c index to keep it from being freed.
  */
-extern JIT_EXPORT void jit_var_mask_push(JIT_ENUM JitBackend backend, uint32_t index,
-                                         int combine JIT_DEF(1));
+extern JIT_EXPORT void jit_var_mask_push(JIT_ENUM JitBackend backend, uint32_t index);
 
 /// Pop the mask stack
 extern JIT_EXPORT void jit_var_mask_pop(JIT_ENUM JitBackend backend);
 
-/// Return the top entry of the mask stack and increase its ext. ref. count
+/**
+ * \brief Return the top entry of the mask stack and increase its external
+ * reference count. Returns zero when the stack is empty.
+ */
 extern JIT_EXPORT uint32_t jit_var_mask_peek(JIT_ENUM JitBackend backend);
 
-/// Return the size of the mask stack
-extern JIT_EXPORT size_t jit_var_mask_size(JIT_ENUM JitBackend backend);
+/// Return the default mask for a wavefront of the given \c size
+extern JIT_EXPORT uint32_t jit_var_mask_default(JIT_ENUM JitBackend backend,
+                                                uint32_t size);
 
-/// Return the default mask
-extern JIT_EXPORT uint32_t jit_var_mask_default(JIT_ENUM JitBackend backend);
+/**
+ * \brief Combine the given mask 'index' with the mask stack
+ *
+ * On the LLVM backend, a default mask will be created when the mask stack is empty.
+ * The \c size parameter determines the size of the associated wavefront.
+ */
+extern JIT_EXPORT uint32_t jit_var_mask_apply(uint32_t index, uint32_t size);
 
 // ====================================================================
 //                          Horizontal reductions

--- a/include/drjit-core/state.h
+++ b/include/drjit-core/state.h
@@ -63,9 +63,9 @@ template <JitBackend Backend> struct JitState {
         m_recording = false;
     }
 
-    void set_mask(uint32_t index, bool combine = true) {
+    void set_mask(uint32_t index) {
         assert(!m_mask_set);
-        jit_var_mask_push(Backend, index, combine);
+        jit_var_mask_push(Backend, index);
         m_mask_set = true;
     }
 
@@ -73,6 +73,13 @@ template <JitBackend Backend> struct JitState {
         assert(m_mask_set);
         jit_var_mask_pop(Backend);
         m_mask_set = false;
+    }
+
+    void clear_mask_if_set() {
+        if (m_mask_set) {
+            jit_var_mask_pop(Backend);
+            m_mask_set = false;
+        }
     }
 
     void set_prefix(const char *label) {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -605,9 +605,14 @@ uint32_t jit_var_mask_peek(JitBackend backend) {
     return jitc_var_mask_peek(backend);
 }
 
-void jit_var_mask_push(JitBackend backend, uint32_t index, int combine) {
+uint32_t jit_var_mask_apply(uint32_t index, uint32_t size) {
     lock_guard guard(state.lock);
-    jitc_var_mask_push(backend, index, combine);
+    return jitc_var_mask_apply(index, size);
+}
+
+void jit_var_mask_push(JitBackend backend, uint32_t index) {
+    lock_guard guard(state.lock);
+    jitc_var_mask_push(backend, index);
 }
 
 void jit_var_mask_pop(JitBackend backend) {
@@ -615,14 +620,9 @@ void jit_var_mask_pop(JitBackend backend) {
     jitc_var_mask_pop(backend);
 }
 
-size_t jit_var_mask_size(JitBackend backend) {
+uint32_t jit_var_mask_default(JitBackend backend, uint32_t size) {
     lock_guard guard(state.lock);
-    return jitc_var_mask_size(backend);
-}
-
-uint32_t jit_var_mask_default(JitBackend backend) {
-    lock_guard guard(state.lock);
-    return jitc_var_mask_default(backend);
+    return jitc_var_mask_default(backend, size);
 }
 
 int jit_var_any(uint32_t index) {

--- a/src/eval_llvm.cpp
+++ b/src/eval_llvm.cpp
@@ -602,25 +602,15 @@ void jitc_llvm_ray_trace(uint32_t func, uint32_t scene, int shadow_ray,
     }
 
     // ----------------------------------------------------------
-    Ref valid;
+    Ref valid = steal(jitc_var_mask_apply(in[1], size));
     {
-        Ref mask_top = steal(jitc_var_mask_peek(JitBackend::LLVM));
-        uint32_t size_top = jitc_var(mask_top)->size;
-
-        // Mask on mask stack is incompatible -- get the default mask
-        if (size_top != size && size_top != 1 && size != 1)
-            mask_top = steal(jitc_var_mask_default(JitBackend::LLVM));
-
-        uint32_t deps_1[2] = { in[1], mask_top };
-        Ref mask_combined = steal(jitc_var_new_op(JitOp::And, 2, deps_1));
-
         int32_t minus_one_c = -1, zero_c = 0;
         Ref minus_one = steal(jitc_var_new_literal(
                 JitBackend::LLVM, VarType::Int32, &minus_one_c, 1, 0)),
             zero = steal(jitc_var_new_literal(
                 JitBackend::LLVM, VarType::Int32, &zero_c, 1, 0));
 
-        uint32_t deps_2[3] = { mask_combined, minus_one, zero };
+        uint32_t deps_2[3] = { valid, minus_one, zero };
         valid = steal(jitc_var_new_op(JitOp::Select, 3, deps_2));
     }
 

--- a/src/var.h
+++ b/src/var.h
@@ -166,16 +166,16 @@ extern int jitc_var_device(uint32_t index);
 extern uint32_t jitc_var_mask_peek(JitBackend backend);
 
 /// Push an active mask
-extern void jitc_var_mask_push(JitBackend backend, uint32_t index, int combine);
+extern void jitc_var_mask_push(JitBackend backend, uint32_t index);
 
 /// Pop an active mask
 extern void jitc_var_mask_pop(JitBackend backend);
 
-/// Return the size of the mask stack
-extern size_t jitc_var_mask_size(JitBackend backend);
+/// Combine the given mask 'index' with the mask stack. 'size' indicates the wavefront size
+extern uint32_t jitc_var_mask_apply(uint32_t index, uint32_t size);
 
 /// Return the default mask
-extern uint32_t jitc_var_mask_default(JitBackend backend);
+extern uint32_t jitc_var_mask_default(JitBackend backend, uint32_t size);
 
 /// Reduce (And) a boolean array to a single value, synchronizes.
 extern bool jitc_var_all(uint32_t index);

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -127,7 +127,7 @@ Result vcall_impl(const char *domain, uint32_t n_inst, const Func &func,
                 Backend, VarType::Bool,
                 "$r0 = or <$w x i1> %mask, zeroinitializer", 1, 0,
                 nullptr));
-            jit_state.set_mask(vcall_mask.index(), false);
+            jit_state.set_mask(vcall_mask.index());
         }
 
         if constexpr (std::is_same_v<Result, std::nullptr_t>)
@@ -149,11 +149,8 @@ Result vcall_impl(const char *domain, uint32_t n_inst, const Func &func,
 
     dr_index_vector indices_out(indices_out_all.size() / n_inst);
 
-    Mask mask_combined =
-        mask & neq(self, nullptr) & Mask::steal(jit_var_mask_peek(Backend));
-
     uint32_t se = jit_var_vcall(
-        domain, self.index(), mask_combined.index(), n_inst, inst_id.data(),
+        domain, self.index(), mask.index(), n_inst, inst_id.data(),
         (uint32_t) indices_in.size(), indices_in.data(),
         (uint32_t) indices_out_all.size(), indices_out_all.data(), state.data(),
         indices_out.data());
@@ -447,8 +444,8 @@ TEST_BOTH(04_devirtualize) {
                 },
                 self, p1, p2);
 
-            Mask mask_combined =
-                neq(self, nullptr) & Mask::steal(jit_var_mask_peek(Backend));
+            Mask mask = neq(self, nullptr),
+                 mask_combined = Mask::steal(jit_var_mask_apply(mask.index(), 10));
 
             Float p2_wrap = Float::steal(jit_var_wrap_vcall(p2.index()));
             Float alt = (p2_wrap + 2) & mask_combined;


### PR DESCRIPTION
This commit bundles several improvements to the mask stack. For context, the mask stack is an implicit stack of masks, whose top element is automatically applied to memory reads/writes and a few other operations to disable inactive entries of the current wavefront. That is important because undefined behavior resulting from unmasked memory operations could cause inconsistencies or even crash the program.

LLVM has an implicit default mask (even when the stack is empty) that is needed because the wavefront size might not be an exact multiple of the SIMD vector width. This means that some elements are always masked even in the absence of conditional operations that normally cause some masking (loops, vcalls).

The changes are:

- The implicit default mask on LLVM is now consistently created based on the size of the underlying wavefront. That requires changes in a few places because the size has to be determined. Previously, the default mask always had a size of 1, which made no sense and could cause serious issues when somebody actually evaluated the mask and turned into a memory-backed variable.

- Several parts of Dr.Jit fetch the top of the mask stack and combine it with an existing mask if the sizes are compatible. The commit adds a function `jit_var_mask_apply()` to factor out this repeated code.

- The ``dr::Loop::operator()`` routine was refactored.

- The `jit_var_vcall()` routine for recorded dynamic dispatch now incorporates the `jit_var_mask_apply()` logic as well as a check for whether `self == nullptr`. That means that these steps can be removed from the caller.