### PR TITLE
Fix nested virtual function calls with side-effects

### DIFF
--- a/src/vcall.cpp
+++ b/src/vcall.cpp
@@ -691,6 +691,7 @@ void jitc_var_vcall_assemble(VCall *vcall, uint32_t self_reg, uint32_t mask_reg,
         vcall->in_count_initial, in_size, vcall->in_size_initial, n_out_active,
         n_out, out_size, vcall->out_size_initial, se_count);
 
+    jitc_var_inc_ref(vcall->id);
     vcalls_assembled.push_back(vcall);
 }
 
@@ -789,6 +790,9 @@ void jitc_vcall_upload(ThreadState *ts) {
             jitc_task = new_task;
         }
     }
+
+    for (VCall *vcall : vcalls_assembled)
+        jitc_var_dec_ref(vcall->id);
     vcalls_assembled.clear();
 }
 

--- a/src/vcall.h
+++ b/src/vcall.h
@@ -1,3 +1,4 @@
+#include "internal.h"
 #include <stdint.h>
 
 extern void jitc_vcall_set_self(JitBackend backend, uint32_t value, uint32_t index);


### PR DESCRIPTION
This PR increases the reference count of vcalls while they're being assembled. This guarantees that they will not be freed until all vcalls have been assembled and their data uploaded with `jitc_vcall_upload`.

Without this change, nested recorded vcalls where the inner vcall has a side-effect produces an error. In this example, as the outer vcall is assembled [its side-effects are cleared](https://github.com/mitsuba-renderer/drjit-core/blob/master/src/vcall.cpp#L658). The inner vcall is a side-effect of the outer vcall and is therefore deleted. The error happens once `jitc_vcall_upload` is reached, as it tries to access the inner vcall. 

An additional test case for a nested vcall with a side-effect has been added.