### PR TITLE
Disable LLVM backend when the FMA3 instruction set is unavailable

### DIFF
--- a/src/llvm_core.cpp
+++ b/src/llvm_core.cpp
@@ -103,6 +103,14 @@ bool jitc_llvm_init() {
         }
     }
 
+    if (!strstr(jitc_llvm_target_features, "+fma")) {
+        jitc_log(Warn, "jit_llvm_init(): your CPU does not support the `fma` "
+                       "instruction set, shutting down the LLVM "
+                       "backend...");
+        jitc_llvm_shutdown();
+        return false;
+    }
+
     jitc_llvm_vector_width = 1;
 
     if (strstr(jitc_llvm_target_features, "+sse4.2"))


### PR DESCRIPTION
This PR is a follow-up to #59.

When the FMA3 instruction set is not supported on the target CPU, the JIT will now gracefully shutdown with a warning message.

Correctly emulating the instruction is difficult and bumping the CPU architecture requirement is too-strict as some users might only use the CUDA backend.

(Fixes https://github.com/mitsuba-renderer/drjit/issues/46).