### PR TITLE
Fix bug due to iterator invalidation

### DIFF
--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -189,6 +189,10 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
             jitc_llvm_render_stmt(index, v, false);
         }
 
+        // Fetch "v" again, as the original pointer may have been invalidated by now
+        // due to modifications to the hash map "state.variables".
+        v = jitc_var(index);
+
         if (v->param_type == ParamType::Output) {
             if (vt != VarType::Bool) {
                 fmt("    store $V, {$T*} $v_p5, align $A, !noalias !2, !nontemporal !3\n",


### PR DESCRIPTION
Hi,

I came across a strange bug in Mitsuba this week. Somehow during optimization, at a seemingly arbitrary (but not random) iteration, the LLVM backend would emit an error
```
drjit_f04142c9302e9174a3dbe2f6a84e85d3:1755:23: error: use of undefined value '%f0'
    store <8 x float> %f0, ptr %f0_p5, align 32, !noalias !2, !nontemporal !3
                      ^
```
Weirdly enough, this happened without any particular change of the code. The kernel was identical for all iterations of the optimization, except for this one extra line. And depending on the code in my program, it would happen at different iterations or not at all. But it was not random - for a fixed code, it would happen exactly at the same point across machines.

The variable it was trying to store here came from a VCall's creation, which didn't make any sense (as confirmed by @njroussel). 

Some further debugging showed: in the beginning of the loop in `jitc_llvm_assemble`, the variable `v` had the correct state, most importantly `kind` was different from `ParamType::Output`. The code in the loop body doesn't seem to overwrite the original state either, as `jit_var(index)` always returned the correct result. However, I think what's happening is that the pointer `v` gets invalidated due to updates to the hash map `state.variable` when emitting the vcall code. So by the end of the loop iteration `jit_var(index)` is still fine, but `v` isn't valid anymore. This would also explain why the issue seems deterministic and why running it with sanitizers (address and UB etc) didn't reveal anything.

This PR contains a simple fix that seems to work. It simply fetches the variable pointer again before the final part of the loop body. This is a bit of a bandaid though, as it doesn't really guarantee much except that the last part of the loop body will execute correctly (where the problematic statement was emitted in the first place)

Here is a minimal Mitsuba reproducer that shows the bug when running using the latest Mitsuba `master` (on Linux).
```
import numpy as np
import drjit as dr

import mitsuba as mi
mi.set_variant('llvm_ad_rgb')

scene = mi.load_dict({
    'type': 'scene',
    'integrator': {'type': 'direct', 'bsdf_samples': 0},
    'emitter': {'type': 'point'},
    'object': {
        'type': 'cube',
        'bsdf': {
          'type': 'diffuse',
          'reflectance': {
              'type': 'bitmap',
              'bitmap': mi.Bitmap(np.ones((512, 512, 3), dtype=np.float32)),
          },
    }}
})
n_iter = 1024
n_sensors = 3

sensors = []
for _ in range(n_sensors):
  sensors.append( mi.load_dict({
      'type': 'perspective',
      'film': {'type': 'hdrfilm','height': 512,'width': 512},
  }))
params = mi.traverse(scene)
key = 'object.bsdf.reflectance.data'

opt = mi.ad.Adam(lr=2e-2)
params[key] = mi.TensorXf(np.ones((512, 512, 3)))
opt[key] = params[key]
opt.set_learning_rate({key: 2e-2})
params.update(opt)

# Initialize sensor resolutions
for sensor in sensors:
  sensor_params = mi.traverse(sensor)
  sensor_params['film.size'] = mi.ScalarVector2i(64, 64)
  sensor_params.update()

seed = 0
for i in range(n_iter):
  print(f'Iter {i}')
  for sensor in sensors:
    img = mi.render(scene, sensor=sensor, spp=2, params=params)
    loss = dr.mean(img**2)
    dr.backward(loss)

  opt.step()
  params.update(opt)

```


