### PR TITLE
Single iteration loop

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1512,7 +1512,7 @@ extern JIT_EXPORT uint32_t jit_var_loop(const char *name, uint32_t loop_init,
                                         uint32_t loop_cond, size_t n_indices,
                                         uint32_t *indices_in,
                                         uint32_t **indices, uint32_t checkpoint,
-                                        int first_round);
+                                        int first_round, int single_iteration);
 
 /**
  * \brief Pushes a new mask variable onto the mask stack

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -817,10 +817,11 @@ uint32_t jit_var_loop_cond(uint32_t loop_init, uint32_t cond, size_t n_indices,
 
 uint32_t jit_var_loop(const char *name, uint32_t loop_init, uint32_t loop_cond,
                       size_t n_indices, uint32_t *indices_in,
-                      uint32_t **indices, uint32_t checkpoint, int first_round) {
+                      uint32_t **indices, uint32_t checkpoint, int first_round,
+                      int single_iteration) {
     lock_guard guard(state.lock);
     return jitc_var_loop(name, loop_init, loop_cond, n_indices, indices_in,
-                         indices, checkpoint, first_round);
+                         indices, checkpoint, first_round, single_iteration);
 }
 
 struct VCallBucket *

--- a/src/loop.h
+++ b/src/loop.h
@@ -8,6 +8,7 @@ extern uint32_t jitc_var_loop_cond(uint32_t loop_var_init, uint32_t cond,
 extern uint32_t jitc_var_loop(const char *name, uint32_t loop_init,
                               uint32_t loop_cond, size_t n_indices,
                               uint32_t *indices_in, uint32_t **indices,
-                              uint32_t checkpoint, int first_round);
+                              uint32_t checkpoint, int first_round,
+                              int single_iteration);
 
 extern void jitc_var_loop_simplify();

--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -1389,8 +1389,8 @@ void jitc_vcall_upload(ThreadState *ts) {
         } else {
             Task *new_task = task_submit_dep(
                 nullptr, &ts->task, 1, 1,
-                [](uint32_t, void *payload) { jitc_free(*((void **) payload)); },
-                &data, sizeof(void *));
+                [](uint32_t, void *payload) { jit_free(*((void **) payload)); },
+                &data, sizeof(void *), nullptr, 1);
             task_release(ts->task);
             ts->task = new_task;
         }

--- a/tests/ekloop.h
+++ b/tests/ekloop.h
@@ -218,7 +218,7 @@ protected:
                 rv = jit_var_loop(m_name.get(), m_loop_init, m_loop_cond,
                                   m_indices.size(), m_indices_prev.data(),
                                   m_indices.data(), m_jit_state.checkpoint(),
-                                  m_state == 2);
+                                  m_state == 2, 0);
 
                 m_state++;
 


### PR DESCRIPTION
This patch allows the user to specify that a recorded loop will only perform a single iteration, i which case we avoid executing the condition branch a second time.