### PR TITLE
Remove PTX `@p` predicates

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -729,6 +729,8 @@ void jitc_eval(ThreadState *ts) {
                 }
                 v = jitc_var(index);
             }
+
+            state.extra[index].assemble = nullptr;
         }
 
         jitc_cse_drop(index, v);

--- a/src/eval_cuda.cpp
+++ b/src/eval_cuda.cpp
@@ -104,6 +104,7 @@ void jitc_assemble_cuda(ThreadState *ts, ScheduledGroup group,
         const uint32_t vti = v->type,
                        size = v->size;
         const VarType vt = (VarType) vti;
+        bool assemble = false;
 
         if (unlikely(v->extra)) {
             auto it = state.extra.find(index);
@@ -119,7 +120,7 @@ void jitc_assemble_cuda(ThreadState *ts, ScheduledGroup group,
 
             if (extra.assemble) {
                 extra.assemble(v, extra);
-                continue;
+                assemble = true;
             }
         }
 
@@ -155,7 +156,7 @@ void jitc_assemble_cuda(ThreadState *ts, ScheduledGroup group,
                            v->reg_index);
             }
             continue;
-        } else {
+        } else if (likely(!assemble)) {
             jitc_render_stmt_cuda(index, v);
         }
 

--- a/src/eval_llvm.cpp
+++ b/src/eval_llvm.cpp
@@ -463,7 +463,7 @@ static void jitc_render_stmt_llvm(uint32_t index, const Variable *v, bool in_fun
 #endif
     } else {
         const char *s = v->stmt;
-        if (unlikely(*s == '\0'))
+        if (unlikely(!s || *s == '\0'))
             return;
         buffer.put("    ");
         char c;


### PR DESCRIPTION
This patch gets rid of the use of `@pXXX ...` predicated instructions in the PTX generation for `dr.gather`, `dr.scatter` and `dr.select()`.