### PR TITLE
Branch/Switch for virtual function calls

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1304,42 +1304,49 @@ enum class JitFlag : uint32_t {
     /// Record virtual function calls instead of splitting them into many small kernel launches
     VCallRecord = 16,
 
+    /**
+     * \brief Use branches instead of direct callables (in OptiX) or indirect
+     * function calls (in CUDA) for virtual function calls.
+     */
+    VCallBranch = 32,
+
     /// De-duplicate virtual function calls that produce the same code
-    VCallDeduplicate = 32,
+    VCallDeduplicate = 64,
 
     /// Enable constant propagation and elide unnecessary function arguments
-    VCallOptimize = 64,
+    VCallOptimize = 128,
 
     /**
      * \brief Inline calls if there is only a single instance? (off by default,
      * inlining can make kernels so large that they actually run slower in
      * CUDA/OptiX).
      */
-    VCallInline = 128,
+    VCallInline = 256,
 
     /// Force execution through OptiX even if a kernel doesn't use ray tracing
-    ForceOptiX = 256,
+    ForceOptiX = 512,
 
     /// Temporarily postpone evaluation of statements with side effects
-    Recording = 512,
+    Recording = 1024,
 
     /// Print the intermediate representation of generated programs
-    PrintIR = 1024,
+    PrintIR = 2048,
 
     /// Enable writing of the kernel history
-    KernelHistory = 2048,
+    KernelHistory = 4096,
 
     /* Force synchronization after every kernel launch. This is useful to
        isolate crashes to a specific kernel, and to benchmark kernel runtime
        along with the KernelHistory feature. */
-    LaunchBlocking = 4096,
+    LaunchBlocking = 8192,
 
     /// Exploit literal constants during AD (used in the Dr.Jit parent project)
-    ADOptimize = 8192,
+    ADOptimize = 16384,
 
     /// Default flags
     Default = (uint32_t) ConstProp | (uint32_t) ValueNumbering |
               (uint32_t) LoopRecord | (uint32_t) LoopOptimize |
+              //(uint32_t) VCallBranch |
               (uint32_t) VCallRecord | (uint32_t) VCallDeduplicate |
               (uint32_t) VCallOptimize | (uint32_t) ADOptimize
 };
@@ -1350,15 +1357,16 @@ enum JitFlag {
     JitFlagLoopRecord          = 4,
     JitFlagLoopOptimize        = 8,
     JitFlagVCallRecord         = 16,
-    JitFlagVCallDeduplicate    = 32,
-    JitFlagVCallOptimize       = 64,
-    JitFlagVCallInline         = 128,
-    JitFlagForceOptiX          = 256,
-    JitFlagRecording           = 512,
-    JitFlagPrintIR             = 1024,
-    JitFlagKernelHistory       = 2048,
-    JitFlagLaunchBlocking      = 4096,
-    JitFlagADOptimize          = 8192
+    JitFlagVCallBranch         = 32,
+    JitFlagVCallDeduplicate    = 64,
+    JitFlagVCallOptimize       = 128,
+    JitFlagVCallInline         = 256,
+    JitFlagForceOptiX          = 512,
+    JitFlagRecording           = 1024,
+    JitFlagPrintIR             = 2048,
+    JitFlagKernelHistory       = 4096,
+    JitFlagLaunchBlocking      = 8192,
+    JitFlagADOptimize          = 16384,
 };
 #endif
 

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1285,7 +1285,7 @@ extern JIT_EXPORT void jit_prefix_pop(JIT_ENUM JitBackend backend);
  * The default set of flags is:
  *
  * <tt>ConstProp | ValueNumbering | LoopRecord | LoopOptimize |
