### PR TITLE
Fix a typo in the name of `nvidia-smi` utility.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -352,7 +352,7 @@ ThreadState *jitc_init_thread_state(JitBackend backend) {
                            "computer simply does not contain a graphics card "
                            "that supports CUDA.\n\n 2. your CUDA kernel module "
                            "and CUDA library are out of sync. Try to see if "
-                           "you\n    can run a utility like 'nvida-smi'. If "
+                           "you\n    can run a utility like 'nvidia-smi'. If "
                            "not, a reboot will likely fix this\n    issue. "
                            "Otherwise reinstall your graphics driver. \n\n "
                            "The specific error message produced by cuInit was\n"


### PR DESCRIPTION
This commit fixed a typo in the name of the `nvidia-smi` utility, a term which users may elect to copy and run in their terminal during troubleshooting.

There are no other language or functionality changes in this PR.