### PR TITLE
Bug: Evaluating variable in two kernels of different sizes

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -726,7 +726,7 @@ void jitc_eval(ThreadState *ts) {
             v->free_stmt = false;
         }
 
-        if (v->output_flag) {
+        if (v->output_flag && v->size == sv.size) {
             v->kind = (uint32_t) VarKind::Data;
             v->data = sv.data;
             v->output_flag = false;


### PR DESCRIPTION
This PR fixes a bug where `jitc_eval`  would crash when a variable is evaluated and used in two kernels of different sizes.

Here's a snippet that illustrates when this could occur:
```python
import drjit as dr
from drjit.cuda import Float

a = dr.opaque(Float, 1)
b = Float([1, 2, 3])

c = a + 1 # c has size 1
d = b + c # d has size 3

dr.eval(d, c) # Two kernel launches (size 3 and 1)
print(c) # Crash here
```

During `dr.eval(d, c)`  both kernels execute as expected, and the scheduled variables for `c` and `d`  have the correct pointers to device memory. However, there is also an internal duplicate `c` of size 3 which is need to evaluate `d`.

When writing the device pointers back to the actual JIT variables the current code would sometimes (depending or kernel launch order) use the "duplicate" `c` rather than true `c` which has the correct size. This would effectively set the device pointer to `nullptr` for `c` and causes crashes whenever it's used later on.