### PR TITLE
jitc_run modularization

### DIFF
--- a/src/cuda_ts.cpp
+++ b/src/cuda_ts.cpp
@@ -1,6 +1,8 @@
 #include "cuda_ts.h"
 #include "var.h"
 #include "log.h"
+#include "optix.h"
+#include "eval.h"
 
 const static char *reduction_name[(int) ReduceOp::Count] = { "none", "sum", "mul",
                                                       "min", "max", "and", "or" };
@@ -36,6 +38,43 @@ static void submit_gpu(KernelType type, CUfunction kernel, uint32_t block_count,
 
         state.kernel_history.append(entry);
     }
+}
+
+Task *CUDAThreadState::launch(Kernel kernel, uint32_t size){
+#if defined(DRJIT_ENABLE_OPTIX)
+        if (unlikely(uses_optix))
+            jitc_optix_launch(this, kernel, size, kernel_params_global,
+                              kernel_param_count);
+#endif
+
+        if (!uses_optix) {
+            size_t buffer_size = kernel_params.size() * sizeof(void *);
+
+            void *config[] = {
+                CU_LAUNCH_PARAM_BUFFER_POINTER,
+                kernel_params.data(),
+                CU_LAUNCH_PARAM_BUFFER_SIZE,
+                &buffer_size,
+                CU_LAUNCH_PARAM_END
+            };
+
+            uint32_t block_count, thread_count;
+            const Device &device = state.devices[this->device];
+            device.get_launch_config(&block_count, &thread_count, size,
+                                     (uint32_t) kernel.cuda.block_size);
+
+            cuda_check(cuLaunchKernel(kernel.cuda.func, block_count, 1, 1,
+                                      thread_count, 1, 1, 0, this->stream,
+                                      nullptr, config));
+            jitc_trace("jit_run(): launching %u thread%s in %u block%s ..",
+                       thread_count, thread_count == 1 ? "" : "s", block_count,
+                       block_count == 1 ? "" : "s");
+        }
+
+        if (unlikely(jit_flag(JitFlag::LaunchBlocking)))
+            cuda_check(cuStreamSynchronize(this->stream));
+
+    return nullptr;
 }
 
 /// Fill a device memory region with constants of a given type

--- a/src/cuda_ts.cpp
+++ b/src/cuda_ts.cpp
@@ -42,37 +42,37 @@ static void submit_gpu(KernelType type, CUfunction kernel, uint32_t block_count,
 
 Task *CUDAThreadState::launch(Kernel kernel, uint32_t size){
 #if defined(DRJIT_ENABLE_OPTIX)
-        if (unlikely(uses_optix))
-            jitc_optix_launch(this, kernel, size, kernel_params_global,
-                              kernel_param_count);
+    if (unlikely(uses_optix))
+        jitc_optix_launch(this, kernel, size, kernel_params_global,
+                          kernel_param_count);
 #endif
 
-        if (!uses_optix) {
-            size_t buffer_size = kernel_params.size() * sizeof(void *);
+    if (!uses_optix) {
+        size_t buffer_size = kernel_params.size() * sizeof(void *);
 
-            void *config[] = {
-                CU_LAUNCH_PARAM_BUFFER_POINTER,
-                kernel_params.data(),
-                CU_LAUNCH_PARAM_BUFFER_SIZE,
-                &buffer_size,
-                CU_LAUNCH_PARAM_END
-            };
+        void *config[] = {
+            CU_LAUNCH_PARAM_BUFFER_POINTER,
+            kernel_params.data(),
+            CU_LAUNCH_PARAM_BUFFER_SIZE,
+            &buffer_size,
+            CU_LAUNCH_PARAM_END
+        };
 
-            uint32_t block_count, thread_count;
-            const Device &device = state.devices[this->device];
-            device.get_launch_config(&block_count, &thread_count, size,
-                                     (uint32_t) kernel.cuda.block_size);
+        uint32_t block_count, thread_count;
+        const Device &device = state.devices[this->device];
+        device.get_launch_config(&block_count, &thread_count, size,
+                                 (uint32_t) kernel.cuda.block_size);
 
-            cuda_check(cuLaunchKernel(kernel.cuda.func, block_count, 1, 1,
-                                      thread_count, 1, 1, 0, this->stream,
-                                      nullptr, config));
-            jitc_trace("jit_run(): launching %u thread%s in %u block%s ..",
-                       thread_count, thread_count == 1 ? "" : "s", block_count,
-                       block_count == 1 ? "" : "s");
-        }
+        cuda_check(cuLaunchKernel(kernel.cuda.func, block_count, 1, 1,
+                                  thread_count, 1, 1, 0, this->stream,
+                                  nullptr, config));
+        jitc_trace("jit_run(): launching %u thread%s in %u block%s ..",
+                   thread_count, thread_count == 1 ? "" : "s", block_count,
+                   block_count == 1 ? "" : "s");
+    }
 
-        if (unlikely(jit_flag(JitFlag::LaunchBlocking)))
-            cuda_check(cuStreamSynchronize(this->stream));
+    if (unlikely(jit_flag(JitFlag::LaunchBlocking)))
+        cuda_check(cuStreamSynchronize(this->stream));
 
     return nullptr;
 }

--- a/src/cuda_ts.cpp
+++ b/src/cuda_ts.cpp
@@ -40,7 +40,10 @@ static void submit_gpu(KernelType type, CUfunction kernel, uint32_t block_count,
     }
 }
 