- * VCallRecord | VCallOptimize | ADOptimize</tt>
+ * VCallRecord | VCallDeduplicate | VCallOptimize | ADOptimize</tt>
  */
 #if defined(__cplusplus)
 enum class JitFlag : uint32_t {
@@ -1306,70 +1306,75 @@ enum class JitFlag : uint32_t {
 
     /**
      * \brief Use branches instead of direct callables (in OptiX) or indirect
-     * function calls (in CUDA) for virtual function calls.
+     * function calls (in CUDA) for virtual function calls. The default
+     * branching strategy is a linear search among all targets.
      */
     VCallBranch = 32,
 
+    /// Use a jump table to reach appropriate target when `VCallBranch` is enabled
+    VCallBranchJumpTable = 64,
+
+    /// Perform a binary search to find the appropriate target when `VCallBranch` is enabled
+    VCallBranchBinarySearch = 128,
+
     /// De-duplicate virtual function calls that produce the same code
-    VCallDeduplicate = 64,
+    VCallDeduplicate = 256,
 
     /// Enable constant propagation and elide unnecessary function arguments
-    VCallOptimize = 128,
+    VCallOptimize = 512,
 
     /**
      * \brief Inline calls if there is only a single instance? (off by default,
      * inlining can make kernels so large that they actually run slower in
      * CUDA/OptiX).
      */
-    VCallInline = 256,
+    VCallInline = 1024,
 
     /// Force execution through OptiX even if a kernel doesn't use ray tracing
-    ForceOptiX = 512,
+    ForceOptiX = 2048,
 
     /// Temporarily postpone evaluation of statements with side effects
-    Recording = 1024,
+    Recording = 4096,
 
     /// Print the intermediate representation of generated programs
-    PrintIR = 2048,
+    PrintIR = 8192,
 
     /// Enable writing of the kernel history
-    KernelHistory = 4096,
+    KernelHistory = 16384,
 
     /* Force synchronization after every kernel launch. This is useful to
        isolate crashes to a specific kernel, and to benchmark kernel runtime
        along with the KernelHistory feature. */
-    LaunchBlocking = 8192,
+    LaunchBlocking = 32768,
 
     /// Exploit literal constants during AD (used in the Dr.Jit parent project)
-    ADOptimize = 16384,
-
-    VCallBranchJumpTable = 32768,
+    ADOptimize = 65536,
 
     /// Default flags
     Default = (uint32_t) ConstProp | (uint32_t) ValueNumbering |
               (uint32_t) LoopRecord | (uint32_t) LoopOptimize |
               (uint32_t) VCallRecord | (uint32_t) VCallDeduplicate |
-              (uint32_t) VCallBranch | (uint32_t) VCallBranchJumpTable |
               (uint32_t) VCallOptimize | (uint32_t) ADOptimize
 };
 #else
 enum JitFlag {
-    JitFlagConstProp            = 1,
-    JitFlagValueNumbering       = 2,
-    JitFlagLoopRecord           = 4,
-    JitFlagLoopOptimize         = 8,
-    JitFlagVCallRecord          = 16,
-    JitFlagVCallBranch          = 32,
-    JitFlagVCallDeduplicate     = 64,
-    JitFlagVCallOptimize        = 128,
-    JitFlagVCallInline          = 256,
-    JitFlagForceOptiX           = 512,
-    JitFlagRecording            = 1024,
-    JitFlagPrintIR              = 2048,
-    JitFlagKernelHistory        = 4096,
-    JitFlagLaunchBlocking       = 8192,
-    JitFlagADOptimize           = 16384,
-    JitFlagVCallBranchJumpTable = 32768,
+    JitFlagConstProp               = 1,
+    JitFlagValueNumbering          = 2,
+    JitFlagLoopRecord              = 4,
+    JitFlagLoopOptimize            = 8,
+    JitFlagVCallRecord             = 16,
+    JitFlagVCallBranch             = 32,
+    JitFlagVCallBranchJumpTable    = 64,
+    JitFlagVCallBranchBinarySearch = 128,
+    JitFlagVCallDeduplicate        = 256,
+    JitFlagVCallOptimize           = 512,
+    JitFlagVCallInline             = 1024,
+    JitFlagForceOptiX              = 2048,
+    JitFlagRecording               = 4096,
+    JitFlagPrintIR                 = 8192,
+    JitFlagKernelHistory           = 16384,
+    JitFlagLaunchBlocking          = 32768,
+    JitFlagADOptimize              = 65536,
 };
 #endif
 

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1343,30 +1343,33 @@ enum class JitFlag : uint32_t {
     /// Exploit literal constants during AD (used in the Dr.Jit parent project)
     ADOptimize = 16384,
 
+    VCallBranchJumpTable = 32768,
+
     /// Default flags
     Default = (uint32_t) ConstProp | (uint32_t) ValueNumbering |
               (uint32_t) LoopRecord | (uint32_t) LoopOptimize |
-              //(uint32_t) VCallBranch |
               (uint32_t) VCallRecord | (uint32_t) VCallDeduplicate |
+              (uint32_t) VCallBranch | (uint32_t) VCallBranchJumpTable |
               (uint32_t) VCallOptimize | (uint32_t) ADOptimize
 };
 #else
 enum JitFlag {
-    JitFlagConstProp           = 1,
-    JitFlagValueNumbering      = 2,
-    JitFlagLoopRecord          = 4,
-    JitFlagLoopOptimize        = 8,
-    JitFlagVCallRecord         = 16,
-    JitFlagVCallBranch         = 32,
-    JitFlagVCallDeduplicate    = 64,
-    JitFlagVCallOptimize       = 128,
-    JitFlagVCallInline         = 256,
-    JitFlagForceOptiX          = 512,
-    JitFlagRecording           = 1024,
-    JitFlagPrintIR             = 2048,
-    JitFlagKernelHistory       = 4096,
-    JitFlagLaunchBlocking      = 8192,
-    JitFlagADOptimize          = 16384,
+    JitFlagConstProp            = 1,
+    JitFlagValueNumbering       = 2,
+    JitFlagLoopRecord           = 4,
+    JitFlagLoopOptimize         = 8,
+    JitFlagVCallRecord          = 16,
+    JitFlagVCallBranch          = 32,
+    JitFlagVCallDeduplicate     = 64,
+    JitFlagVCallOptimize        = 128,
+    JitFlagVCallInline          = 256,
+    JitFlagForceOptiX           = 512,
+    JitFlagRecording            = 1024,
+    JitFlagPrintIR              = 2048,
+    JitFlagKernelHistory        = 4096,
+    JitFlagLaunchBlocking       = 8192,
+    JitFlagADOptimize           = 16384,
+    JitFlagVCallBranchJumpTable = 32768,
 };
 #endif
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -71,6 +71,18 @@ struct XXH128Cmp {
     }
 };
 
