### PR TITLE
src/common.h: explicitly include `cstdint`

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -20,6 +20,7 @@
 
 #if defined(__linux__)
 #include <pthread.h>
+#include <cstdint>
 using Lock = pthread_spinlock_t;
 
 // Danger zone: the drjit-core locks are held for an extremely short amount of


### PR DESCRIPTION
Fixes an error when compiling with GCC 13.

Build log:

https://gist.github.com/ConnorBaker/4fa0dd6e8b6ca71cbe60c1983b97e2ab

Snippet

```console
/nix/store/ldxpb0mc2qxx247wi5bnsplcaxdnhyw5-gcc-wrapper-13.2.0/bin/g++ -DDRJIT_BUILD=1 -DDRJIT_DYNAMIC_CUDA=1 -DDRJIT_DYNAMIC_LLVM=1 -DDRJIT_ENABLE_OPTIX=1 -DLZ4LIB_VISIBILITY="" -DXXH_EXPORT -Ddrjit_core_EXPORTS -I/build/source/include -fdiagnostics-color=always -O3 -DNDEBUG -flto=auto -fno-fat-lto-objects -fPIC -fvisibility=hidden -march=native -Wall -Wextra -Wno-unused-local-typedefs -fno-math-errno -ffp-contract=fast -fno-trapping-math -Wno-free-nonheap-object -MD -MT CMakeFiles/drjit-core.dir/src/strbuf.cpp.o -MF CMakeFiles/drjit-core.dir/src/strbuf.cpp.o.d -o CMakeFiles/drjit-core.dir/src/strbuf.cpp.o -c /build/source/src/strbuf.cpp
In file included from /build/source/src/strbuf.h:2,
                 from /build/source/src/strbuf.cpp:1:
/build/source/src/common.h:91:53: error: 'uint8_t' does not name a type
   91 | template <> struct uint_with_size<1> { using type = uint8_t; };
      |                                                     ^~~~~~~
/build/source/src/common.h:23:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   22 | #include <pthread.h>
  +++ |+#include <cstdint>
   23 | using Lock = pthread_spinlock_t;
```