### PR TITLE
Make program structure independent of variable indices

### DIFF
--- a/include/drjit-core/state.h
+++ b/include/drjit-core/state.h
@@ -22,9 +22,8 @@ NAMESPACE_BEGIN(detail)
 /**
  * \brief JitState RAII wrapper
  *
- * This class encapsulates several configuration attributes of Dr.Jit (the
- * mask stack, variable name prefixes, the CSE scope, whether program recording
- * is enabled.)
+ * This class encapsulates several configuration attributes of Dr.Jit (the mask
+ * stack, variable name prefixes, whether program recording is enabled.)
  *
  * The <tt>set_*</tt>, <tt>clear_*</tt>, <tt>begin_*</tt>, and <tt>end_*</tt>
  * methods can be used to change and clear these attributes. The deconstructor
@@ -33,7 +32,7 @@ NAMESPACE_BEGIN(detail)
 template <JitBackend Backend> struct JitState {
     JitState()
         : m_mask_set(false), m_prefix_set(false), m_self_set(false),
-          m_scope_set(false), m_recording(false) { }
+          m_recording(false) { }
 
     ~JitState() {
         if (m_mask_set)
@@ -42,8 +41,6 @@ template <JitBackend Backend> struct JitState {
             clear_prefix();
         if (m_self_set)
             clear_self();
-        if (m_scope_set)
-            clear_scope();
         if (m_recording)
             end_recording();
     }
@@ -94,17 +91,7 @@ template <JitBackend Backend> struct JitState {
     }
 
     void new_scope() {
-        if (!m_scope_set) {
-            m_scope = jit_scope(Backend);
-            m_scope_set = true;
-        }
         jit_new_scope(Backend);
-    }
-
-    void clear_scope() {
-        assert(m_scope_set);
-        jit_set_scope(Backend, m_scope);
-        m_scope_set = false;
     }
 
     void set_self(uint32_t value, uint32_t index = 0) {
@@ -127,9 +114,7 @@ private:
     bool m_mask_set;
     bool m_prefix_set;
     bool m_self_set;
-    bool m_scope_set;
     bool m_recording;
-    uint32_t m_scope;
     uint32_t m_checkpoint;
     uint32_t m_self_value;
     uint32_t m_self_index;

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -91,23 +91,15 @@ uint32_t jit_scope(JitBackend backend) {
     return thread_state(backend)->scope;
 }
 
-void jit_set_scope(JitBackend backend, uint32_t scope_index) {
+void jit_set_scope(JitBackend backend, uint32_t scope) {
     lock_guard guard(state.lock);
-    if (unlikely(scope_index >= (1 << 24)))
-        jitc_raise("jit_set_scope(): overflow (scope index exceeds the 24 "
-                   "bit counter of the Variable data structure)!");
-    jitc_trace("jit_set_scope(%u)", scope_index);
-    thread_state(backend)->scope = scope_index;
+    jitc_trace("jit_set_scope(%u)", scope);
+    thread_state(backend)->scope = scope;
 }
 
 void jit_new_scope(JitBackend backend) {
     lock_guard guard(state.lock);
-    uint32_t scope_index = ++state.scope_ctr;
-    if (unlikely(scope_index >= (1 << 24)))
-        jitc_raise("jit_new_scope(): overflow (scope index exceeds the 24 "
-                   "bit counter of the Variable data structure)!");
-    jitc_trace("jit_new_scope(%u)", scope_index);
-    thread_state(backend)->scope = scope_index;
+    jitc_new_scope(backend);
 }
 
 void jit_set_log_level_stderr(LogLevel level) {

--- a/src/eval.h
+++ b/src/eval.h
@@ -16,10 +16,11 @@
 struct ScheduledVariable {
     uint32_t size;
     uint32_t index;
+    uint32_t scope;
     void *data;
 
-    ScheduledVariable(uint32_t size, uint32_t index)
-        : size(size), index(index), data(nullptr) { }
+    ScheduledVariable(uint32_t size, uint32_t scope, uint32_t index)
+        : size(size), index(index), scope(scope), data(nullptr) { }
 };
 
 /// Start and end index of a group of variables that will be merged into the same kernel
@@ -83,10 +84,10 @@ extern bool assemble_func;
 extern int32_t alloca_size;
 extern int32_t alloca_align;
 
-/// Number of callables that were compiled so far
+/// Number of tentative callables that were assembled in the kernel being compiled
 extern uint32_t callable_count;
 
-/// Number of unique callables that were compiled so far
+/// Number of unique callables in the kernel being compiled
 extern uint32_t callable_count_unique;
 
 /// Specifies the nesting level of virtual calls being compiled

--- a/src/eval_llvm.cpp
+++ b/src/eval_llvm.cpp
@@ -150,7 +150,6 @@ void jitc_assemble_llvm(ThreadState *ts, ScheduledGroup group) {
         if (alloca_size >= 0)
             buffer.fmt("    %%buffer = alloca i8, i32 %i, align %i\n",
                        alloca_size, alloca_align);
-        buffer.put("\n");
 
         jitc_insert_code_at(insertion_point, insertion_start);
     }

--- a/src/var.h
+++ b/src/var.h
@@ -165,6 +165,9 @@ extern uint32_t jitc_var_mask_apply(uint32_t index, uint32_t size);
 /// Return the default mask
 extern uint32_t jitc_var_mask_default(JitBackend backend, uint32_t size);
 
+/// Start a new scope of the program being recorded
+extern void jitc_new_scope(JitBackend backend);
+
 /// Reduce (And) a boolean array to a single value, synchronizes.
 extern bool jitc_var_all(uint32_t index);
 

--- a/tests/ekloop.h
+++ b/tests/ekloop.h
@@ -147,10 +147,7 @@ struct Loop<Value, enable_if_jit_array_t<Value>> {
         if (m_state)
             jit_raise("Loop(\"%s\"): was already initialized!", m_name.get());
 
-        m_indices_prev  = dr_vector<uint32_t>(m_indices.size(), 0);
-
-        // Capture JIT state and begin recording session
-        m_jit_state.new_scope();
+        m_indices_prev = dr_vector<uint32_t>(m_indices.size(), 0);
 
         // Rewrite loop state variables (1)
         m_loop_init = jit_var_loop_init(m_indices.size(), m_indices.data());
@@ -242,7 +239,6 @@ protected:
                     m_indices_prev.clear();
 
                     m_jit_state.end_recording();
-                    m_jit_state.clear_scope();
                     m_jit_state.clear_mask_if_set();
                     jit_var_mark_side_effect(rv);
 


### PR DESCRIPTION
Note: this PR builds on PR #40.

When Dr.Jit generates IR output, there is a question of how statements should be ordered. Any ordering that does not violate variable dependencies or basic block boundaries is in principle admissible. Previously, Dr.Jit arranged variables in the order in which they were originally constructed by sorting them according to the monotonically increasing variable index.

This was correct but had three negative implications:

- Variable IDs are 32 bit counters in Dr.Jit, and this is generally desirable to keep the central `Variable` data structure small. However, long-running programs could overflow that 32 bit counter, which meant that the program order no longer made sense. Dr.Jit failed with an error when this happened. At this point, a number of users have encountered this frustrating failure mode.

- Mitsuba, the parent project of Dr.Jit, has the ability to construct scenes in parallel. This leads to an unpredictable ordering of variables and broke kernel caching across runs of the system, hence parallelization had to disabled in practice.

- Variable index changes impeded the effectiveness of the function deduplication optimization.

This commit changes code generation so that IR statements in the generated output are ordered by their scope ID. Within each scope, the order is determined by a DFS traversal.

This is simple and always generates consistent output regardless of variable indices. It no longer matters when the variable index counter overflows.

The same issue will reappear when the scope counter overflows, but 4 billion scopes ought to be ... (ducks).

A few `jit_var_new_scope()` calls had to be inserted in strategic places to ensure that LLVM requirements are satisfied (for example, PHI nodes must always occur at the beginning of a basic block).