### PR TITLE
Added cmath to `half` test and fixed arg mismatch in `cuda_eval`

### DIFF
--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -680,7 +680,7 @@ static void jitc_cuda_render(Variable *v) {
 
                 if (masked) {
                     if (is_bool)
-                        fmt("    mov.b16 %w0, 0;\n", v);
+                        fmt("    mov.b16 %w0, 0;\n");
                     else
                         fmt("    mov.$b $v, 0;\n", v, v);
                     fmt("    @$v ", a2);

--- a/tests/half.cpp
+++ b/tests/half.cpp
@@ -2,6 +2,7 @@
 
 #include <drjit-core/half.h>
 #include <stdio.h>
+#include <cmath>
 
 using drjit::half;
 


### PR DESCRIPTION
The function `std::isnan` is provided by the `cmath` library which was not included in the `half` test.
There was a format mismatch in `cuda_eval` causing a runtime exception on the gather test.