### PR TITLE
Fix race condition in `jit_init`

### DIFF
--- a/src/cuda.h
+++ b/src/cuda.h
@@ -39,7 +39,8 @@ extern void *jitc_cuda_lookup(const char *name);
 struct Kernel;
 
 /// Compile an PTX string. Returns the resulting module and a cache hit true/false flag
-extern std::pair<CUmodule, bool> jitc_cuda_compile(const char *str);
+extern std::pair<CUmodule, bool>
+jitc_cuda_compile(const char *str, bool release_state_lock = true);
 
 /// Assert that a CUDA operation is correctly issued
 #define cuda_check(err) cuda_check_impl(err, __FILE__, __LINE__)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -336,15 +336,8 @@ ThreadState *jitc_init_thread_state(JitBackend backend) {
 
     if (backend == JitBackend::CUDA) {
         if ((state.backends & (uint32_t) JitBackend::CUDA) == 0) {
-            #if defined(_WIN32)
-                const char *cuda_fname = "nvcuda.dll";
-            #elif defined(__linux__)
-                const char *cuda_fname  = "libcuda.so";
-            #else
-                const char *cuda_fname  = "libcuda.dylib";
-            #endif
-
             delete ts;
+
             if (jitc_cuda_cuinit_result == CUDA_ERROR_NOT_INITIALIZED) {
                 jitc_raise(
                     "jit_init_thread_state(): the CUDA backend hasn't been "
@@ -365,13 +358,20 @@ ThreadState *jitc_init_thread_state(JitBackend backend) {
                            "The specific error message produced by cuInit was\n"
                            "   \"%s\"", msg);
             } else {
-                jitc_raise(
-                    "jit_init_thread_state(): the CUDA backend is inactive "
-                    "because it has not been initialized via jit_init(), or "
-                    "because the CUDA driver library (\"%s\") could not be "
-                    "found! Set the DRJIT_LIBCUDA_PATH environment variable to "
-                    "specify its path.",
-                    cuda_fname);
+#if defined(_WIN32)
+              const char *cuda_fname = "nvcuda.dll";
+#elif defined(__linux__)
+              const char *cuda_fname = "libcuda.so";
+#else
+              const char *cuda_fname = "libcuda.dylib";
+#endif
+              jitc_raise(
+                  "jit_init_thread_state(): the CUDA backend is inactive "
+                  "because it has not been initialized via jit_init(), or "
+                  "because the CUDA driver library (\"%s\") could not be "
+                  "found! Set the DRJIT_LIBCUDA_PATH environment variable to "
+                  "specify its path.",
+                  cuda_fname);
             }
         }
 


### PR DESCRIPTION
A race condition was introduced in 12a2b8b: `jit_init` calls `jitc_cuda_compile`, which now locally unlocks the state lock. This means that operations such as `jitc_init_thread_state` could start executing before `jit_init` would complete.

The race condition was easily reproducible on my machine by deleting the cache directories. The next run would almost always trigger:

```
jit_init_thread_state(): the CUDA backend is inactive because it has not been initialized via jit_init(), or because the CUDA driver library ("libcuda.so") could not be found! Set the DRJIT_LIBCUDA_PATH environment variable to specify its path.
```

As a simple fix, I introduced a `release_state_lock` argument, which is only set to `false` in `jit_init`. Hopefully that's the only case where we really need to keep the lock?

Also fixed some indentation (mixed tabs and spaces).

---

PS: technically I encountered this after backporting 12a2b8b to `master`, but if I understand correctly, the `nanobind` branch is affected as well.