### PR TITLE
Allow evaluations of side effects during recording

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -585,9 +585,6 @@ void jitc_eval(ThreadState *ts) {
     // Collect variables that must be computed along with their dependencies
     for (int j = 0; j < 2; ++j) {
         auto &source = j == 0 ? ts->scheduled : ts->side_effects;
-        if (j == 1 && (jitc_flags() & (uint32_t) JitFlag::Recording))
-            break;
-
         for (size_t i = 0; i < source.size(); ++i) {
             uint32_t index = source[i];
             auto it = state.variables.find(index);


### PR DESCRIPTION
Evaluation of side-effects was explicitly disabled whenever Dr.Jit was in a recorded phase of some computation. This PR changes this behaviour and now allows these evaluations.

The new test case in this PR motivates this change: we want to access/use some "dirty" variable during a recorded loop.

The original behavior was introduced in https://github.com/mitsuba-renderer/drjit-core/commit/30b3f575004ed83aa778c845d35cfdd3c49af88a. At that point in the development of Dr.Jit, symbolic loops or virtual function calls did not store their side-effects in a separate list (`ThreadState.side_effects_recorded` did not exist yet). The fact that these are now stored in a separate list allows us to disambiguate which side-effects are independent of the recording and can be evaluated.