### PR TITLE
Improve efficiency of CUDA scatter-reduction

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -252,7 +252,10 @@ struct Device {
     int id;
 
     /// Device compute capability (major * 10 + minor)
-    int compute_capability;
+    uint32_t compute_capability = 0;
+
+    /// Targeted PTX version (major * 10 + minor)
+    uint32_t ptx_version = 0;
 
     /// Number of SMs
     uint32_t num_sm;
@@ -419,16 +422,16 @@ struct ThreadState {
      */
     int device = 0;
 
-    /// Targeted compute compatibility
-    uint32_t compute_capability = 50;
+    /// Device compute capability (major * 10 + minor)
+    uint32_t compute_capability = 0;
 
     /// Targeted PTX version (major * 10 + minor)
-    uint32_t ptx_version = 60;
+    uint32_t ptx_version = 0;
 
 #if defined(DRJIT_ENABLE_OPTIX)
     /// OptiX pipeline associated with the next kernel launch
-    OptixPipelineData *optix_pipeline;
-    OptixShaderBindingTable *optix_sbt;
+    OptixPipelineData *optix_pipeline = nullptr;
+    OptixShaderBindingTable *optix_sbt = nullptr;
 #endif
 };
 

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -2177,13 +2177,10 @@ uint32_t jitc_var_new_scatter(uint32_t target_, uint32_t value, uint32_t index_,
                     "    atom.add.f32 %f19, [%rd3], %f21;\n"
                     "done:\n"
                     "    ret;\n"
-                    "}");
+                    "}\n\n");
 
-                buffer.put("    {\n");
-                buffer.put("        .visible .func reduce_f32(.param .u64 ptr, .param .u32 index, .param .f32 value);\n");
-                buffer.fmt("        call reduce_f32, (%%rd%u, %%r%u, %%f%u);\n",
+                buffer.fmt("    call reduce_f32, (%%rd%u, %%r%u, %%f%u);\n",
                            dst_i, index_i, src_i);
-                buffer.put("    }\n");
                 if (masked)
                     buffer.fmt("l_%u_done:\n", v_i);
                 return;


### PR DESCRIPTION
This PR consists of two changes:

The first improves the implementation of the important special case of FP32 scatter-add reduction on CUDA/OptiX. The previous implementation generated up to 32 atomic memory transaction per warp, causing significant contention in some cases. The new implementation first performs an intra-warp reduction. A warp that consistently targets the same location in memory will then only generate a single memory transaction.

The second adjusts the type of PTX IR generated by Dr.Jit. We previously targeted a generic low PTX version and compute capability. The commit changes the logic so that both numbers are bumped according to a table containing known safe combinations.