### PR TITLE
Further variable data structure refactoring

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -825,7 +825,7 @@ enum JitOp {
  * This function can perform a large range of unary, binary, and ternary
  * arithmetic operations. It automatically infers the necessary LLVM or PTX
  * instructions and performs constant propagation if possible (when one or
- * more input are literals).
+ * more input are literal constants).
  *
  * You will probably want to access this function through the wrappers \ref
  * jit_var_new_op_0() to \ref jit_var_new_op_4() that take an explicit
@@ -1048,7 +1048,7 @@ extern JIT_EXPORT const char *jit_var_stmt(uint32_t index);
 /// Query the type of a given variable
 extern JIT_EXPORT JIT_ENUM VarType jit_var_type(uint32_t index);
 
-/// Check if a variable is a constant literal
+/// Check if a variable is a literal constant
 extern JIT_EXPORT int jit_var_is_literal(uint32_t index);
 
 /// Check if a variable is evaluated
@@ -1289,7 +1289,7 @@ extern JIT_EXPORT void jit_prefix_pop(JIT_ENUM JitBackend backend);
  */
 #if defined(__cplusplus)
 enum class JitFlag : uint32_t {
-    /// Constant propagation: don't generate code for arithmetic involving literals
+    /// Constant propagation: don't generate code for arithmetic involving literal constants
     ConstProp = 1,
 
     /// Local value numbering (cheap form of common subexpression elimination)
@@ -1430,7 +1430,7 @@ extern JIT_EXPORT uint32_t jit_var_wrap_loop(uint32_t index, uint32_t cond, uint
  * o virtual function calls
  *
  * Following a call to \ref jit_vcall_set_self(), the JIT compiler will
- * intercept constant literals referring to the instance ID 'value'. In this
+ * intercept literal constants referring to the instance ID 'value'. In this
  * case, it will return the variable ID 'index'.
  *
  * This feature is crucial to avoid merging instance IDs into generated code.
@@ -1762,13 +1762,13 @@ extern JIT_EXPORT void jit_llvm_ray_trace(uint32_t func, uint32_t scene,
  * This function sets a unique scope identifier (a simple 32 bit integer)
  * isolate the effects of this optimization.
  */
-extern JIT_EXPORT void jit_new_cse_scope(JIT_ENUM JitBackend backend);
+extern JIT_EXPORT void jit_new_scope(JIT_ENUM JitBackend backend);
 
-/// Queries the CSE scope identifier (see \ref jit_new_cse_scope())
-extern JIT_EXPORT uint32_t jit_cse_scope(JIT_ENUM JitBackend backend);
+/// Queries the scope identifier (see \ref jit_new_scope())
+extern JIT_EXPORT uint32_t jit_scope(JIT_ENUM JitBackend backend);
 
-/// Manually sets a CSE scope identifier (see \ref jit_new_cse_scope())
-extern JIT_EXPORT void jit_set_cse_scope(JIT_ENUM JitBackend backend, uint32_t domain);
+/// Manually sets a scope identifier (see \ref jit_new_scope())
+extern JIT_EXPORT void jit_set_scope(JIT_ENUM JitBackend backend, uint32_t domain);
 
 // ====================================================================
 //                            Kernel History

--- a/include/drjit-core/state.h
+++ b/include/drjit-core/state.h
@@ -33,7 +33,7 @@ NAMESPACE_BEGIN(detail)
 template <JitBackend Backend> struct JitState {
     JitState()
         : m_mask_set(false), m_prefix_set(false), m_self_set(false),
-          m_cse_scope_set(false), m_recording(false) { }
+          m_scope_set(false), m_recording(false) { }
 
     ~JitState() {
         if (m_mask_set)
@@ -42,7 +42,7 @@ template <JitBackend Backend> struct JitState {
             clear_prefix();
         if (m_self_set)
             clear_self();
-        if (m_cse_scope_set)
+        if (m_scope_set)
             clear_scope();
         if (m_recording)
             end_recording();
@@ -94,17 +94,17 @@ template <JitBackend Backend> struct JitState {
     }
 
     void new_scope() {
-        if (!m_cse_scope_set) {
-            m_cse_scope = jit_cse_scope(Backend);
-            m_cse_scope_set = true;
+        if (!m_scope_set) {
+            m_scope = jit_scope(Backend);
+            m_scope_set = true;
         }
-        jit_new_cse_scope(Backend);
+        jit_new_scope(Backend);
     }
 
     void clear_scope() {
-        assert(m_cse_scope_set);
-        jit_set_cse_scope(Backend, m_cse_scope);
-        m_cse_scope_set = false;
+        assert(m_scope_set);
+        jit_set_scope(Backend, m_scope);
+        m_scope_set = false;
     }
 
     void set_self(uint32_t value, uint32_t index = 0) {
@@ -127,9 +127,9 @@ private:
     bool m_mask_set;
     bool m_prefix_set;
     bool m_self_set;
-    bool m_cse_scope_set;
+    bool m_scope_set;
     bool m_recording;
-    uint32_t m_cse_scope;
+    uint32_t m_scope;
     uint32_t m_checkpoint;
     uint32_t m_self_value;
     uint32_t m_self_index;

--- a/src/eval.h
+++ b/src/eval.h
@@ -16,9 +16,10 @@
 struct ScheduledVariable {
     uint32_t size;
     uint32_t index;
+    void *data;
 
     ScheduledVariable(uint32_t size, uint32_t index)
-        : size(size), index(index) { }
+        : size(size), index(index), data(nullptr) { }
 };
 
 /// Start and end index of a group of variables that will be merged into the same kernel

--- a/src/eval_cuda.cpp
+++ b/src/eval_cuda.cpp
@@ -128,7 +128,7 @@ void jitc_assemble_cuda(ThreadState *ts, ScheduledGroup group,
             const char *prefix = "%rd";
             uint32_t id = 0;
 
-            if (v->literal) {
+            if (v->is_literal()) {
                 prefix = type_prefix[vti];
                 id = v->reg_index;
             }
@@ -136,7 +136,7 @@ void jitc_assemble_cuda(ThreadState *ts, ScheduledGroup group,
             buffer.fmt("    ld.%s.u64 %s%u, [%s+%u];\n", params_type,
                        prefix, id, params_base, v->param_offset);
 
-            if (v->literal)
+            if (v->is_literal())
                 continue;
 
             if (size > 1)
@@ -313,7 +313,7 @@ void jitc_assemble_cuda_func(const char *name, uint32_t inst_id,
                            "    setp.ne.u16 %%p%u, %%w0, 0;\n",
                            v->param_offset, v->reg_index);
             }
-        } else if (v->data || vt == VarType::Pointer) {
+        } else if (v->is_data() || vt == VarType::Pointer) {
             uint64_t key = (uint64_t) sv.index + (((uint64_t) inst_id) << 32);
             auto it = data_map.find(key);
 
@@ -379,7 +379,7 @@ void jitc_assemble_cuda_func(const char *name, uint32_t inst_id,
 
 /// Convert an IR template with '$' expressions into valid IR
 static void jitc_render_stmt_cuda(uint32_t index, const Variable *v) {
-    if (v->literal) {
+    if (v->is_literal()) {
         const char *prefix = type_prefix[v->type],
                    *tname = type_name_ptx_bin[v->type];
 
@@ -392,7 +392,7 @@ static void jitc_render_stmt_cuda(uint32_t index, const Variable *v) {
         buffer.put(prefix, prefix_len);
         buffer.put_uint32(v->reg_index);
         buffer.put(", 0x");
-        buffer.put_uint64_hex(v->value);
+        buffer.put_uint64_hex(v->literal);
         buffer.put(";\n");
     } else {
         const char *s = v->stmt;

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -168,7 +168,7 @@ static void jitc_var_printf_assemble_cuda(const Variable *v,
                (unsigned long long) hash.low64);
     if (v->dep[0]) {
         Variable *v2 = jitc_var(v->dep[0]);
-        if (!v2->literal || v2->value != 1)
+        if (!v2->is_literal() || v2->literal != 1)
             buffer.fmt("@%%p%u ", v2->reg_index);
     }
     buffer.put("call (rv_p), vprintf, (fmt_p, buf_p);\n"

--- a/src/var.h
+++ b/src/var.h
@@ -17,7 +17,7 @@ struct Variable;
 /// Look up a variable by its ID
 extern Variable *jitc_var(uint32_t index);
 
-/// Create a literal constant variable of the given size
+/// Create a value constant variable of the given size
 extern uint32_t jitc_var_new_literal(JitBackend backend, VarType type,
                                      const void *value, size_t size,
                                      int eval, int is_class = 0);
@@ -120,7 +120,7 @@ extern uint32_t jitc_var_write(uint32_t index, size_t offset, const void *src);
 /// Schedule a variable \c index for future evaluation via \ref jit_eval()
 extern int jitc_var_schedule(uint32_t index);
 
-/// Evaluate a literal constant variable
+/// Evaluate a value constant variable
 extern void jitc_var_eval_literal(uint32_t index, Variable *v);
 
 /// Evaluate the variable \c index right away, if it is unevaluated/dirty.
@@ -136,13 +136,13 @@ extern const char *jitc_var_whos();
 extern const char *jitc_var_graphviz();
 
 /// Remove a variable from the cache used for common subexpression elimination
-extern void jitc_cse_drop(uint32_t index, const Variable *v);
+extern void jitc_lvn_drop(uint32_t index, const Variable *v);
 
 /// Register a variable with cache used for common subexpression elimination
-extern void jitc_cse_put(uint32_t index, const Variable *v);
+extern void jitc_lvn_put(uint32_t index, const Variable *v);
 
 /// Append the given variable to the instruction trace and return its ID
-extern uint32_t jitc_var_new(Variable &v, bool disable_cse = false);
+extern uint32_t jitc_var_new(Variable &v, bool disable_lvn = false);
 
 /// Query the current (or future, if not yet evaluated) allocation flavor of a variable
 extern AllocType jitc_var_alloc_type(uint32_t index);

--- a/tests/basics.cpp
+++ b/tests/basics.cpp
@@ -70,11 +70,11 @@ TEST_BOTH(03_load_store_mask) {
         uint32_t mask = jit_var_new_op_2(JitOp::Eq, odd, zero);
 
         jit_assert(strcmp(jit_var_str(mask),
-                           i == 0 ? "[1]" : "[1, 0, 1, 0, 1, 0, 1, 0, 1, 0]") == 0);
+                          i == 0 ? "[1]" : "[1, 0, 1, 0, 1, 0, 1, 0, 1, 0]") == 0);
 
         uint32_t flip = jit_var_new_op_1(JitOp::Not, mask);
         jit_assert(strcmp(jit_var_str(flip),
-                           i == 0 ? "[0]" : "[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]") == 0);
+                          i == 0 ? "[0]" : "[0, 1, 0, 1, 0, 1, 0, 1, 0, 1]") == 0);
 
         jit_var_dec_ref(flip);
         jit_var_dec_ref(ctr);
@@ -86,7 +86,7 @@ TEST_BOTH(03_load_store_mask) {
 }
 
 TEST_BOTH(04_load_store_float) {
-    /// Check usage of floats/doubles (loading, storing, literals)
+    /// Check usage of floats/doubles (loading, storing, constant literals)
     for (int i = 0; i < 2; ++i) {
         for (int j = 0; j < 2; ++j) {
             for (int k = 0; k < 2; ++k) {

--- a/tests/mem.cpp
+++ b/tests/mem.cpp
@@ -164,3 +164,18 @@ TEST_BOTH(10_scatter_atomic_rmw) {
                    "[4, 1, 2, 1, 1, 1, 1, 0, 1, 1, 2, 0, 0, 0, 0, 0]") == 0);
     }
 }
+
+TEST_BOTH(11_reindex) {
+    // Test that a gather expression can rewrite the original expression
+    UInt32 i1 = arange<UInt32>(100) + 5,
+           i2 = arange<UInt32>(10) * 2,
+           i3 = gather<UInt32>(i1, i2),
+           i4 = arange<UInt32>(10) * 2 + 5;
+
+    jit_assert(!jit_var_is_evaluated(i1.index()) &&
+               !jit_var_is_evaluated(i2.index()) &&
+               !jit_var_is_evaluated(i3.index()) &&
+               !jit_var_is_evaluated(i4.index()));
+
+    jit_assert(i3.index() == i4.index());
+}


### PR DESCRIPTION
This commit builds on PR #38 and further refactors the `Variable` data structure by adding a ``kind`` field that specifies the kind of the variable in question. The field must be set to one of:

- `VarKind::Literal`: constant literals
- `VarKind::Stmt`: a statement in an intermediate representation (LLVM IR, PTX)
- `VarKind::Data`: a pointer to device memory

This permits overlapping `data`, `literal`, and `stmt` using a union, which frees up 64 bits (`data` was previously stored separately):

```cpp
union {
    uint64_t literal;
    const char *stmt;
    void *data;
}
```

The `Variable` struct was extended with convenience functions to check `kind`:

```cpp
inline bool is_literal() { return kind == (uint32_t) VarKind::Literal; }
inline bool is_stmt()    { return kind == (uint32_t) VarKind::Stmt; }
inline bool is_data()    { return kind == (uint32_t) VarKind::Data; }
```

Most of the PR then consists of adding checks that call these helper functions to disambiguate the kind of variable being processed.

A few other minor changes are rolled in:

- The Variable data structure gets a helper function `is_dirty()` that wraps the somewhat opaque expression `ref_count_se > 0` previously used in various places.

- CSE is renamed to LVN (local value numbering) throughout the codebase. CVN and LVN are related but not quite the same, and LVN is what is implemented in Dr.Jit.

- The Variable `cse_scope` field was renamed to `scope` and extended to 32 bit. The name change is motivated by the more general use of this variable in the future. A similar renaming change was made to API, which affects the `jit_set_scope()`, `jit_scope()`, and `jit_new_scope()` functions in `jit.h`.

- The `ref_count_se` field was extended to 32 bits.

- There was still space left over in the `Variable` data structure, so a 32 bit variable named `unused` was added to the data structure to keep the size of a hash table entry at 64 bytes (1 cache line). This field will be default-initialized to zero.

- The second commit adds a test for the symbolic gather feature. `dr.gather()` has the ability to rewrite an input array if it is in symbolic form, but there wasn't a test to check that this rewriting is actually happening.