### PR TITLE
Fix jitc_var_vcall_reduce for dr.switch()

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1680,8 +1680,8 @@ struct VCallBucket {
 };
 
 /**
- * \brief Compute a permutation to reorder an array of registered pointers
- * in preparation for a vectorized method call
+ * \brief Compute a permutation to reorder an array of registered pointers or
+ * indices in preparation for a vectorized function call
  *
  * This function expects an array of integers, whose entries correspond to
  * pointers that have previously been registered by calling \ref
@@ -1692,6 +1692,14 @@ struct VCallBucket {
  * jit_registry_get_ptr()) and the variable index of an unsigned 32 bit array
  * containing the corresponding entries of the input array. The total number of
  * buckets is returned via the \c bucket_count_out argument.
+ *
+ * Alternatively, this function can be used to abuse the virtual function call
+ * mechanism of Dr.Jit to dispatch the wavefront on an arbitrary list of
+ * callables. In this case, \c domain should be set to \c nullptr and the
+ * function will expects an array of integers that correspond to the indices of
+ * the callable to execute. The largest possible value in the array of indices
+ * has to be passed via the \c bucket_count_out argument, which will then be
+ * overwritten with the total number of buckets.
  *
  * The memory region accessible via the \c VCallBucket pointer will remain
  * accessible until the variable \c index is itself freed (i.e. when its

--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -1410,7 +1410,12 @@ VCallBucket *jitc_var_vcall_reduce(JitBackend backend, const char *domain,
         }
     }
 
-    uint32_t bucket_count = jitc_registry_get_max(backend, domain) + 1;
+    uint32_t bucket_count;
+    if (domain)
+        bucket_count = jitc_registry_get_max(backend, domain) + 1;
+    else
+        bucket_count = *bucket_count_out + 1;
+
     if (unlikely(bucket_count == 1)) {
         *bucket_count_out = 0;
         return nullptr;
@@ -1421,7 +1426,10 @@ VCallBucket *jitc_var_vcall_reduce(JitBackend backend, const char *domain,
 
     uint32_t size = jitc_var(index)->size;
 
-    jitc_log(Debug, "jit_vcall(r%u, domain=\"%s\")", index, domain);
+    if (domain)
+        jitc_log(Debug, "jit_vcall(r%u, domain=\"%s\")", index, domain);
+    else
+        jitc_log(Debug, "jitc_var_vcall_reduce(r%u)", index);
 
     size_t perm_size    = (size_t) size * (size_t) sizeof(uint32_t),
            offsets_size = (size_t(bucket_count) * 4 + 1) * sizeof(uint32_t);
@@ -1477,7 +1485,12 @@ VCallBucket *jitc_var_vcall_reduce(JitBackend backend, const char *domain,
         uint32_t index2 = jitc_var_new(v2);
 
         VCallBucket bucket_out;
-        bucket_out.ptr = jitc_registry_get_ptr(backend, domain, bucket.id);
+
+        if (domain)
+            bucket_out.ptr = jitc_registry_get_ptr(backend, domain, bucket.id);
+        else
+            bucket_out.ptr = nullptr;
+
         bucket_out.index = index2;
         bucket_out.id = bucket.id;
 


### PR DESCRIPTION
This PR adapt `jit_var_vcall_reduce` to also work with callable that are not methods of classes registered in the Dr.Jit registry. This is necessary for the implementation of `dr.switch` and `dr.dispatch()`.