-Task *CUDAThreadState::launch(Kernel kernel, uint32_t size){
+Task *CUDAThreadState::launch(Kernel kernel, uint32_t size,
+                              std::vector<void *> *kernel_params,
+                              uint32_t kernel_param_count,
+                              const uint8_t *kernel_params_global) {
 #if defined(DRJIT_ENABLE_OPTIX)
     if (unlikely(uses_optix))
         jitc_optix_launch(this, kernel, size, kernel_params_global,
@@ -48,11 +51,11 @@ Task *CUDAThreadState::launch(Kernel kernel, uint32_t size){
 #endif
 
     if (!uses_optix) {
-        size_t buffer_size = kernel_params.size() * sizeof(void *);
+        size_t buffer_size = kernel_params->size() * sizeof(void *);
 
         void *config[] = {
             CU_LAUNCH_PARAM_BUFFER_POINTER,
-            kernel_params.data(),
+            kernel_params->data(),
             CU_LAUNCH_PARAM_BUFFER_SIZE,
             &buffer_size,
             CU_LAUNCH_PARAM_END

--- a/src/cuda_ts.h
+++ b/src/cuda_ts.h
@@ -3,6 +3,8 @@
 
 struct CUDAThreadState: ThreadState{
 
+    Task *launch(Kernel kernel, uint32_t size) override;
+
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,
                       const void *src) override;

--- a/src/cuda_ts.h
+++ b/src/cuda_ts.h
@@ -3,7 +3,10 @@
 
 struct CUDAThreadState: ThreadState{
 
-    Task *launch(Kernel kernel, uint32_t size) override;
+    Task *launch(Kernel kernel, uint32_t size,
+                 std::vector<void *> *kernel_params,
+                 uint32_t kernel_param_count,
+                 const uint8_t *kernel_params_global) override;
 
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -54,9 +54,9 @@ struct VisitedKeyHash {
 static tsl::robin_set<VisitedKey, VisitedKeyHash> visited;
 
 /// Kernel parameter buffer and device copy
-std::vector<void *> kernel_params;
-uint8_t *kernel_params_global = nullptr;
-uint32_t kernel_param_count = 0;
+static std::vector<void *> kernel_params;
+static uint8_t *kernel_params_global = nullptr;
+static uint32_t kernel_param_count = 0;
 
 /// Ensure uniqueness of globals/callables arrays
 GlobalsMap globals_map;
@@ -517,7 +517,8 @@ Task *jitc_run(ThreadState *ts, ScheduledGroup group) {
     }
 
     Task* ret_task = nullptr;
-    ret_task = ts->launch(kernel, group.size);
+    ret_task = ts->launch(kernel, group.size, &kernel_params,
+                          kernel_param_count, kernel_params_global);
 
     if (unlikely(jit_flag(JitFlag::KernelHistory))) {
         if (ts->backend == JitBackend::CUDA) {

--- a/src/eval.h
+++ b/src/eval.h
@@ -72,11 +72,6 @@ extern StringBuffer globals;
 /// Mapping that describes the contents of the 'globals' buffer
 extern GlobalsMap globals_map;
 
-/// Kernel parameter buffer and device copy
-extern std::vector<void *> kernel_params;
-extern uint8_t *kernel_params_global;
-extern uint32_t kernel_param_count;
-
 /// Name of the last generated kernel
 extern char kernel_name[52];
 

--- a/src/eval.h
+++ b/src/eval.h
@@ -72,6 +72,11 @@ extern StringBuffer globals;
 /// Mapping that describes the contents of the 'globals' buffer
 extern GlobalsMap globals_map;
 
+/// Kernel parameter buffer and device copy
+extern std::vector<void *> kernel_params;
+extern uint8_t *kernel_params_global;
+extern uint32_t kernel_param_count;
+
 /// Name of the last generated kernel
 extern char kernel_name[52];
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -583,6 +583,8 @@ struct ThreadState {
     ThreadState() = default;
     ThreadState(const ThreadState &other) = default;
 
+    virtual Task *launch(Kernel kernel, uint32_t size) = 0;
+
     /// Fill a device memory region with constants of a given type
     virtual void memset_async(void *ptr, uint32_t size, uint32_t isize,
                               const void *src) = 0;

--- a/src/internal.h
+++ b/src/internal.h
@@ -583,7 +583,10 @@ struct ThreadState {
     ThreadState() = default;
     ThreadState(const ThreadState &other) = default;
 
-    virtual Task *launch(Kernel kernel, uint32_t size) = 0;
+    virtual Task *launch(Kernel kernel, uint32_t size,
+                         std::vector<void *> *kernel_params,
+                         uint32_t kernel_param_count,
+                         const uint8_t *kernel_params_global) = 0;
 
     /// Fill a device memory region with constants of a given type
     virtual void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/llvm_ts.cpp
+++ b/src/llvm_ts.cpp
@@ -135,7 +135,10 @@ static void submit_cpu(KernelType type, Func &&func, uint32_t width,
     jitc_task = new_task;
 }
 
-Task *LLVMThreadState::launch(Kernel kernel, uint32_t size){
+Task *LLVMThreadState::launch(Kernel kernel, uint32_t size,
+                              std::vector<void *> *kernel_params,
+                              uint32_t kernel_param_count,
+                              const uint8_t *kernel_params_global) {
     Task *ret_task = nullptr;
     
     uint32_t packet_size = jitc_llvm_vector_width,
@@ -201,8 +204,8 @@ Task *LLVMThreadState::launch(Kernel kernel, uint32_t size){
 #endif
     };
 
-    kernel_params[0] = (void *) kernel.llvm.reloc[0];
-    kernel_params[1] = (void *) ((((uintptr_t) block_size) << 32) +
+    (*kernel_params)[0] = (void *) kernel.llvm.reloc[0];
+    (*kernel_params)[1] = (void *) ((((uintptr_t) block_size) << 32) +
                                  (uintptr_t) size);
 
 #if defined(DRJIT_ENABLE_ITTNOTIFY)
@@ -215,8 +218,8 @@ Task *LLVMThreadState::launch(Kernel kernel, uint32_t size){
 
     ret_task = task_submit_dep(
         nullptr, &jitc_task, 1, blocks,
-        callback, kernel_params.data(),
-        (uint32_t) (kernel_params.size() * sizeof(void *)),
+        callback, kernel_params->data(),
+        (uint32_t) (kernel_params->size() * sizeof(void *)),
         nullptr
     );
 

--- a/src/llvm_ts.h
+++ b/src/llvm_ts.h
@@ -2,7 +2,10 @@
 
 struct LLVMThreadState: ThreadState{
 
-    Task *launch(Kernel kernel, uint32_t size) override;
+    Task *launch(Kernel kernel, uint32_t size,
+                 std::vector<void *> *kernel_params,
+                 uint32_t kernel_param_count,
+                 const uint8_t *kernel_params_global) override;
     
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/llvm_ts.h
+++ b/src/llvm_ts.h
@@ -2,6 +2,8 @@
 
 struct LLVMThreadState: ThreadState{
 
+    Task *launch(Kernel kernel, uint32_t size) override;
+    
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,
                       const void *src) override;


### PR DESCRIPTION
Adds a new virtual function to `ThreadState`, that takes a `Kernel` after and launches it.
This modularizes part of `jitc_run`.