### PR TITLE
Support large launches with up to 2^32 threads on OptiX backend

### DIFF
--- a/src/eval_cuda.cpp
+++ b/src/eval_cuda.cpp
@@ -82,19 +82,10 @@ void jitc_assemble_cuda(ThreadState *ts, ScheduledGroup group,
         buffer.fmt("body: // sm_%u\n",
                    state.devices[ts->device].compute_capability);
     } else {
-#if 0
-        buffer.put("    call (%r0), _optix_get_launch_dimension_y, ();\n"
-                   "    call (%r1), _optix_get_launch_index_y, ();\n"
-                   "    call (%r2), _optix_get_launch_index_x, ();\n"
-                   "    mad.lo.u32 %r0, %r0, %r1, %r2;\n"
-                   "    call (%r1), _optix_get_launch_dimension_z, ();\n"
-                   "    call (%r2), _optix_get_launch_index_z, ();\n"
-                   "    mad.lo.u32 %r0, %r0, %r1, %r2;\n\n"
+        buffer.put("    call (%r0), _optix_get_launch_index_x, ();\n"
+                   "    ld.const.u32 %r1, [params + 4];\n"
+                   "    add.u32 %r0, %r0, %r1;\n\n"
                    "body:\n");
-#else
-        buffer.put("    call (%r0), _optix_get_launch_index_x, ();\n\n"
-                   "body:\n");
-#endif
     }
 
     const char *params_base = "params",


### PR DESCRIPTION
Mitsuba rendering tasks executed using Dr.Jit's OptiX backend are currently limited to 2^30 ≈ 1 billion Monte Carlo samples in total, which sounds like a lot. However, that's just enough to render a full HD image using 512 samples per pixel:

   1920*1080*512 = 1'061'683'200 < 1'073'741'824 = 2^32

This commit increases the limit to 4 billion, which corresponds to 2048 samples per pixel at 1080p resolution. This is the *absolute maximum* wavefront size that Dr.Jit can accommodate due to its 32 bit based indexing.

It's worth mentioning that further increasing that limit by upgrading to 64 bit indexing is not a good idea as this comes with significant costs on modern GPUs that lack 64 bit registers. Instead, multiple rendering passes should be used in the renderer to handle such very large rendering tasks.

What this commit commit enables is to internally run multiple passes without re-tracing when the sample count is between 2^30 and 2^32, which makes it less likely that users would require the `n_passes` parameter of the renderer (which arguably adds a few complications).