### PR TITLE
Bug fix for CUDA assembly & logging improvements for OptiX compilation (minor changes)

### DIFF
--- a/src/eval_cuda.cpp
+++ b/src/eval_cuda.cpp
@@ -121,6 +121,7 @@ void jitc_assemble_cuda(ThreadState *ts, ScheduledGroup group,
             if (extra.assemble) {
                 extra.assemble(v, extra);
                 assemble = true;
+                v = jitc_var(index); // The address of 'v' can change
             }
         }
 

--- a/src/optix_api.cpp
+++ b/src/optix_api.cpp
@@ -643,8 +643,9 @@ bool jitc_optix_compile(ThreadState *ts, const char *buf, size_t buf_size,
     if (compilation_state != OPTIX_MODULE_COMPILE_STATE_COMPLETED)
         jitc_fail("jit_optix_compile(): optixModuleGetCompilationState() "
                   "indicates that the compilation did not complete "
-                  "succesfully. The module's compilation state is: %#06x",
-                  compilation_state);
+                  "succesfully. The module's compilation state is: %#06x\n"
+                  "Please see the PTX assembly listing and error message "
+                  "below:\n\n%s\n\n%s", compilation_state, buf, error_log);
 
     // =====================================================
     // 3. Create an OptiX program group


### PR DESCRIPTION
The following 2 commits of this PR do:
1) A bug fix related to an issue reported here: https://github.com/mitsuba-renderer/mitsuba3/issues/408. During `jit_assemble_cuda` JIT variables can change addresses because of extra assembly steps required by some variables (a vcall variable in this specific instance). 
2) Improvements to the logging when the OptiX compilation fails. The new message prints the exact failure reported by OptiX rather than only the compilation state. 