### PR TITLE
Fix asynchronous jit_free calls (and more)

### DIFF
--- a/src/cuda_api.cpp
+++ b/src/cuda_api.cpp
@@ -199,15 +199,15 @@ bool jitc_cuda_init() {
         LOAD(cuDriverGetVersion);
         LOAD(cuEventCreate);
         LOAD(cuEventDestroy, "v2");
-        LOAD(cuEventRecord, "ptsz");
+        LOAD(cuEventRecord);
         LOAD(cuEventSynchronize);
         LOAD(cuEventElapsedTime);
         LOAD(cuFuncSetAttribute);
         LOAD(cuGetErrorName);
         LOAD(cuGetErrorString);
         LOAD(cuInit);
-        LOAD(cuLaunchHostFunc, "ptsz");
-        LOAD(cuLaunchKernel, "ptsz");
+        LOAD(cuLaunchHostFunc);
+        LOAD(cuLaunchKernel);
         LOAD(cuLinkAddData, "v2");
         LOAD(cuLinkComplete);
         LOAD(cuLinkCreate, "v2");
@@ -218,13 +218,13 @@ bool jitc_cuda_init() {
         LOAD(cuMemAllocManaged);
         LOAD(cuMemFree, "v2");
         LOAD(cuMemFreeHost);
-        LOAD(cuMemPrefetchAsync, "ptsz");
+        LOAD(cuMemPrefetchAsync);
 
-        LOAD(cuMemcpy, "ptds");
-        LOAD(cuMemcpyAsync, "ptsz");
-        LOAD(cuMemsetD16Async, "ptsz");
-        LOAD(cuMemsetD32Async, "ptsz");
-        LOAD(cuMemsetD8Async, "ptsz");
+        LOAD(cuMemcpy);
+        LOAD(cuMemcpyAsync);
+        LOAD(cuMemsetD16Async);
+        LOAD(cuMemsetD32Async);
+        LOAD(cuMemsetD8Async);
         LOAD(cuModuleGetFunction);
         LOAD(cuModuleLoadData);
         LOAD(cuModuleUnload);
@@ -233,8 +233,8 @@ bool jitc_cuda_init() {
         LOAD(cuCtxPopCurrent, "v2");
         LOAD(cuStreamCreate);
         LOAD(cuStreamDestroy, "v2");
-        LOAD(cuStreamSynchronize, "ptsz");
-        LOAD(cuStreamWaitEvent, "ptsz");
+        LOAD(cuStreamSynchronize);
+        LOAD(cuStreamWaitEvent);
         LOAD(cuPointerGetAttribute);
         LOAD(cuArrayCreate, "v2");
         LOAD(cuArray3DCreate, "v2");
@@ -243,8 +243,8 @@ bool jitc_cuda_init() {
         LOAD(cuTexObjectCreate);
         LOAD(cuTexObjectGetResourceDesc);
         LOAD(cuTexObjectDestroy);
-        LOAD(cuMemcpy2DAsync, "v2_ptsz");
-        LOAD(cuMemcpy3DAsync, "v2_ptsz");
+        LOAD(cuMemcpy2DAsync, "v2");
+        LOAD(cuMemcpy3DAsync, "v2");
         #undef LOAD
     } while (false);
 
@@ -256,8 +256,8 @@ bool jitc_cuda_init() {
     }
 
     // These two functions are optional
-    cuMemAllocAsync = decltype(cuMemAllocAsync)(dlsym(jitc_cuda_handle, "cuMemAllocAsync_ptsz"));
-    cuMemFreeAsync = decltype(cuMemFreeAsync)(dlsym(jitc_cuda_handle, "cuMemFreeAsync_ptsz"));
+    cuMemAllocAsync = decltype(cuMemAllocAsync)(dlsym(jitc_cuda_handle, "cuMemAllocAsync"));
+    cuMemFreeAsync = decltype(cuMemFreeAsync)(dlsym(jitc_cuda_handle, "cuMemFreeAsync"));
 #endif
 
     jitc_cuda_cuinit_result = cuInit(0);

--- a/src/internal.h
+++ b/src/internal.h
@@ -248,6 +248,12 @@ struct Device {
     // CUDA device context
     CUcontext context;
 
+    /// Associated CUDA stream handle
+    CUstream stream = nullptr;
+
+    /// A CUDA event for synchronization purposes
+    CUevent event = nullptr;
+
     /// CUDA device ID
     int id;
 

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -110,9 +110,10 @@ static void jitc_var_printf_assemble_cuda(const Variable *v,
     if (offset == 0)
         offset = 1;
 
+    buffer.put("    {\n");
     buffer.fmt("        .local .align %u .b8 buf[%u];\n", align, offset);
     buffer.put("        .extern .func (.param .b32 rv) vprintf (.param .b64 fmt, .param .b64 buf);\n");
-    buffer.put("        .global .align 1 .b8 data[] = { ");
+    buffer.put("        .global .align 1 .b8 print_data[] = { ");
 
     for (uint32_t i = 0; ; ++i) {
         buffer.put_uint32((uint32_t) fmt[i]);
@@ -120,7 +121,7 @@ static void jitc_var_printf_assemble_cuda(const Variable *v,
             break;
         buffer.put(", ");
     }
-    buffer.put(" };");
+    buffer.put(" };\n");
 
     offset = 0;
     for (uint32_t i = 0; i < extra.n_dep; ++i) {

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -337,6 +337,7 @@ void jitc_registry_set_attr(JitBackend backend, void *ptr, const char *name,
     }
 
     if (backend == JitBackend::CUDA) {
+        scoped_set_context guard(state.devices[0].context);
         cuda_check(
             cuMemcpyAsync((CUdeviceptr)((uint8_t *) attr.ptr + id * isize),
                           (CUdeviceptr) value, isize, ts->stream));

--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -1389,8 +1389,8 @@ void jitc_vcall_upload(ThreadState *ts) {
         } else {
             Task *new_task = task_submit_dep(
                 nullptr, &ts->task, 1, 1,
-                [](uint32_t, void *payload) { jitc_free(*((void **) payload)); },
-                &data, sizeof(void *));
+                [](uint32_t, void *payload) { jit_free(*((void **) payload)); },
+                &data, sizeof(void *), nullptr, 1);
             task_release(ts->task);
             ts->task = new_task;
         }


### PR DESCRIPTION
This patch fixes a concurrency issue with asynchronous calls to `jitc_free` in `vcall.cpp` and `util.cpp`. 

Here is an example of the potential sequence of events that might lead to a crash:
```
Thread #1: jitc_free(123)
                 -> state.alloc_free.push_back(123);  
Thread #2: jitc_malloc()
                 -> state.alloc_free.find(...); -> 123
                 -> state.alloc_used.push_back(123); -> does nothing since 123 is already in this set
Thread #1: 
                 -> state.alloc_used.erase(123); <- also remove the one that was just added by thread #2
Thread #2: jitc_free(123) -> CRASH since it cannot find 123 in alloc_used as it was erased by thread #1
```

This can be fixed by replacing those two calls to `jitc_free` with `jit_free`.