### PR TITLE
Merged internal and external reference count fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,13 +246,12 @@ uint32_t v3 = jit_var_new_stmt_2(/* backend = */ JitBackendCUDA,
 ```
 Suppose that we don't plan to perform any
 further computation / accesses involving ``v0``, ``v1``, and ``v2``. This must
-be indicated to Dr.Jit by reducing their *external* reference count
-("external" refers to references by *your* code):
+be indicated to Dr.Jit by reducing their reference count.
 
 ```cpp
-jit_var_dec_ref_ext(v0);
-jit_var_dec_ref_ext(v1);
-jit_var_dec_ref_ext(v2);
+jit_var_dec_ref(v0);
+jit_var_dec_ref(v1);
+jit_var_dec_ref(v2);
 ```
 
 They still have a nonzero *internal* reference count (i.e. by Dr.Jit itself)
@@ -291,13 +290,12 @@ will turn the variable from a symbolic representation into a GPU-backed array,
 and further queued computation accessing it will simply index into that array
 instead of repeating the original computation.
 
-At the end of the program, we must not forget to decrease the external
-reference count associated with ``v2``, which will release the array from
-memory. Finally, ``jit_shutdown()`` releases any remaining resources held by
-Dr.Jit.
+At the end of the program, we must not forget to decrease the reference count
+associated with ``v2``, which will release the array from memory. Finally,
+``jit_shutdown()`` releases any remaining resources held by Dr.Jit.
 
 ```cpp
-jit_var_dec_ref_ext(v3);
+jit_var_dec_ref(v3);
 jit_shutdown(0);
 ```
 

--- a/include/drjit-core/array.h
+++ b/include/drjit-core/array.h
@@ -30,10 +30,10 @@ template <JitBackend Backend_, typename Value_> struct JitArray {
 
     JitArray() = default;
 
-    ~JitArray() { jit_var_dec_ref_ext(m_index); }
+    ~JitArray() { jit_var_dec_ref(m_index); }
 
     JitArray(const JitArray &a) : m_index(a.m_index) {
-        jit_var_inc_ref_ext(m_index);
+        jit_var_inc_ref(m_index);
     }
 
     template <typename T> JitArray(const JitArray<Backend_, T> &v) {
@@ -70,8 +70,8 @@ template <JitBackend Backend_, typename Value_> struct JitArray {
     }
 
     JitArray &operator=(const JitArray &a) {
-        jit_var_inc_ref_ext(a.m_index);
-        jit_var_dec_ref_ext(m_index);
+        jit_var_inc_ref(a.m_index);
+        jit_var_dec_ref(m_index);
         m_index = a.m_index;
         return *this;
     }
@@ -224,7 +224,7 @@ template <JitBackend Backend_, typename Value_> struct JitArray {
 
 	void resize(size_t size) {
         uint32_t index = jit_var_resize(m_index, size);
-        jit_var_dec_ref_ext(m_index);
+        jit_var_dec_ref(m_index);
         m_index = index;
     }
 
@@ -254,7 +254,7 @@ template <JitBackend Backend_, typename Value_> struct JitArray {
 
     void write(size_t offset, Value value) {
         uint32_t index = jit_var_write(m_index, offset, &value);
-        jit_var_dec_ref_ext(m_index);
+        jit_var_dec_ref(m_index);
         m_index = index;
     }
 
@@ -353,7 +353,7 @@ template <JitBackend Backend_, typename Value_> struct JitArray {
 
 	friend void set_label(JitArray &v, const char *label) {
 		uint32_t index = jit_var_set_label(v.m_index, label);
-		jit_var_dec_ref_ext(v.m_index);
+		jit_var_dec_ref(v.m_index);
 		v.m_index = index;
 	}
 protected:
@@ -398,7 +398,7 @@ Array gather(const Array &source, const JitArray<Array::Backend, Index> index,
 }
 
 template <typename Array, typename Index>
-void scatter(Array &target, const Array &value, const JitArray<Array::Backend, Index> index,
+void scatter(Array &target, const Array &value, const JitArray<Array::Backend, Index>& index,
              const JitArray<Array::Backend, bool> &mask = true) {
     target = Array::steal(jit_var_new_scatter(target.index(), value.index(),
                                               index.index(), mask.index(),
@@ -407,7 +407,7 @@ void scatter(Array &target, const Array &value, const JitArray<Array::Backend, I
 
 template <typename Array, typename Index>
 void scatter_reduce(ReduceOp op, Array &target, const Array &value,
-                    const JitArray<Array::Backend, Index> index,
+                    const JitArray<Array::Backend, Index> &index,
                     const JitArray<Array::Backend, bool> &mask = true) {
     target = Array::steal(jit_var_new_scatter(target.index(), value.index(),
                                               index.index(), mask.index(), op));

--- a/include/drjit-core/containers.h
+++ b/include/drjit-core/containers.h
@@ -124,13 +124,13 @@ struct dr_index_vector : dr_vector<uint32_t> {
     ~dr_index_vector() { clear(); }
 
     void push_back(uint32_t value) {
-        jit_var_inc_ref_ext_impl(value);
+        jit_var_inc_ref_impl(value);
         Base::push_back(value);
     }
 
     void clear() {
         for (size_t i = 0; i < size(); ++i)
-            jit_var_dec_ref_ext_impl(operator[](i));
+            jit_var_dec_ref_impl(operator[](i));
         Base::clear();
     }
 };

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -930,7 +930,7 @@ enum ReduceOp {
  *
  * A direct write may not be safe (e.g. if unevaluated computation references
  * the array \c target). The function thus returns the index of a new array
- * (which may happen to be identical to \c target), whose external reference
+ * (which may happen to be identical to \c target), whose reference
  * count is increased by 1.
  *
  * For performance reasons, sequences involving multiple scatters to the same
@@ -950,14 +950,14 @@ extern JIT_EXPORT uint32_t jit_var_new_scatter(uint32_t target, uint32_t value,
  * \brief Create an identical copy of the given variable
  *
  * This function creates an exact copy of the variable \c index and returns the
- * index of the copy, whose external reference count is initialized to 1.
+ * index of the copy, whose reference count is initialized to 1.
  */
 extern JIT_EXPORT uint32_t jit_var_copy(uint32_t index);
 
 
 /**
  * Register an existing memory region as a variable in the JIT compiler, and
- * return its index. Its external reference count is initialized to \c 1.
+ * return its index. Its reference count is initialized to \c 1.
  *
  * \param type
  *    Type of the variable to be created, see \ref VarType for details.
@@ -983,7 +983,7 @@ extern JIT_EXPORT uint32_t jit_var_mem_map(JIT_ENUM JitBackend backend,
 
 /**
  * Copy a memory region onto the device and return its variable index. Its
- * external reference count is initialized to \c 1.
+ * reference count is initialized to \c 1.
  *
  * \param atype
  *    Enumeration characterizing the "flavor" of the source memory.
@@ -1008,10 +1008,10 @@ extern JIT_EXPORT uint32_t jit_var_mem_copy(JIT_ENUM JitBackend backend,
                                             const void *ptr,
                                             size_t size);
 
-/// Increase the external reference count of a given variable
+/// Increase the reference count of a given variable
 extern JIT_EXPORT void jit_var_inc_ref_impl(uint32_t index) JIT_NOEXCEPT;
 
-/// Decrease the external reference count of a given variable
+/// Decrease the reference count of a given variable
 extern JIT_EXPORT void jit_var_dec_ref_impl(uint32_t index) JIT_NOEXCEPT;
 
 #if defined(__GNUC__)
@@ -1033,7 +1033,7 @@ JIT_INLINE void jit_var_dec_ref(uint32_t index) JIT_NOEXCEPT {
 /// Check if a variable with a given index exists
 extern JIT_EXPORT int jit_var_exists(uint32_t index);
 
-/// Query the a variable's external reference count (used by the test suite)
+/// Query the a variable's reference count (used by the test suite)
 extern JIT_EXPORT uint32_t jit_var_ref(uint32_t index);
 
 /// Query the pointer variable associated with a given variable
@@ -1064,9 +1064,9 @@ extern JIT_EXPORT int jit_var_is_placeholder(uint32_t index);
  * size, potentially creating a new copy in case something already depends on
  * \c index. The returned copy is symbolic form.
  *
- * The function increases the external reference count of the returned value.
+ * The function increases the reference count of the returned value.
  * When \c index is not a scalar variable and its size exactly matches \c size,
- * the function does nothing and just increases the external reference count of
+ * the function does nothing and just increases the reference count of
  * \c index. Otherwise, it fails.
  */
 extern JIT_EXPORT uint32_t jit_var_resize(uint32_t index, size_t size);
@@ -1074,7 +1074,7 @@ extern JIT_EXPORT uint32_t jit_var_resize(uint32_t index, size_t size);
 /**
  * \brief Asynchronously migrate a variable to a different flavor of memory
  *
- * Returns the resulting variable index and increases its external reference
+ * Returns the resulting variable index and increases its reference
  * count by one. When source and target type are identical, this function does
  * not perform a migration and simply returns the input index (though it
  * increases the reference count even in this case). When the source and target
@@ -1098,7 +1098,7 @@ extern JIT_EXPORT int jit_var_device(uint32_t index);
  * \brief Mark a variable as a scatter operation
  *
  * This function informs the JIT compiler that the variable 'index' has side
- * effects. It then steals an external reference, includes the variable in the
+ * effects. It then steals a reference, includes the variable in the
  * next kernel launch, and de-references it following execution.
  */
 extern JIT_EXPORT void jit_var_mark_side_effect(uint32_t index);
@@ -1137,8 +1137,8 @@ extern JIT_EXPORT void jit_var_read(uint32_t index, size_t offset,
  *
  * A direct write may not be safe (e.g. if unevaluated computation references
  * the array \c index). The function thus returns the index of a new array
- * (which may happen to be identical to \c index), whose external reference
- * count is increased by 1.
+ * (which may happen to be identical to \c index), whose reference count is
+ * increased by 1.
  */
 extern JIT_EXPORT uint32_t jit_var_write(uint32_t index, size_t offset,
                                          const void *src);

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1009,35 +1009,32 @@ extern JIT_EXPORT uint32_t jit_var_mem_copy(JIT_ENUM JitBackend backend,
                                             size_t size);
 
 /// Increase the external reference count of a given variable
-extern JIT_EXPORT void jit_var_inc_ref_ext_impl(uint32_t index) JIT_NOEXCEPT;
+extern JIT_EXPORT void jit_var_inc_ref_impl(uint32_t index) JIT_NOEXCEPT;
 
 /// Decrease the external reference count of a given variable
-extern JIT_EXPORT void jit_var_dec_ref_ext_impl(uint32_t index) JIT_NOEXCEPT;
+extern JIT_EXPORT void jit_var_dec_ref_impl(uint32_t index) JIT_NOEXCEPT;
 
 #if defined(__GNUC__)
-JIT_INLINE void jit_var_inc_ref_ext(uint32_t index) JIT_NOEXCEPT {
+JIT_INLINE void jit_var_inc_ref(uint32_t index) JIT_NOEXCEPT {
     /* If 'index' is known at compile time, it can only be zero, in
-       which case we can skip the redundant call to jit_var_dec_ref_ext */
+       which case we can skip the redundant call to jit_var_dec_ref */
     if (!__builtin_constant_p(index) || index != 0)
-        jit_var_inc_ref_ext_impl(index);
+        jit_var_inc_ref_impl(index);
 }
-JIT_INLINE void jit_var_dec_ref_ext(uint32_t index) JIT_NOEXCEPT {
+JIT_INLINE void jit_var_dec_ref(uint32_t index) JIT_NOEXCEPT {
     if (!__builtin_constant_p(index) || index != 0)
-        jit_var_dec_ref_ext_impl(index);
+        jit_var_dec_ref_impl(index);
 }
 #else
-#define jit_var_dec_ref_ext jit_var_dec_ref_ext_impl
-#define jit_var_inc_ref_ext jit_var_inc_ref_ext_impl
+#define jit_var_dec_ref jit_var_dec_ref_impl
+#define jit_var_inc_ref jit_var_inc_ref_impl
 #endif
 
 /// Check if a variable with a given index exists
 extern JIT_EXPORT int jit_var_exists(uint32_t index);
 
-/// Query the a variable's internal reference count (used by the test suite)
-extern JIT_EXPORT uint32_t jit_var_ref_int(uint32_t index);
-
 /// Query the a variable's external reference count (used by the test suite)
-extern JIT_EXPORT uint32_t jit_var_ref_ext(uint32_t index);
+extern JIT_EXPORT uint32_t jit_var_ref(uint32_t index);
 
 /// Query the pointer variable associated with a given variable
 extern JIT_EXPORT void *jit_var_ptr(uint32_t index);
@@ -1523,8 +1520,8 @@ extern JIT_EXPORT uint32_t jit_var_loop(const char *name, uint32_t loop_init,
  * In advanced usage of Dr.Jit (e.g. recorded loops, virtual function calls,
  * etc.), it may be necessary to mask scatter and gather operations to prevent
  * undefined behavior and crashes. This function can be used to push a mask
- * onto a mask stack.  While on the stack, Dr.Jit will hold an internal
- * reference to \c index to keep it from being freed.
+ * onto a mask stack.  While on the stack, Dr.Jit will hold a reference to \c
+ * index to keep it from being freed.
  */
 extern JIT_EXPORT void jit_var_mask_push(JIT_ENUM JitBackend backend, uint32_t index);
 
@@ -1698,10 +1695,10 @@ struct VCallBucket {
  *
  * The memory region accessible via the \c VCallBucket pointer will remain
  * accessible until the variable \c index is itself freed (i.e. when its
- * internal and external reference counts both become equal to zero). Until
- * then, additional calls to \ref jit_var_vcall() will return the previously
- * computed result. This is an important optimization in situations where
- * multiple vector function calls are executed on the same set of instances.
+ * reference count becomes equal to zero). Until then, additional calls to \ref
+ * jit_var_vcall() will return the previously computed result. This is an
+ * important optimization in situations where multiple vector function calls
+ * are executed on the same set of instances.
  */
 extern JIT_EXPORT struct VCallBucket *
 jit_var_vcall_reduce(JIT_ENUM JitBackend backend, const char *domain,

--- a/include/drjit-core/state.h
+++ b/include/drjit-core/state.h
@@ -110,7 +110,7 @@ template <JitBackend Backend> struct JitState {
     void set_self(uint32_t value, uint32_t index = 0) {
         if (!m_self_set) {
             jit_vcall_self(Backend, &m_self_value, &m_self_index);
-            jit_var_inc_ref_ext(m_self_index);
+            jit_var_inc_ref(m_self_index);
             m_self_set = true;
         }
         jit_vcall_set_self(Backend, value, index);
@@ -119,7 +119,7 @@ template <JitBackend Backend> struct JitState {
     void clear_self() {
         assert(m_self_set);
         jit_vcall_set_self(Backend, m_self_value, m_self_index);
-        jit_var_dec_ref_ext(m_self_index);
+        jit_var_dec_ref(m_self_index);
         m_self_set = false;
     }
 

--- a/src/common.h
+++ b/src/common.h
@@ -96,20 +96,20 @@ template <> struct uint_with_size<8> { using type = uint64_t; };
 template <typename T>
 using uint_with_size_t = typename uint_with_size<sizeof(T)>::type;
 
-extern void jitc_var_dec_ref_ext(uint32_t) noexcept(true);
-extern void jitc_var_inc_ref_ext(uint32_t) noexcept(true);
+extern void jitc_var_dec_ref(uint32_t) noexcept(true);
+extern void jitc_var_inc_ref(uint32_t) noexcept(true);
 
 struct Ref {
     friend Ref steal(uint32_t);
     friend Ref borrow(uint32_t);
 
     Ref() : index(0) { }
-    ~Ref() { jitc_var_dec_ref_ext(index); }
+    ~Ref() { jitc_var_dec_ref(index); }
 
     Ref(Ref &&r) : index(r.index) { r.index = 0; }
 
     Ref &operator=(Ref &&r) {
-        jitc_var_dec_ref_ext(index);
+        jitc_var_dec_ref(index);
         index = r.index;
         r.index = 0;
         return *this;
@@ -125,7 +125,7 @@ struct Ref {
         return value;
     }
     void reset() {
-        jitc_var_dec_ref_ext(index);
+        jitc_var_dec_ref(index);
         index = 0;
     }
 
@@ -142,7 +142,7 @@ inline Ref steal(uint32_t index) {
 inline Ref borrow(uint32_t index) {
     Ref r;
     r.index = index;
-    jitc_var_inc_ref_ext(index);
+    jitc_var_inc_ref(index);
     return r;
 }
 

--- a/src/cuda_tex.cpp
+++ b/src/cuda_tex.cpp
@@ -498,7 +498,7 @@ void jitc_cuda_tex_lookup(size_t ndim, const void *texture_handle,
                                        stmt_1[ndim - 2], 1, (unsigned int) ndim,
                                        pos);
         } else {
-            jitc_var_inc_ref_ext(dep[1]);
+            jitc_var_inc_ref(dep[1]);
         }
 
         const char *stmt_2[3] = {
@@ -514,7 +514,7 @@ void jitc_cuda_tex_lookup(size_t ndim, const void *texture_handle,
 
         uint32_t lookup = jitc_var_new_stmt(JitBackend::CUDA, VarType::Void,
                                             stmt_2[ndim - 1], 1, 2, dep);
-        jitc_var_dec_ref_ext(dep[1]);
+        jitc_var_dec_ref(dep[1]);
 
         const char *stmt_3[4] = {
             "mov.f32 $r0, $r1.r",
@@ -529,7 +529,7 @@ void jitc_cuda_tex_lookup(size_t ndim, const void *texture_handle,
             out[tex * 4 + ch] = lookup_result_index;
         }
 
-        jitc_var_dec_ref_ext(lookup);
+        jitc_var_dec_ref(lookup);
     }
 }
 
@@ -596,10 +596,10 @@ void jitc_cuda_tex_bilerp_fetch(size_t ndim, const void *texture_handle,
                 out[(i * texture.n_channels) + (tex * 4 + ch)] = result_index;
             }
 
-            jitc_var_dec_ref_ext(fetch_channel);
+            jitc_var_dec_ref(fetch_channel);
         }
 
-        jitc_var_dec_ref_ext(dep[1]);
+        jitc_var_dec_ref(dep[1]);
     }
 }
 
@@ -617,6 +617,6 @@ void jitc_cuda_tex_destroy(void *texture_handle) {
     // textures out of the loop condition.
     const size_t n_textures = texture->n_textures;
     for (size_t tex = 0; tex < n_textures; ++tex) {
-        jitc_var_dec_ref_ext(texture->indices[tex]);
+        jitc_var_dec_ref(texture->indices[tex]);
     }
 }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -152,7 +152,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
         // Some sanity checks
         if (unlikely((JitBackend) v->backend != backend))
             jitc_raise("jit_assemble(): variable r%u scheduled in wrong ThreadState", index);
-        if (unlikely(v->ref_count_int == 0 && v->ref_count_ext == 0))
+        if (unlikely(v->ref_count == 0))
             jitc_fail("jit_assemble(): schedule contains unreferenced variable r%u!", index);
         if (unlikely(v->size != 1 && v->size != group.size))
             jitc_fail("jit_assemble(): schedule contains variable r%u with incompatible size "
@@ -602,8 +602,8 @@ void jitc_eval(ThreadState *ts) {
 
             Variable *v = &it.value();
 
-            // Skip variables that aren't externally referenced or already evaluated
-            if (v->ref_count_ext == 0 || v->data)
+            // Skip variables that are already evaluated
+            if (v->data)
                 continue;
 
             jitc_var_traverse(v->size, index);
@@ -749,9 +749,9 @@ void jitc_eval(ThreadState *ts) {
         v->side_effect = false;
 
         if (side_effect)
-            jitc_var_dec_ref_ext(index);
+            jitc_var_dec_ref(index);
         for (int j = 0; j < 4; ++j)
-            jitc_var_dec_ref_int(dep[j]);
+            jitc_var_dec_ref(dep[j]);
     }
 
     jitc_free_flush(ts);

--- a/src/eval_llvm.cpp
+++ b/src/eval_llvm.cpp
@@ -619,7 +619,7 @@ void jitc_llvm_ray_trace(uint32_t func, uint32_t scene, int shadow_ray,
     e.dep = (uint32_t *) malloc_check(sizeof(uint32_t) * n_args);
     for (uint32_t i = 0; i < n_args; ++i) {
         uint32_t index = i != 1 ? in[i] : valid;
-        jitc_var_inc_ref_int(index);
+        jitc_var_inc_ref(index);
         e.dep[i] = index;
     }
     e.n_dep = n_args;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -284,7 +284,7 @@ void jitc_shutdown(int light) {
 #if defined(DRJIT_ENABLE_OPTIX)
     // Free the default OptiX shader binding table and pipeline (ref counting)
     if (state.optix_default_sbt_index) {
-        jitc_var_dec_ref_ext(state.optix_default_sbt_index);
+        jitc_var_dec_ref(state.optix_default_sbt_index);
         state.optix_default_sbt_index = 0;
     }
 #endif
@@ -296,7 +296,7 @@ void jitc_shutdown(int light) {
         for (ThreadState *ts : state.tss) {
             for (uint32_t i : ts->side_effects) {
                 if (state.variables.find(i) != state.variables.end())
-                    jitc_var_dec_ref_ext(i);
+                    jitc_var_dec_ref(i);
             }
             jitc_free_flush(ts);
             if (ts->backend == JitBackend::CUDA) {
@@ -349,11 +349,10 @@ void jitc_shutdown(int light) {
             if (n_leaked < 10)
                 jitc_log(Warn,
                          " - variable r%u is still being referenced! "
-                         "(int_ref=%u, ext_ref=%u, se_ref=%u, type=%s, size=%u, "
+                         "(ref=%u, ref_se=%u, type=%s, size=%u, "
                          "stmt=\"%s\", dep=[%u, %u, %u, %u])",
                          var.first,
-                         (uint32_t) var.second.ref_count_int,
-                         (uint32_t) var.second.ref_count_ext,
+                         (uint32_t) var.second.ref_count,
                          (uint32_t) var.second.ref_count_se,
                          type_name[var.second.type],
                          var.second.size,

--- a/src/internal.h
+++ b/src/internal.h
@@ -60,14 +60,13 @@ struct Variable {
 
     // ===================   References, reference counts   ===================
 
-    /// External reference count (by application using DrJit)
-    uint64_t ref_count_ext : 24;
+    /// Number of times that this variable is referenced elsewhere
+    uint32_t ref_count;
 
-    /// Internal reference count (dependencies within computation graph)
-    uint64_t ref_count_int : 24;
+    uint32_t unused : 16;
 
     /// Number of queued side effects
-    uint64_t ref_count_se : 16;
+    uint32_t ref_count_se : 16;
 
     /// Up to 4 dependencies of this instruction (further possible via 'extra')
     uint32_t dep[4];

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -51,9 +51,9 @@ static void wrap(Variable &v, uint32_t &index, uint32_t dep = 0) {
     v.type = v2->type;
     v.dep[0] = index;
     v.dep[1] = dep;
-    jitc_var_inc_ref_int(index, v2);
-    jitc_var_dec_ref_ext(index, v2);
-    jitc_var_inc_ref_int(dep);
+    jitc_var_inc_ref(index, v2);
+    jitc_var_dec_ref(index, v2);
+    jitc_var_inc_ref(dep);
     index = 0; // in case jitc_var_new throws
     index = jitc_var_new(v, true);
 }
@@ -270,8 +270,8 @@ uint32_t jitc_var_loop(const char *name, uint32_t loop_init,
                     v2->stmt = (char *) "$r0 = phi <$w x $t0> [ $r0, "
                                         "%l_$i2_tail ], [ $r1, %l_$i2_start ]";
                 }
-                jitc_var_inc_ref_ext(index_3);
-                jitc_var_dec_ref_ext(index_1);
+                jitc_var_inc_ref(index_3);
+                jitc_var_dec_ref(index_1);
                 indices_in[i] = index_3;
                 n_invariant++;
             }
@@ -298,14 +298,14 @@ uint32_t jitc_var_loop(const char *name, uint32_t loop_init,
     if (n_invariant && first_round) {
         // Release recorded computation
         for (size_t i = 0; i < n_indices; ++i) {
-            jitc_var_inc_ref_ext(indices_in[i]);
-            jitc_var_dec_ref_ext(*indices[i]);
+            jitc_var_inc_ref(indices_in[i]);
+            jitc_var_dec_ref(*indices[i]);
             *indices[i] = indices_in[i];
         }
 
         // Release side effects
         while (checkpoint != se.size()) {
-            jitc_var_dec_ref_ext(se.back());
+            jitc_var_dec_ref(se.back());
             se.pop_back();
         }
 
@@ -392,8 +392,8 @@ uint32_t jitc_var_loop(const char *name, uint32_t loop_init,
                n_indices * sizeof(uint32_t));
 
         for (size_t i = 0; i < n_indices; ++i) {
-            jitc_var_inc_ref_int(loop->out_body[i]);
-            jitc_var_inc_ref_int(loop->in_cond[i]);
+            jitc_var_inc_ref(loop->out_body[i]);
+            jitc_var_inc_ref(loop->in_cond[i]);
         }
 
         snprintf(temp, sizeof(temp), "Loop (%s) [end]", name);
@@ -411,8 +411,8 @@ uint32_t jitc_var_loop(const char *name, uint32_t loop_init,
             uint32_t index = se[se.size() - loop->se_count + i];
             Variable *v = jitc_var(index);
             v->side_effect = false;
-            jitc_var_inc_ref_int(index, v);
-            jitc_var_dec_ref_ext(index, v);
+            jitc_var_inc_ref(index, v);
+            jitc_var_dec_ref(index, v);
             snprintf(temp, sizeof(temp), "Loop (%s) [side effects]", name);
             dep[i] = index;
         }
@@ -457,20 +457,20 @@ uint32_t jitc_var_loop(const char *name, uint32_t loop_init,
             if (!index) { // Optimized away
                 loop->out.push_back(0);
                 uint32_t index_2 = indices_in[i];
-                jitc_var_inc_ref_ext(index_2);
-                jitc_var_dec_ref_ext(*indices[i]);
+                jitc_var_inc_ref(index_2);
+                jitc_var_dec_ref(*indices[i]);
                 *indices[i] = index_2;
                 continue;
             }
 
             v2.type = jitc_var(index)->type;
             v2.dep[0] = loop->in_cond[i];
-            jitc_var_inc_ref_int(loop->in_cond[i]);
-            jitc_var_inc_ref_int(loop_end);
+            jitc_var_inc_ref(loop->in_cond[i]);
+            jitc_var_inc_ref(loop_end);
 
             uint32_t index_2 = jitc_var_new(v2, true);
             loop->out.push_back(index_2);
-            jitc_var_dec_ref_ext(*indices[i]);
+            jitc_var_dec_ref(*indices[i]);
             *indices[i] = index_2;
 
             const char *label = jitc_var_label(loop->in[i]);
@@ -651,8 +651,8 @@ static size_t jitc_var_loop_simplify(Loop *loop, tsl::robin_set<uint32_t, UInt32
             jitc_fail("jit_var_loop_simplify: internal error (2)");
         e_end.dep[i] = e_end.dep[n + i] = 0;
 
-        jitc_var_dec_ref_int(loop->in_cond[i]);
-        jitc_var_dec_ref_int(loop->out_body[i]);
+        jitc_var_dec_ref(loop->in_cond[i]);
+        jitc_var_dec_ref(loop->out_body[i]);
 
         loop->in[i] = loop->in_cond[i] = loop->in_body[i] = loop->out_body[i] = 0;
     }

--- a/src/optix_api.cpp
+++ b/src/optix_api.cpp
@@ -445,7 +445,7 @@ OptixDeviceContext jitc_optix_context() {
             = (OptixShaderBindingTable*) it->second.callback_data;
 
         state.optix_default_sbt_index = sbt_index;
-        jitc_var_dec_ref_ext(pipeline_index);
+        jitc_var_dec_ref(pipeline_index);
     }
 
     return ctx;
@@ -923,7 +923,7 @@ void jitc_optix_ray_trace(uint32_t n_args, uint32_t *args, uint32_t mask,
     extra.dep = (uint32_t *) malloc(sizeof(uint32_t) * extra.n_dep);
     memcpy(extra.dep, args, n_args * sizeof(uint32_t));
     for (uint32_t i = 0; i < n_args; ++i)
-        jitc_var_inc_ref_int(args[i]);
+        jitc_var_inc_ref(args[i]);
 
     extra.assemble = [](const Variable *v2, const Extra &extra) {
         uint32_t payload_count = extra.n_dep - 15;
@@ -982,7 +982,7 @@ void jitc_optix_ray_trace(uint32_t n_args, uint32_t *args, uint32_t mask,
         jitc_cse_put(index, v2);
     }
 
-    jitc_var_dec_ref_ext(special);
+    jitc_var_dec_ref(special);
 }
 
 void jitc_optix_mark(uint32_t index) {

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -53,11 +53,11 @@ uint32_t jitc_var_printf(JitBackend backend, uint32_t mask, const char *fmt,
     v->side_effect = 1;
     v->size = size;
     v->dep[0] = mask_combined;
-    jitc_var_inc_ref_int(mask_combined);
+    jitc_var_inc_ref(mask_combined);
 
     if (backend == JitBackend::LLVM) {
         v->dep[1] = printf_target;
-        jitc_var_inc_ref_int(printf_target);
+        jitc_var_inc_ref(printf_target);
     }
 
     size_t dep_size = narg * sizeof(uint32_t);
@@ -66,7 +66,7 @@ uint32_t jitc_var_printf(JitBackend backend, uint32_t mask, const char *fmt,
     e.dep = (uint32_t *) malloc(dep_size);
     memcpy(e.dep, arg, dep_size);
     for (uint32_t i = 0; i < narg; ++i)
-        jitc_var_inc_ref_int(arg[i]);
+        jitc_var_inc_ref(arg[i]);
 
     e.assemble = backend == JitBackend::CUDA
                      ? jitc_var_printf_assemble_cuda

--- a/src/var.h
+++ b/src/var.h
@@ -64,29 +64,17 @@ extern uint32_t jitc_var_copy(uint32_t index);
 /// Create a resized copy of a variable
 extern uint32_t jitc_var_resize(uint32_t index, size_t size);
 
-/// Increase the internal reference count of a given variable
-extern void jitc_var_inc_ref_int(uint32_t index, Variable *v) noexcept(true);
-
-/// Increase the internal reference count of a given variable
-extern void jitc_var_inc_ref_int(uint32_t index) noexcept(true);
-
-/// Decrease the internal reference count of a given variable
-extern void jitc_var_dec_ref_int(uint32_t index, Variable *v) noexcept(true);
-
-/// Decrease the internal reference count of a given variable
-extern void jitc_var_dec_ref_int(uint32_t index) noexcept(true);
+/// Increase the external reference count of a given variable
+extern void jitc_var_inc_ref(uint32_t index, Variable *v) noexcept(true);
 
 /// Increase the external reference count of a given variable
-extern void jitc_var_inc_ref_ext(uint32_t index, Variable *v) noexcept(true);
-
-/// Increase the external reference count of a given variable
-extern void jitc_var_inc_ref_ext(uint32_t index) noexcept(true);
+extern void jitc_var_inc_ref(uint32_t index) noexcept(true);
 
 /// Decrease the external reference count of a given variable
-extern void jitc_var_dec_ref_ext(uint32_t index, Variable *v) noexcept(true);
+extern void jitc_var_dec_ref(uint32_t index, Variable *v) noexcept(true);
 
 /// Decrease the external reference count of a given variable
-extern void jitc_var_dec_ref_ext(uint32_t index) noexcept(true);
+extern void jitc_var_dec_ref(uint32_t index) noexcept(true);
 
 /// Increase the side effect reference count of a given variable
 extern void jitc_var_inc_ref_se(uint32_t index, Variable *v) noexcept(true);

--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -579,7 +579,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
             auto& on = vcall->out_nested;
             auto it  = std::find(on.begin(), on.end(), index);
             // Only skip if this variable isn't also an output
-            if (it == vcall->out_nested.end())
+            if (it == on.end())
                 continue;
         }
 

--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -65,7 +65,7 @@ struct VCall {
 
     ~VCall() {
         for (uint32_t index : out_nested)
-            jitc_var_dec_ref_ext(index);
+            jitc_var_dec_ref(index);
         clear_side_effects();
         free(name);
     }
@@ -74,7 +74,7 @@ struct VCall {
         if (checkpoints.empty() || checkpoints.back() == checkpoints.front())
             return;
         for (uint32_t index : side_effects)
-            jitc_var_dec_ref_ext(index);
+            jitc_var_dec_ref(index);
         side_effects.clear();
         std::fill(checkpoints.begin(), checkpoints.end(), 0);
     }
@@ -106,7 +106,7 @@ void jitc_vcall_set_self(JitBackend backend, uint32_t value, uint32_t index) {
     ThreadState *ts = thread_state(backend);
 
     if (ts->vcall_self_index) {
-        jitc_var_dec_ref_ext(ts->vcall_self_index);
+        jitc_var_dec_ref(ts->vcall_self_index);
         ts->vcall_self_index = 0;
     }
 
@@ -114,7 +114,7 @@ void jitc_vcall_set_self(JitBackend backend, uint32_t value, uint32_t index) {
 
     if (value) {
         if (index) {
-            jitc_var_inc_ref_ext(index);
+            jitc_var_inc_ref(index);
             ts->vcall_self_index = index;
         } else {
             Variable v;
@@ -417,7 +417,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
 
             /* Hold a reference to the nested computation until the cleanup
                callback later below is invoked. */
-            jitc_var_inc_ref_ext(index);
+            jitc_var_inc_ref(index);
             vcall->out_nested.push_back(index);
         }
 
@@ -442,7 +442,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
 
             if ((bool) v->placeholder != placeholder || v->size != size ||
                 (bool) v->optix != optix) {
-                if (v->ref_count_ext != 1 || v->ref_count_int != 0) {
+                if (v->ref_count != 1) {
                     result_v = steal(jitc_var_copy(result_v));
                     v = jitc_var(result_v);
                 }
@@ -458,7 +458,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
 
             for (uint32_t i = 0; i < n_inst; ++i) {
                 uint32_t &index_2 = vcall->out_nested[i * n_out + j];
-                jitc_var_dec_ref_ext(index_2);
+                jitc_var_dec_ref(index_2);
                 index_2 = 0;
             }
         }
@@ -506,7 +506,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
         // Inform recursive computation graphs via reference counting
         for (uint32_t j = 0; j < vcall_2->n_inst; ++j) {
             uint32_t &index_2 = vcall_2->out_nested[n_out_2 * j + offset];
-            jitc_var_dec_ref_ext(index_2);
+            jitc_var_dec_ref(index_2);
             index_2 = 0;
         }
         vcall_2->out[offset] = 0;
@@ -519,7 +519,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
                 Extra *e = &state.extra[vcall_2->id];
                 if (unlikely(e->dep[i] != vcall_2->in[i]))
                     jitc_fail("jit_var_vcall(): internal error! (1)");
-                jitc_var_dec_ref_int(vcall_2->in[i]);
+                jitc_var_dec_ref(vcall_2->in[i]);
                 if (state.extra.find(vcall_2->id) == state.extra.end())
                     jitc_fail("jit_var_vcall(): internal error! (2)");
                 e = &state.extra[vcall_2->id]; // may have changed
@@ -547,7 +547,7 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
         v2.backend = v->backend;
         v2.dep[0] = vcall_v;
         v2.extra = 1;
-        jitc_var_inc_ref_int(vcall_v);
+        jitc_var_inc_ref(vcall_v);
         uint32_t index_2 = jitc_var_new(v2, true);
         Extra &extra = state.extra[index_2];
 
@@ -575,19 +575,19 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
             continue;
 
         // Ignore unreferenced inputs
-        if (vcall_optimize && v->ref_count_int == 0) {
+        if (vcall_optimize && v->ref_count == 2 /* 1 each from collect_indices + wrap_vcall */) {
             auto& on = vcall->out_nested;
             auto it  = std::find(on.begin(), on.end(), index);
             // Only skip if this variable isn't also an output
-            if (it == on.end())
+            if (it == vcall->out_nested.end())
                 continue;
         }
 
         vcall->in_nested.push_back(index);
 
-        uint32_t &index_2 = v->dep[0];
+        uint32_t index_2 = v->dep[0];
         vcall->in.push_back(index_2);
-        jitc_var_inc_ref_int(index_2);
+        jitc_var_inc_ref(index_2);
     }
 
     auto comp = [](uint32_t i0, uint32_t i1) {
@@ -1478,7 +1478,7 @@ VCallBucket *jitc_var_vcall_reduce(JitBackend backend, const char *domain,
         v2.data = perm + bucket.offset;
         v2.size = bucket.size;
 
-        jitc_var_inc_ref_int(perm_var);
+        jitc_var_inc_ref(perm_var);
 
         uint32_t index2 = jitc_var_new(v2);
 
@@ -1494,7 +1494,7 @@ VCallBucket *jitc_var_vcall_reduce(JitBackend backend, const char *domain,
                    (uintptr_t) bucket_out.ptr, bucket.size);
     }
 
-    jitc_var_dec_ref_ext(perm_var);
+    jitc_var_dec_ref(perm_var);
 
     *bucket_count_out = unique_count_out;
 

--- a/tests/basics.cpp
+++ b/tests/basics.cpp
@@ -18,10 +18,10 @@ TEST_BOTH(01_creation_destruction_cse) {
             jit_assert(strcmp(jit_var_str(l),
                                i == 0 ? "[1234]" : "[1234, 1234]") == 0);
 
-        jit_var_dec_ref_ext(v0);
-        jit_var_dec_ref_ext(v1);
-        jit_var_dec_ref_ext(v2);
-        jit_var_dec_ref_ext(v3);
+        jit_var_dec_ref(v0);
+        jit_var_dec_ref(v1);
+        jit_var_dec_ref(v2);
+        jit_var_dec_ref(v3);
     }
 }
 
@@ -41,9 +41,9 @@ TEST_BOTH(02_load_store) {
                 uint32_t v1 = jit_var_new_literal(Backend, VarType::UInt32, &value2, 1 + i);
 
                 uint32_t v0p = jit_var_new_op_2(JitOp::Add, o, v0);
-                jit_var_dec_ref_ext(v0);
+                jit_var_dec_ref(v0);
                 uint32_t v1p = jit_var_new_op_2(JitOp::Add, o, v1);
-                jit_var_dec_ref_ext(v1);
+                jit_var_dec_ref(v1);
 
                 jit_assert(v0p == v1p);
 
@@ -51,11 +51,11 @@ TEST_BOTH(02_load_store) {
                     jit_assert(strcmp(jit_var_str(l),
                                        (k == 0 && i == 0) ? "[1235]"
                                                           : "[1235, 1235]") == 0);
-                jit_var_dec_ref_ext(v0p);
-                jit_var_dec_ref_ext(v1p);
+                jit_var_dec_ref(v0p);
+                jit_var_dec_ref(v1p);
             }
 
-            jit_var_dec_ref_ext(o);
+            jit_var_dec_ref(o);
         }
     }
 }
@@ -76,12 +76,12 @@ TEST_BOTH(03_load_store_mask) {
         jit_assert(strcmp(jit_var_str(flip),
                            i == 0 ? "[0]" : "[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]") == 0);
 
-        jit_var_dec_ref_ext(flip);
-        jit_var_dec_ref_ext(ctr);
-        jit_var_dec_ref_ext(one);
-        jit_var_dec_ref_ext(zero);
-        jit_var_dec_ref_ext(odd);
-        jit_var_dec_ref_ext(mask);
+        jit_var_dec_ref(flip);
+        jit_var_dec_ref(ctr);
+        jit_var_dec_ref(one);
+        jit_var_dec_ref(zero);
+        jit_var_dec_ref(odd);
+        jit_var_dec_ref(mask);
     }
 }
 
@@ -107,9 +107,9 @@ TEST_BOTH(04_load_store_float) {
                 jit_assert(strcmp(jit_var_str(v2),
                                    j == 0 ? "[1235]" : "[1235, 1235]") == 0);
 
-                jit_var_dec_ref_ext(v0);
-                jit_var_dec_ref_ext(v1);
-                jit_var_dec_ref_ext(v2);
+                jit_var_dec_ref(v0);
+                jit_var_dec_ref(v1);
+                jit_var_dec_ref(v2);
             }
         }
     }
@@ -181,7 +181,7 @@ template <typename T> bool test_const_prop() {
             uint32_t index = 0;
             if ((op == JitOp::Rcp) && values[i] == 0) {
                 index = in[i];
-                jit_var_inc_ref_ext(index);
+                jit_var_inc_ref(index);
             } else {
                 index = jit_var_new_op(op, 1, in + i);
             }
@@ -234,10 +234,10 @@ template <typename T> bool test_const_prop() {
         }
 
         for (uint32_t i = 0; i < Size2 * Size2; ++i)
-            jit_var_dec_ref_ext(out[i]);
+            jit_var_dec_ref(out[i]);
 
         for (uint32_t i = 0; i < Size2; ++i)
-            jit_var_dec_ref_ext(in[i]);
+            jit_var_dec_ref(in[i]);
     }
 
     // ===============================================================
@@ -267,7 +267,7 @@ template <typename T> bool test_const_prop() {
                 if (((op == JitOp::Div || op == JitOp::Mod) && values[j] == 0) ||
                     ((op == JitOp::Shr || op == JitOp::Shl) && values[j] < Value(0))) {
                     index = in[j];
-                    jit_var_inc_ref_ext(index);
+                    jit_var_inc_ref(index);
                 } else {
                     index = jit_var_new_op(op, 2, deps);
                 }
@@ -315,10 +315,10 @@ template <typename T> bool test_const_prop() {
         }
 
         for (uint32_t i = 0; i < Size2 * Size2; ++i)
-            jit_var_dec_ref_ext(out[i]);
+            jit_var_dec_ref(out[i]);
 
         for (uint32_t i = 0; i < Size2; ++i)
-            jit_var_dec_ref_ext(in[i]);
+            jit_var_dec_ref(in[i]);
     }
 
     // ===============================================================
@@ -405,13 +405,13 @@ template <typename T> bool test_const_prop() {
         }
 
         for (uint32_t i = 0; i < Small2 * Small2 * Small2; ++i)
-            jit_var_dec_ref_ext(out[i]);
+            jit_var_dec_ref(out[i]);
 
         for (uint32_t i = 0; i < Small2; ++i)
-            jit_var_dec_ref_ext(in[i]);
+            jit_var_dec_ref(in[i]);
 
         for (int i = 0; i < 4; ++i)
-            jit_var_dec_ref_ext(in_b[i]);
+            jit_var_dec_ref(in_b[i]);
     }
 
     return fail;
@@ -526,8 +526,8 @@ TEST_BOTH(06_cast) {
                 }
 
                 for (int i = 0; i < size * 2; ++i) {
-                    jit_var_dec_ref_ext(source_value[i]);
-                    jit_var_dec_ref_ext(target_value[i]);
+                    jit_var_dec_ref(source_value[i]);
+                    jit_var_dec_ref(target_value[i]);
                 }
             }
         }
@@ -557,9 +557,9 @@ TEST_BOTH(07_and_or_mixed) {
             uint32_t v5 = jit_var_new_op_2(JitOp::Or, v1, v0);
             uint32_t v6 = jit_var_new_op_2(JitOp::Or, v2, v0);
 
-            jit_var_dec_ref_ext(v0);
-            jit_var_dec_ref_ext(v1);
-            jit_var_dec_ref_ext(v2);
+            jit_var_dec_ref(v0);
+            jit_var_dec_ref(v1);
+            jit_var_dec_ref(v2);
 
             jit_var_schedule(v3);
             jit_var_schedule(v4);
@@ -570,8 +570,8 @@ TEST_BOTH(07_and_or_mixed) {
             float out_f = 0;
             jit_var_read(v3, 0, &out_u);
             jit_var_read(v4, 0, &out_f);
-            jit_var_dec_ref_ext(v3);
-            jit_var_dec_ref_ext(v4);
+            jit_var_dec_ref(v3);
+            jit_var_dec_ref(v4);
 
             jit_assert(out_u == (b ? 1234u : 0u));
             jit_assert(out_f == (b ? 1234u : 0u));
@@ -582,8 +582,8 @@ TEST_BOTH(07_and_or_mixed) {
             jit_assert(out_u == (b ? 0xFFFFFFFF : 1234));
             jit_assert(b ? std::isnan(out_f) : (out_f == 1234));
 
-            jit_var_dec_ref_ext(v5);
-            jit_var_dec_ref_ext(v6);
+            jit_var_dec_ref(v5);
+            jit_var_dec_ref(v6);
         }
     }
 }

--- a/tests/ekloop.h
+++ b/tests/ekloop.h
@@ -82,11 +82,11 @@ struct Loop<Value, enable_if_jit_array_t<Value>> {
                     m_name.get());
         #endif
 
-        jit_var_dec_ref_ext(m_loop_init);
-        jit_var_dec_ref_ext(m_loop_cond);
+        jit_var_dec_ref(m_loop_init);
+        jit_var_dec_ref(m_loop_cond);
 
         for (size_t i = 0; i < m_indices_prev.size(); ++i)
-            jit_var_dec_ref_ext(m_indices_prev[i]);
+            jit_var_dec_ref(m_indices_prev[i]);
 
         if constexpr (IsDiff) {
             using Type = typename Value::Type;
@@ -205,7 +205,7 @@ protected:
                 // Backup loop state before loop (for optimization)
                 for (uint32_t i = 0; i < m_indices.size(); ++i) {
                     m_indices_prev[i] = *m_indices[i];
-                    jit_var_inc_ref_ext(m_indices_prev[i]);
+                    jit_var_inc_ref(m_indices_prev[i]);
                 }
 
                 // Start recording side effects
@@ -238,7 +238,7 @@ protected:
                             "Loop(\"%s\"): --------- done recording loop ----------", m_name.get());
 
                     for (size_t i = 0; i < m_indices_prev.size(); ++i)
-                        jit_var_dec_ref_ext(m_indices_prev[i]);
+                        jit_var_dec_ref(m_indices_prev[i]);
                     m_indices_prev.clear();
 
                     m_jit_state.end_recording();
@@ -276,8 +276,8 @@ protected:
             for (uint32_t i = 0; i < m_indices.size(); ++i) {
                 uint32_t i1 = *m_indices[i], i2 = m_indices_prev[i];
                 *m_indices[i] = jit_var_new_op_3(JitOp::Select, m_cond.index(), i1, i2);
-                jit_var_dec_ref_ext(i1);
-                jit_var_dec_ref_ext(i2);
+                jit_var_dec_ref(i1);
+                jit_var_dec_ref(i2);
             }
             m_indices_prev.clear();
 
@@ -309,7 +309,7 @@ protected:
         if (jit_var_any(cond.index())) {
             for (uint32_t i = 0; i < m_indices.size(); ++i) {
                 uint32_t index = *m_indices[i];
-                jit_var_inc_ref_ext(index);
+                jit_var_inc_ref(index);
                 m_indices_prev.push_back(index);
             }
 


### PR DESCRIPTION
The Variable data structure currently keeps track of an internal and an external reference count. We aren't really using that property, and it consumes precious storage in an otherwise highly optimized data structure. This experimental commit merges them into a joint 32 bit reference count field to free up memory for subsequent refactoring.