### PR TITLE
Various fixes of undefined behavior

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -443,6 +443,8 @@ bool jitc_kernel_write(const char *source, uint32_t source_size,
 
 void jitc_kernel_free(int device_id, const Kernel &kernel) {
     if (device_id == -1) {
+        if (kernel.llvm.n_reloc)
+            free(kernel.llvm.reloc);
 #if !defined(_WIN32)
         if (munmap((void *) kernel.data, kernel.size) == -1)
             jitc_fail("jit_kernel_free(): munmap() failed!");

--- a/src/llvm_core.cpp
+++ b/src/llvm_core.cpp
@@ -327,7 +327,8 @@ void jitc_llvm_compile(Kernel &kernel) {
     if (unlikely(error))
         jitc_fail("jit_llvm_compile(): parsing failed. Please see the LLVM "
                   "IR and error message below:\n\n%s\n\n%s", buffer.get(), error);
-
+    LLVMDisposeMessage(error);
+    
 #if !defined(NDEBUG)
     bool status = LLVMVerifyModule(llvm_module, LLVMReturnStatusAction, &error);
     if (unlikely(status))
@@ -335,6 +336,7 @@ void jitc_llvm_compile(Kernel &kernel) {
                   "see the LLVM IR and error message below:\n\n%s\n\n%s",
                   buffer.get(), error);
 #endif
+    LLVMDisposeMessage(error);
 
     LLVMRunPassManager(jitc_llvm_pass_manager, llvm_module);
 

--- a/src/llvm_core.cpp
+++ b/src/llvm_core.cpp
@@ -328,7 +328,7 @@ void jitc_llvm_compile(Kernel &kernel) {
         jitc_fail("jit_llvm_compile(): parsing failed. Please see the LLVM "
                   "IR and error message below:\n\n%s\n\n%s", buffer.get(), error);
     LLVMDisposeMessage(error);
-    
+
 #if !defined(NDEBUG)
     bool status = LLVMVerifyModule(llvm_module, LLVMReturnStatusAction, &error);
     if (unlikely(status))

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -35,6 +35,10 @@ struct Loop {
     std::vector<uint32_t> out;
     /// Are there unused loop variables that could be stripped away?
     bool simplify = false;
+
+    ~Loop() {
+        free(name);
+    }
 };
 
 static std::vector<Loop *> loops;
@@ -518,7 +522,6 @@ uint32_t jitc_var_loop(const char *name, uint32_t loop_init,
             if (free_var && ptr) {
                 Loop *loop_2 = (Loop *) ptr;
                 jitc_trace("jit_var_loop(\"%s\"): freeing loop.", loop_2->name);
-                free(loop_2->name);
                 loops.erase(std::remove(loops.begin(), loops.end(), loop_2), loops.end());
                 delete loop_2;
             }

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -991,9 +991,12 @@ T eval_ctz(T) { jitc_fail("eval_ctz(): unsupported operands!"); }
 
 template <typename T, enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, bool>> = 0>
 T eval_ctz(T value) {
+    using U = uint_with_size_t<T>;
+    U u_value = memcpy_cast<U>(value);
+
     T result = sizeof(T) * 8;
-    while (value) {
-        value <<= 1;
+    while (u_value) {
+        u_value <<= 1;
         result -= 1;
     }
     return result;

--- a/src/strbuf.cpp
+++ b/src/strbuf.cpp
@@ -99,26 +99,26 @@ static void reverse_str(char *start, char *end) {
 }
 
 void StringBuffer::put_u32(uint32_t value) {
-    if (unlikely(m_cur + MAXSIZE_U32 >= m_end))
+    if (unlikely(!m_cur || m_cur + MAXSIZE_U32 >= m_end))
         expand(MAXSIZE_U32);
     put_u32_unchecked(value);
 }
 
 void StringBuffer::put_u64(uint64_t value) {
-    if (unlikely(m_cur + MAXSIZE_U64 >= m_end))
+    if (unlikely(!m_cur || m_cur + MAXSIZE_U64 >= m_end))
         expand(MAXSIZE_U64);
     put_u64_unchecked(value);
 }
 
 
 void StringBuffer::put_x32(uint32_t value) {
-    if (unlikely(m_cur + MAXSIZE_X32 >= m_end))
+    if (unlikely(!m_cur || m_cur + MAXSIZE_X32 >= m_end))
         expand(MAXSIZE_X32);
     put_x32_unchecked(value);
 }
 
 void StringBuffer::put_x64(uint64_t value) {
-    if (unlikely(m_cur + MAXSIZE_X64 >= m_end))
+    if (unlikely(!m_cur || m_cur + MAXSIZE_X64 >= m_end))
         expand(MAXSIZE_X64);
     put_x64_unchecked(value);
 }
@@ -195,7 +195,7 @@ size_t StringBuffer::fmt(const char *fmt, ...) {
         }
         va_end(args);
 
-        if (likely(m_cur + rv < m_end)) {
+        if (likely(m_cur && m_cur + rv < m_end)) {
             m_cur += rv;
             return (size_t) rv;
         } else {
@@ -220,7 +220,7 @@ size_t StringBuffer::vfmt(const char *fmt, va_list args_) {
             abort();
         }
 
-        if (likely(m_cur + rv < m_end)) {
+        if (likely(m_cur && m_cur + rv < m_end)) {
             m_cur += rv;
             return (size_t) rv;
         } else {
@@ -304,7 +304,7 @@ void StringBuffer::fmt_cuda(size_t nargs, const char *fmt, ...) {
     }
 
     // Enlarge the buffer if necessary
-    if (unlikely(m_cur + len >= m_end))
+    if (unlikely(!m_cur || m_cur + len >= m_end))
         expand(len);
 
     // Phase 2: convert the string
@@ -488,7 +488,7 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
     }
 
     // Enlarge the buffer if necessary
-    if (unlikely(m_cur + len >= m_end))
+    if (unlikely(!m_cur || m_cur + len >= m_end))
         expand(len);
 
     // Phase 2: convert the string

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -108,7 +108,7 @@ public:
 
     /// Append a string with the specified length
     void put(const char *str, size_t size) {
-        if (unlikely(m_cur + size >= m_end))
+        if (unlikely(!m_cur || m_cur + size >= m_end))
             expand(size);
 
         std::memcpy(m_cur, str, size);
@@ -118,7 +118,7 @@ public:
 
     /// Append a single character to the buffer
     void put(char c) {
-        if (unlikely(m_cur + 1 >= m_end))
+        if (unlikely(!m_cur || m_cur + 1 >= m_end))
             expand(1);
         *m_cur++ = c;
         *m_cur = '\0';
@@ -126,7 +126,7 @@ public:
 
     /// Append multiple copies of a single character to the buffer
     void put(char c, size_t count) {
-        if (unlikely(m_cur + count >= m_end))
+        if (unlikely(!m_cur || m_cur + count >= m_end))
             expand(count);
 
         for (size_t i = 0; i < count; ++i)

--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -519,7 +519,8 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
     e_special->dep = (uint32_t *) malloc_check(dep_size);
 
     // Steal input dependencies from placeholder arguments
-    memcpy(e_special->dep, vcall->in.data(), dep_size);
+    if (dep_size)
+        memcpy(e_special->dep, vcall->in.data(), dep_size);
 
     e_special->callback = [](uint32_t, int free, void *ptr) {
         if (free)

--- a/tests/basics.cpp
+++ b/tests/basics.cpp
@@ -291,6 +291,8 @@ template <typename T> bool test_const_prop() {
             in[i] = jit_var_literal(Backend, T::Type, values + i, 1, i >= Size);
 
         for (uint32_t i = 0; i < Size2; ++i) {
+            if (IsSigned && (op == JitOp::Shl) && values[i] < 0)
+                continue;
             for (uint32_t j = 0; j < Size2; ++j) {
                 uint32_t deps[2] = { in[i], in[j] };
                 uint32_t index = 0;
@@ -317,6 +319,8 @@ template <typename T> bool test_const_prop() {
         jit_eval();
 
         for (uint32_t i = 0; i < Size2; ++i) {
+            if (IsSigned && (op == JitOp::Shl) && values[i] < 0)
+                continue;
             for (uint32_t j = 0; j < Size2; ++j) {
                 int ir = i < Size ? i : i - Size;
                 int jr = j < Size ? j : j - Size;
@@ -345,9 +349,12 @@ template <typename T> bool test_const_prop() {
             }
         }
 
-        for (uint32_t i = 0; i < Size2 * Size2; ++i)
-            jit_var_dec_ref(out[i]);
-
+        for (uint32_t i = 0; i < Size2; ++i) {
+            if (IsSigned && (op == JitOp::Shl) && values[i] < 0)
+                continue;
+            for (uint32_t j = 0; j < Size2; ++j)
+                jit_var_dec_ref(out[i * Size2 + j]);
+        }
         for (uint32_t i = 0; i < Size2; ++i)
             jit_var_dec_ref(in[i]);
     }


### PR DESCRIPTION
This PR fixes a few smaller undefined behaviors (see also the discussion in #54).

The fixes in this PR so far are very minor: 
- it ensures that StringBuffers always have a capacity of >= 1. This fixes undefined behavior related to pointer arithmetic on null pointers (addresses #53)
- it fixes an undefined behavior due to invoking memcpy with a nullptr by first checking if >0 bytes should be copied. Calling memcpy(..., nullptr, 0) is invalid, even though logically this should be fine. 
- it fixes a small memory leak of an LLVM error string

There are a few more issues that we we could address also in this PR:
- In test_basics, we are testing the result of CTZ and SHL operations using negative numbers. Left-shifting negative numbers is undefined behavior. Maybe these ops should be skipped for negative arguments in the tests? Not sure whats a good way to do that without overcomplicating the test code though. 
- There are a few more memory leaks. The main one appears to be the `void **reloc` field inside the `Kernel` struct. What would be a good way to fix this? I wasn't sure what would make sense in the context of the code base (i.e. which C++ constructs we use here and which we avoid, e.g. could this field just be an `std::vector` instead?).


