### PR TITLE
Virtual function calls should only devirtualize literals

### DIFF
--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -339,9 +339,9 @@ uint32_t jitc_var_vcall(const char *name, uint32_t self, uint32_t mask_,
             if (!uniform[j])
                 continue;
 
-            /* Should this output value be devirtualized? We want to avoid
-               completely removing the virtual function call.. */
-            if (n_inst == 1 && !vcall_inline && !jitc_var(out_nested[j])->is_literal())
+            /* Only devirtualize literals unless inlining is requested */
+            if (!jitc_var(out_nested[j])->is_literal() &&
+                !((n_inst == 1) && vcall_inline))
                 continue;
 
             Ref result_v = steal(jitc_var_and(out_nested[j], mask));

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -450,16 +450,22 @@ TEST_BOTH(04_devirtualize) {
 
             jit_set_scope(Backend, scope + 1);
 
+            Float p1_wrap = Float::steal(jit_var_wrap_vcall(p1.index()));
             Float p2_wrap = Float::steal(jit_var_wrap_vcall(p2.index()));
 
             Mask mask = neq(self, nullptr),
                  mask_combined = Mask::steal(jit_var_mask_apply(mask.index(), 10));
 
-            Float alt = (p2_wrap + 2) & mask_combined;
+            Float alt0 = (p2_wrap + 2) & mask_combined;
+            Float alt1 = (p1_wrap + 2) & mask_combined;
+            Float alt2 = Float(0) & mask_combined;
 
             jit_set_scope(Backend, scope + 2);
 
-            jit_assert((result.template get<0>().index() == alt.index()) == (i == 1));
+            jit_assert((result.template get<0>().index() == alt0.index()) == ((i == 1) && (k == 0)));
+            jit_assert((result.template get<1>().index() != alt1.index()));
+            jit_assert((result.template get<2>().index() == alt2.index()) == (i == 1));
+
             jit_assert(jit_var_is_literal(result.template get<2>().index()) == (i == 1));
 
             jit_var_schedule(result.template get<0>().index());


### PR DESCRIPTION
This PR changes the behavior of the `VCallOptimize` flag.

Currently, when the `VCallOptimize` flag is set, virtual function return values that are identical across all instances/targets are de-virtualized (the computation is inlined into the caller's scope). This PR limits the de-virtualization to return values that are literals, reducing some potentially aggressive inlining.

There are no apparent performance changes in standard scenes:
```
| scene          | mode   | compilation before   | compilation after   | execution before   | execution after   |
|----------------|--------|----------------------|---------------------|--------------------|-------------------|
| glass-of-water | cuda   | 4.76 (1.00)          | 4.77 (1.00)         | 4.58  (1.00)       | 4.58  (1.00)      |
| glass-of-water | llvm   | 0.07 (1.00)          | 0.07 (1.00)         | 53.07 (1.00)       | 53.74 (1.01)      |
| living-room    | cuda   | 5.15 (1.00)          | 5.14 (1.00)         | 4.87  (1.00)       | 4.86  (1.00)      |
| living-room    | llvm   | 0.30 (1.00)          | 0.30 (1.01)         | 40.56 (1.00)       | 40.48 (1.00)      |
| staircase      | cuda   | 3.48 (1.00)          | 3.49 (1.00)         | 3.22  (1.00)       | 3.23  (1.00)      |
| staircase      | llvm   | 0.44 (1.00)          | 0.44 (1.00)         | 28.29 (1.00)       | 28.16 (1.00)      |
```

This change also fixes a bug related to de-virtualzation in LLVM modes (https://github.com/mitsuba-renderer/mitsuba3/issues/533).