+struct XXH128Eq {
+    bool operator()(const XXH128_hash_t &lhs, const XXH128_hash_t &rhs) const {
+        return lhs.high64 == rhs.high64 && lhs.low64 == rhs.low64;
+    }
+};
+
+struct XXH128Hash {
+    size_t operator()(const XXH128_hash_t &hash) const {
+        return hash.low64 ^ hash.high64;
+    }
+};
+
 inline void hash_combine(size_t& seed, size_t value) {
     /// From CityHash (https://github.com/google/cityhash)
     const size_t mult = 0x9ddfea08eb382d69ull;

--- a/src/optix_api.cpp
+++ b/src/optix_api.cpp
@@ -662,19 +662,21 @@ bool jitc_optix_compile(ThreadState *ts, const char *buf, size_t buf_size,
     pgd[0].raygen.module = kernel.optix.mod;
     pgd[0].raygen.entryFunctionName = strdup(kern_name);
 
-    for (auto const &it : globals_map) {
-        if (!it.first.callable)
-            continue;
+    if (!jit_flag(JitFlag::VCallBranch)) {
+        for (auto const &it : globals_map) {
+            if (!it.first.callable)
+                continue;
 
-        char *name = (char *) malloc_check(52);
-        snprintf(name, 52, "__direct_callable__%016llx%016llx",
-                 (unsigned long long) it.first.hash.high64,
-                 (unsigned long long) it.first.hash.low64);
+            char *name = (char *) malloc_check(52);
+            snprintf(name, 52, "__direct_callable__%016llx%016llx",
+                     (unsigned long long) it.first.hash.high64,
+                     (unsigned long long) it.first.hash.low64);
 
-        uint32_t index = 1 + it.second.callable_index;
-        pgd[index].kind = OPTIX_PROGRAM_GROUP_KIND_CALLABLES;
-        pgd[index].callables.moduleDC = kernel.optix.mod;
-        pgd[index].callables.entryFunctionNameDC = name;
+            uint32_t index = 1 + it.second.callable_index;
+            pgd[index].kind = OPTIX_PROGRAM_GROUP_KIND_CALLABLES;
+            pgd[index].callables.moduleDC = kernel.optix.mod;
+            pgd[index].callables.entryFunctionNameDC = name;
+        }
     }
 
     kernel.optix.pg = new OptixProgramGroup[n_programs];

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -229,9 +229,6 @@ TEST_BOTH(01_recorded_vcall) {
     A1 a1;
     A2 a2;
 
-    jit_set_flag(JitFlag::PrintIR, true);
-    jit_set_log_level_stderr(LogLevel::Trace);
-
     // jit_llvm_set_target("skylake-avx512", "+avx512f,+avx512dq,+avx512vl,+avx512cd", 16);
     uint32_t i1 = jit_registry_put(Backend, "Base", &a1);
     uint32_t i2 = jit_registry_put(Backend, "Base", &a2);

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -239,10 +239,15 @@ TEST_BOTH(01_recorded_vcall) {
     BasePtr self = arange<UInt32>(10) % 3;
 
     for (uint32_t i = 0; i < 2; ++i) {
-        jit_set_flag(JitFlag::VCallOptimize, i);
-        Float y = vcall(
-            "Base", [](Base *self2, Float x2) { return self2->f(x2); }, self, x);
-        jit_assert(strcmp(y.str(), "[0, 22, 204, 0, 28, 210, 0, 34, 216, 0]") == 0);
+        for (uint32_t j = 0; j < 4; ++j) {
+            jit_set_flag(JitFlag::VCallBranch, j > 0);
+            jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+            jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
+            jit_set_flag(JitFlag::VCallOptimize, i);
+            Float y = vcall(
+                "Base", [](Base *self2, Float x2) { return self2->f(x2); }, self, x);
+            jit_assert(strcmp(y.str(), "[0, 22, 204, 0, 28, 210, 0, 34, 216, 0]") == 0);
+        }
     }
 
     jit_registry_remove(Backend, &a1);
@@ -290,35 +295,40 @@ TEST_BOTH(02_calling_conventions) {
     (void) i1; (void) i2; (void) i3;
 
     for (uint32_t i = 0; i < 2; ++i) {
-        jit_set_flag(JitFlag::VCallOptimize, i);
+        for (uint32_t j = 0; j < 4; ++j) {
+            jit_set_flag(JitFlag::VCallBranch, j > 0);
+            jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+            jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
+            jit_set_flag(JitFlag::VCallOptimize, i);
 
-        using BasePtr = Array<Base *>;
-        BasePtr self = arange<UInt32>(12) % 4;
+            using BasePtr = Array<Base *>;
+            BasePtr self = arange<UInt32>(12) % 4;
 
-        Mask p0(false);
-        Float p1(12);
-        Double p2(34);
-        Float p3(56);
-        Mask p4(true);
+            Mask p0(false);
+            Float p1(12);
+            Double p2(34);
+            Float p3(56);
+            Mask p4(true);
 
-        auto result = vcall(
-            "Base",
-            [](Base *self2, Mask p0, Float p1, Double p2, Float p3, Mask p4) {
-                return self2->f(p0, p1, p2, p3, p4);
-            },
-            self, p0, p1, p2, p3, p4);
+            auto result = vcall(
+                "Base",
+                [](Base *self2, Mask p0, Float p1, Double p2, Float p3, Mask p4) {
+                    return self2->f(p0, p1, p2, p3, p4);
+                },
+                self, p0, p1, p2, p3, p4);
 
-        jit_var_schedule(result.template get<0>().index());
-        jit_var_schedule(result.template get<1>().index());
-        jit_var_schedule(result.template get<2>().index());
-        jit_var_schedule(result.template get<3>().index());
-        jit_var_schedule(result.template get<4>().index());
+            jit_var_schedule(result.template get<0>().index());
+            jit_var_schedule(result.template get<1>().index());
+            jit_var_schedule(result.template get<2>().index());
+            jit_var_schedule(result.template get<3>().index());
+            jit_var_schedule(result.template get<4>().index());
 
-        jit_assert(strcmp(result.template get<0>().str(), "[0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0]") == 0);
-        jit_assert(strcmp(result.template get<1>().str(), "[0, 12, 13, 0, 0, 12, 13, 0, 0, 12, 13, 0]") == 0);
-        jit_assert(strcmp(result.template get<2>().str(), "[0, 34, 36, 0, 0, 34, 36, 0, 0, 34, 36, 0]") == 0);
-        jit_assert(strcmp(result.template get<3>().str(), "[0, 56, 59, 0, 0, 56, 59, 0, 0, 56, 59, 0]") == 0);
-        jit_assert(strcmp(result.template get<4>().str(), "[0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0]") == 0);
+            jit_assert(strcmp(result.template get<0>().str(), "[0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0]") == 0);
+            jit_assert(strcmp(result.template get<1>().str(), "[0, 12, 13, 0, 0, 12, 13, 0, 0, 12, 13, 0]") == 0);
+            jit_assert(strcmp(result.template get<2>().str(), "[0, 34, 36, 0, 0, 34, 36, 0, 0, 34, 36, 0]") == 0);
+            jit_assert(strcmp(result.template get<3>().str(), "[0, 56, 59, 0, 0, 56, 59, 0, 0, 56, 59, 0]") == 0);
+            jit_assert(strcmp(result.template get<4>().str(), "[0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0]") == 0);
+        }
     }
 
     jit_registry_remove(Backend, &b1);
@@ -362,32 +372,36 @@ TEST_BOTH(03_optimize_away_outputs) {
     BasePtr self = arange<UInt32>(10) % 4;
 
     for (uint32_t i = 0; i < 2; ++i) {
-        i = 1;
-        jit_set_flag(JitFlag::VCallOptimize, i);
+        for (uint32_t j = 0; j < 4; ++j) {
+            jit_set_flag(JitFlag::VCallBranch, j > 0);
+            jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+            jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
+            jit_set_flag(JitFlag::VCallOptimize, i);
 
-        jit_assert(jit_var_ref(p3.index()) == 1);
+            jit_assert(jit_var_ref(p3.index()) == 1);
 
-        auto result = vcall(
-            "Base",
-            [](Base *self2, Float p1, Float p2, Float p3) {
-                return self2->f(p1, p2, p3);
-            },
-            self, p1, p2, p3);
+            auto result = vcall(
+                "Base",
+                [](Base *self2, Float p1, Float p2, Float p3) {
+                    return self2->f(p1, p2, p3);
+                },
+                self, p1, p2, p3);
 
-        jit_assert(jit_var_ref(p1.index()) == 3);
-        jit_assert(jit_var_ref(p2.index()) == 3);
+            jit_assert(jit_var_ref(p1.index()) == 3);
+            jit_assert(jit_var_ref(p2.index()) == 3);
 
-        // Irrelevant input optimized away
-        jit_assert(jit_var_ref(p3.index()) == 2 - i);
+            // Irrelevant input optimized away
+            jit_assert(jit_var_ref(p3.index()) == 2 - i);
 
-        result.template get<0>() = Float(0);
+            result.template get<0>() = Float(0);
 
-        jit_assert(jit_var_ref(p1.index()) == 3);
-        jit_assert(jit_var_ref(p2.index()) == 3 - 2*i);
-        jit_assert(jit_var_ref(p3.index()) == 2 - i);
+            jit_assert(jit_var_ref(p1.index()) == 3);
+            jit_assert(jit_var_ref(p2.index()) == 3 - 2*i);
+            jit_assert(jit_var_ref(p3.index()) == 2 - i);
 
-        jit_assert(strcmp(jit_var_str(result.template get<1>().index()),
-                            "[0, 13, 13, 14, 0, 13, 13, 14, 0, 13]") == 0);
+            jit_assert(strcmp(jit_var_str(result.template get<1>().index()),
+                                "[0, 13, 13, 14, 0, 13, 13, 14, 0, 13]") == 0);
+        }
     }
 
     jit_registry_remove(Backend, &c1);
@@ -424,47 +438,52 @@ TEST_BOTH(04_devirtualize) {
 
     for (uint32_t k = 0; k < 2; ++k) {
         for (uint32_t i = 0; i < 2; ++i) {
-            Float p1, p2;
-            if (k == 0) {
-                p1 = 12;
-                p2 = 34;
-            } else {
-                p1 = dr::opaque<Float>(12);
-                p2 = dr::opaque<Float>(34);
+            for (uint32_t j = 0; j < 4; ++j) {
+                jit_set_flag(JitFlag::VCallBranch, j > 0);
+                jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+                jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
+                Float p1, p2;
+                if (k == 0) {
+                    p1 = 12;
+                    p2 = 34;
+                } else {
+                    p1 = dr::opaque<Float>(12);
+                    p2 = dr::opaque<Float>(34);
+                }
+
+                jit_set_flag(JitFlag::VCallOptimize, i);
+                uint32_t scope = jit_scope(Backend);
+
+                auto result = vcall(
+                    "Base",
+                    [](Base *self2, Float p1, Float p2) {
+                        return self2->f(p1, p2);
+                    },
+                    self, p1, p2);
+
+                jit_set_scope(Backend, scope + 1);
+
+                Float p2_wrap = Float::steal(jit_var_wrap_vcall(p2.index()));
+
+                Mask mask = neq(self, nullptr),
+                     mask_combined = Mask::steal(jit_var_mask_apply(mask.index(), 10));
+
+                Float alt = (p2_wrap + 2) & mask_combined;
+
+                jit_set_scope(Backend, scope + 2);
+
+                jit_assert((result.template get<0>().index() == alt.index()) == (i == 1));
+                jit_assert(jit_var_is_literal(result.template get<2>().index()) == (i == 1));
+
+                jit_var_schedule(result.template get<0>().index());
+                jit_var_schedule(result.template get<1>().index());
+
+                jit_assert(
+                    strcmp(jit_var_str(result.template get<0>().index()),
+                                "[0, 36, 36, 0, 36, 36, 0, 36, 36, 0]") == 0);
+                jit_assert(strcmp(jit_var_str(result.template get<1>().index()),
+                                "[0, 13, 14, 0, 13, 14, 0, 13, 14, 0]") == 0);
             }
-
-            jit_set_flag(JitFlag::VCallOptimize, i);
-            uint32_t scope = jit_scope(Backend);
-
-            auto result = vcall(
-                "Base",
-                [](Base *self2, Float p1, Float p2) {
-                    return self2->f(p1, p2);
-                },
-                self, p1, p2);
-
-            jit_set_scope(Backend, scope + 1);
-
-            Float p2_wrap = Float::steal(jit_var_wrap_vcall(p2.index()));
-
-            Mask mask = neq(self, nullptr),
-                 mask_combined = Mask::steal(jit_var_mask_apply(mask.index(), 10));
-
-            Float alt = (p2_wrap + 2) & mask_combined;
-
-            jit_set_scope(Backend, scope + 2);
-
-            jit_assert((result.template get<0>().index() == alt.index()) == (i == 1));
-            jit_assert(jit_var_is_literal(result.template get<2>().index()) == (i == 1));
-
-            jit_var_schedule(result.template get<0>().index());
-            jit_var_schedule(result.template get<1>().index());
-
-            jit_assert(
-                strcmp(jit_var_str(result.template get<0>().index()),
-                            "[0, 36, 36, 0, 36, 36, 0, 36, 36, 0]") == 0);
-            jit_assert(strcmp(jit_var_str(result.template get<1>().index()),
-                            "[0, 13, 14, 0, 13, 14, 0, 13, 14, 0]") == 0);
         }
     }
     jit_registry_remove(Backend, &d1);
@@ -509,11 +528,16 @@ TEST_BOTH(05_extra_data) {
         }
 
         for (uint32_t i = 0; i < 2; ++i) {
-            jit_set_flag(JitFlag::VCallOptimize, i);
-            Float result = vcall(
-                "Base", [](Base *self2, Float x) { return self2->f(x); }, self,
-                x);
-            jit_assert(strcmp(result.str(), "[0, 9, 13, 0, 21, 28, 0, 33, 43, 0]") == 0);
+            for (uint32_t j = 0; j < 4; ++j) {
+                jit_set_flag(JitFlag::VCallBranch, j > 0);
+                jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+                jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
+                jit_set_flag(JitFlag::VCallOptimize, i);
+                Float result = vcall(
+                    "Base", [](Base *self2, Float x) { return self2->f(x); }, self,
+                    x);
+                jit_assert(strcmp(result.str(), "[0, 9, 13, 0, 21, 28, 0, 33, 43, 0]") == 0);
+            }
         }
     }
     jit_registry_remove(Backend, &e1);
@@ -550,20 +574,25 @@ TEST_BOTH(06_side_effects) {
     BasePtr self = arange<UInt32>(11) % 3;
 
     for (uint32_t i = 0; i < 2; ++i) {
-        jit_set_flag(JitFlag::VCallOptimize, i);
+        for (uint32_t j = 0; j < 4; ++j) {
+            jit_set_flag(JitFlag::VCallBranch, j > 0);
+            jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+            jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
+            jit_set_flag(JitFlag::VCallOptimize, i);
 
-        F1 f1; F2 f2;
-        uint32_t i1 = jit_registry_put(Backend, "Base", &f1);
-        uint32_t i2 = jit_registry_put(Backend, "Base", &f2);
-        jit_assert(i1 == 1 && i2 == 2);
+            F1 f1; F2 f2;
+            uint32_t i1 = jit_registry_put(Backend, "Base", &f1);
+            uint32_t i2 = jit_registry_put(Backend, "Base", &f2);
+            jit_assert(i1 == 1 && i2 == 2);
 
-        vcall("Base", [](Base *self2) { self2->go(); }, self);
-        jit_assert(strcmp(f1.buffer.str(), "[0, 4, 0, 8, 0]") == 0);
-        jit_assert(strcmp(f2.buffer.str(), "[0, 1, 5, 3]") == 0);
+            vcall("Base", [](Base *self2) { self2->go(); }, self);
+            jit_assert(strcmp(f1.buffer.str(), "[0, 4, 0, 8, 0]") == 0);
+            jit_assert(strcmp(f2.buffer.str(), "[0, 1, 5, 3]") == 0);
 
-        jit_registry_remove(Backend, &f1);
-        jit_registry_remove(Backend, &f2);
-        jit_registry_trim();
+            jit_registry_remove(Backend, &f1);
+            jit_registry_remove(Backend, &f2);
+            jit_registry_trim();
+        }
     }
 }
 
@@ -595,26 +624,31 @@ TEST_BOTH(07_side_effects_only_once) {
     BasePtr self = arange<UInt32>(11) % 3;
 
     for (uint32_t i = 0; i < 2; ++i) {
-        jit_set_flag(JitFlag::VCallOptimize, i);
+        for (uint32_t j = 0; j < 4; ++j) {
+            jit_set_flag(JitFlag::VCallBranch, j > 0);
+            jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+            jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
+            jit_set_flag(JitFlag::VCallOptimize, i);
 
-        G1 g1; G2 g2;
-        uint32_t i1 = jit_registry_put(Backend, "Base", &g1);
-        uint32_t i2 = jit_registry_put(Backend, "Base", &g2);
-        jit_assert(i1 == 1 && i2 == 2);
+            G1 g1; G2 g2;
+            uint32_t i1 = jit_registry_put(Backend, "Base", &g1);
+            uint32_t i2 = jit_registry_put(Backend, "Base", &g2);
+            jit_assert(i1 == 1 && i2 == 2);
 
-        auto result = vcall("Base", [](Base *self2) { return self2->f(); }, self);
-        Float f1 = result.template get<0>();
-        Float f2 = result.template get<1>();
-        jit_assert(strcmp(f1.str(), "[0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1]") == 0);
-        jit_assert(strcmp(g1.buffer.str(), "[0, 4, 0, 0, 0]") == 0);
-        jit_assert(strcmp(g2.buffer.str(), "[0, 0, 3, 0, 0]") == 0);
-        jit_assert(strcmp(f2.str(), "[0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2]") == 0);
-        jit_assert(strcmp(g1.buffer.str(), "[0, 4, 0, 0, 0]") == 0);
-        jit_assert(strcmp(g2.buffer.str(), "[0, 0, 3, 0, 0]") == 0);
+            auto result = vcall("Base", [](Base *self2) { return self2->f(); }, self);
+            Float f1 = result.template get<0>();
+            Float f2 = result.template get<1>();
+            jit_assert(strcmp(f1.str(), "[0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1]") == 0);
+            jit_assert(strcmp(g1.buffer.str(), "[0, 4, 0, 0, 0]") == 0);
+            jit_assert(strcmp(g2.buffer.str(), "[0, 0, 3, 0, 0]") == 0);
+            jit_assert(strcmp(f2.str(), "[0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2]") == 0);
+            jit_assert(strcmp(g1.buffer.str(), "[0, 4, 0, 0, 0]") == 0);
+            jit_assert(strcmp(g2.buffer.str(), "[0, 0, 3, 0, 0]") == 0);
 
-        jit_registry_remove(Backend, &g1);
-        jit_registry_remove(Backend, &g2);
-        jit_registry_trim();
+            jit_registry_remove(Backend, &g1);
+            jit_registry_remove(Backend, &g2);
+            jit_registry_trim();
+        }
     }
 }
 
@@ -652,12 +686,17 @@ TEST_BOTH(08_multiple_calls) {
 
 
     for (uint32_t i = 0; i < 2; ++i) {
-        jit_set_flag(JitFlag::VCallOptimize, i);
+        for (uint32_t j = 0; j < 4; ++j) {
+            jit_set_flag(JitFlag::VCallBranch, j > 0);
+            jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+            jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
+            jit_set_flag(JitFlag::VCallOptimize, i);
 
-        Float y = vcall("Base", [](Base *self2, Float x2) { return self2->f(x2); }, self, x);
-        Float z = vcall("Base", [](Base *self2, Float x2) { return self2->f(x2); }, self, y);
+            Float y = vcall("Base", [](Base *self2, Float x2) { return self2->f(x2); }, self, x);
+            Float z = vcall("Base", [](Base *self2, Float x2) { return self2->f(x2); }, self, y);
 
-        jit_assert(strcmp(z.str(), "[0, 12, 14, 0, 12, 14, 0, 12, 14, 0]") == 0);
+            jit_assert(strcmp(z.str(), "[0, 12, 14, 0, 12, 14, 0, 12, 14, 0]") == 0);
+        }
     }
 
     jit_registry_remove(Backend, &h1);
@@ -710,26 +749,31 @@ TEST_BOTH(09_big) {
     self2 = select(self2 <= n2, self2, 0);
 
     for (uint32_t i = 0; i < 2; ++i) {
-        jit_set_flag(JitFlag::VCallOptimize, i);
+        for (uint32_t j = 0; j < 4; ++j) {
+            jit_set_flag(JitFlag::VCallBranch, j > 0);
+            jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+            jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
+            jit_set_flag(JitFlag::VCallOptimize, i);
 
-        Float x = vcall("Base1", [](Base1 *self_) { return self_->f(); }, Base1Ptr(self1));
-        Float y = vcall("Base2", [](Base2 *self_) { return self_->f(); }, Base2Ptr(self2));
+            Float x = vcall("Base1", [](Base1 *self_) { return self_->f(); }, Base1Ptr(self1));
+            Float y = vcall("Base2", [](Base2 *self_) { return self_->f(); }, Base2Ptr(self2));
 
-        jit_var_schedule(x.index());
-        jit_var_schedule(y.index());
+            jit_var_schedule(x.index());
+            jit_var_schedule(y.index());
 
-        jit_assert(x.read(0) == 0);
-        jit_assert(y.read(0) == 0);
+            jit_assert(x.read(0) == 0);
+            jit_assert(y.read(0) == 0);
 
-        for (uint32_t j = 1; j <= n1; ++j)
-            jit_assert(x.read(j) == j - 1);
-        for (uint32_t j = 1; j <= n2; ++j)
-            jit_assert(y.read(j) == 100 + j - 1);
+            for (uint32_t j = 1; j <= n1; ++j)
+                jit_assert(x.read(j) == j - 1);
+            for (uint32_t j = 1; j <= n2; ++j)
+                jit_assert(y.read(j) == 100 + j - 1);
 
-        for (uint32_t j = n1 + 1; j < n; ++j)
-            jit_assert(x.read(j + 1) == 0);
-        for (uint32_t j = n2 + 1; j < n; ++j)
-            jit_assert(y.read(j + 1) == 0);
+            for (uint32_t j = n1 + 1; j < n; ++j)
+                jit_assert(x.read(j + 1) == 0);
+            for (uint32_t j = n2 + 1; j < n; ++j)
+                jit_assert(y.read(j + 1) == 0);
+        }
     }
 
     for (int i = 0; i < n1; ++i)
@@ -754,12 +798,18 @@ TEST_BOTH(09_self) {
     uint32_t i2_id = jit_registry_put(Backend, "Base", &i2);
 
     UInt32 self(i1_id, i2_id);
-    UInt32 y = vcall(
-        "Base",
-        [](Base *self_) { return self_->f(); },
-        BasePtr(self));
+    for (uint32_t j = 0; j < 4; ++j) {
+        jit_set_flag(JitFlag::VCallBranch, j > 0);
+        jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+        jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
 
-    jit_assert(strcmp(y.str(), "[1, 2]") == 0);
+        UInt32 y = vcall(
+            "Base",
+            [](Base *self_) { return self_->f(); },
+            BasePtr(self));
+
+        jit_assert(strcmp(y.str(), "[1, 2]") == 0);
+    }
 
     jit_registry_remove(Backend, &i1);
     jit_registry_remove(Backend, &i2);
@@ -796,14 +846,20 @@ TEST_BOTH(10_recursion) {
     UInt32 self2(i21_id, i22_id);
     Float x(3.f, 5.f);
 
-    Float y = vcall(
-        "Base2",
-        [](Base2 *self_, const Base1Ptr &ptr_, const Float &x_) {
-            return self_->g(ptr_, x_);
-        },
-        Base2Ptr(self2), Base1Ptr(self1), x);
+    for (uint32_t j = 0; j < 4; ++j) {
+        jit_set_flag(JitFlag::VCallBranch, j > 0);
+        jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+        jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
 
-    jit_assert(strcmp(y.str(), "[7, 16]") == 0);
+        Float y = vcall(
+            "Base2",
+            [](Base2 *self_, const Base1Ptr &ptr_, const Float &x_) {
+                return self_->g(ptr_, x_);
+            },
+            Base2Ptr(self2), Base1Ptr(self1), x);
+
+        jit_assert(strcmp(y.str(), "[7, 16]") == 0);
+    }
 
     jit_registry_remove(Backend, &i11);
     jit_registry_remove(Backend, &i12);
@@ -842,14 +898,20 @@ TEST_BOTH(11_recursion_with_local) {
     UInt32 self2(i21_id, i22_id);
     Float x(3.f, 5.f);
 
-    Float y = vcall(
-        "Base2",
-        [](Base2 *self_, const Base1Ptr &ptr_, const Float &x_) {
-            return self_->g(ptr_, x_);
-        },
-        Base2Ptr(self2), Base1Ptr(self1), x);
+    for (uint32_t j = 0; j < 4; ++j) {
+        jit_set_flag(JitFlag::VCallBranch, j > 0);
+        jit_set_flag(JitFlag::VCallBranchBinarySearch, j == 2);
+        jit_set_flag(JitFlag::VCallBranchJumpTable, j == 3);
 
-    jit_assert(strcmp(y.str(), "[7, 16]") == 0);
+        Float y = vcall(
+            "Base2",
+            [](Base2 *self_, const Base1Ptr &ptr_, const Float &x_) {
+                return self_->g(ptr_, x_);
+            },
+            Base2Ptr(self2), Base1Ptr(self1), x);
+
+        jit_assert(strcmp(y.str(), "[7, 16]") == 0);
+    }
 
     jit_registry_remove(Backend, &i11);
     jit_registry_remove(Backend, &i12);

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -229,6 +229,9 @@ TEST_BOTH(01_recorded_vcall) {
     A1 a1;
     A2 a2;
 
+    jit_set_flag(JitFlag::PrintIR, true);
+    jit_set_log_level_stderr(LogLevel::Trace);
+
     // jit_llvm_set_target("skylake-avx512", "+avx512f,+avx512dq,+avx512vl,+avx512cd", 16);
     uint32_t i1 = jit_registry_put(Backend, "Base", &a1);
     uint32_t i2 = jit_registry_put(Backend, "Base", &a2);
@@ -293,7 +296,7 @@ TEST_BOTH(02_calling_conventions) {
         jit_set_flag(JitFlag::VCallOptimize, i);
 
         using BasePtr = Array<Base *>;
-        BasePtr self = arange<UInt32>(10) % 3;
+        BasePtr self = arange<UInt32>(12) % 4;
 
         Mask p0(false);
         Float p1(12);
@@ -314,11 +317,11 @@ TEST_BOTH(02_calling_conventions) {
         jit_var_schedule(result.template get<3>().index());
         jit_var_schedule(result.template get<4>().index());
 
-        jit_assert(strcmp(result.template get<0>().str(), "[0, 0, 1, 0, 0, 1, 0, 0, 1, 0]") == 0);
-        jit_assert(strcmp(result.template get<1>().str(), "[0, 12, 13, 0, 12, 13, 0, 12, 13, 0]") == 0);
-        jit_assert(strcmp(result.template get<2>().str(), "[0, 34, 36, 0, 34, 36, 0, 34, 36, 0]") == 0);
-        jit_assert(strcmp(result.template get<3>().str(), "[0, 56, 59, 0, 56, 59, 0, 56, 59, 0]") == 0);
-        jit_assert(strcmp(result.template get<4>().str(), "[0, 1, 0, 0, 1, 0, 0, 1, 0, 0]") == 0);
+        jit_assert(strcmp(result.template get<0>().str(), "[0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0]") == 0);
+        jit_assert(strcmp(result.template get<1>().str(), "[0, 12, 13, 0, 0, 12, 13, 0, 0, 12, 13, 0]") == 0);
+        jit_assert(strcmp(result.template get<2>().str(), "[0, 34, 36, 0, 0, 34, 36, 0, 0, 34, 36, 0]") == 0);
+        jit_assert(strcmp(result.template get<3>().str(), "[0, 56, 59, 0, 0, 56, 59, 0, 0, 56, 59, 0]") == 0);
+        jit_assert(strcmp(result.template get<4>().str(), "[0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0]") == 0);
     }
 
     jit_registry_remove(Backend, &b1);


### PR DESCRIPTION
This PR adds different strategies to handle virtual function calls.

Currently, in order to do a virtual function call in CUDA, we use indirect function calls to call either an OptiX direct callable or a CUDA function. Given that we know exactly the set of possible targets for any virtual function call, it is not necessary to have the indirection and we can explicitly call the appropriate target function.

This PR adds a new `JitFlag`, called `VCallBranch` which will replace the indirect function call by a series of branches to call the appropriate target function. There are three different branching strategies implemented:

- Linear search: We lineraly compare against all possible target functions to determine the final/appropriate target. This is the default behaviour when enabling `VCallBranch`.
- Binary search: The set of possible target functions is represented as a binary search tree, and the final target is computed by searching through. This strategy can be enabled by using the `VCallBranchBinarySearch` JIT flag.
- Jump table: A jump table from the instance's callable index to all possible targets is used. This strategy can be enabled by using the `VCallBranchJumpTable` JIT flag