### PR TITLE
Add `jit_registry_peek`

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -501,6 +501,9 @@ extern JIT_EXPORT uint32_t jit_registry_id_bound(JitBackend backend,
 extern JIT_EXPORT void *jit_registry_ptr(JitBackend backend,
                                          const char *domain, uint32_t id);
 
+/// Return an arbitrary pointer value associated with a given domain
+extern JIT_EXPORT void *jit_registry_peek(JitBackend backend, const char *domain);
+
 /// Disable any instances that are currently registered in the registry
 extern JIT_EXPORT void jit_registry_clear();
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -947,6 +947,11 @@ void *jit_registry_ptr(JitBackend backend, const char *domain, uint32_t id) {
     return jitc_registry_ptr(backend, domain, id);
 }
 
+void *jit_registry_peek(JitBackend backend, const char *domain) {
+    lock_guard guard(state.lock);
+    return jitc_registry_peek(backend, domain);
+}
+
 void jit_registry_clear() {
     lock_guard guard(state.lock);
     jitc_registry_clear();

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -175,6 +175,23 @@ void *jitc_registry_ptr(JitBackend backend, const char *domain_name, uint32_t id
     return ptr;
 }
 
+void *jitc_registry_peek(JitBackend backend, const char *domain_name) {
+    Registry &r = registry;
+    auto it = r.domain_ids.find(DomainKey{ backend, domain_name });
+    void *ptr = nullptr;
+
+    if (it != r.domain_ids.end()) {
+        Domain &domain = r.domains[it->second];
+        uint32_t bound = domain.id_bound;
+        if (bound > 0) {
+            Ptr entry = domain.fwd_map[bound - 1];
+            return entry.ptr;
+        }
+    }
+
+    return ptr;
+}
+
 void jitc_registry_clear() {
     jitc_log(Debug, "jit_registry_clear()");
     Registry &r = registry;

--- a/src/registry.h
+++ b/src/registry.h
@@ -27,6 +27,9 @@ extern uint32_t jitc_registry_id_bound(JitBackend backend, const char *domain);
 /// Return the pointer value associated with a given instance ID
 extern void *jitc_registry_ptr(JitBackend backend, const char *domain, uint32_t id);
 
+/// Return an arbitrary pointer value associated with a given domain
+extern void *jitc_registry_peek(JitBackend backend, const char *domain);
+
 /// Check for leaks in the registry
 extern void jitc_registry_shutdown();
 


### PR DESCRIPTION
This PR adds an Interface to get an arbitrary pointer to an instance in a given domain: `jit_registry_peek`. This is useful for vectorized dispatches where it is sometimes necessary to trace some function for an arbitrary instance.


The proposed implementation is effectively a compostion of `jit_registry_ptr` and `jit_registry_id_bound`. Returning the highest ID in a domain isn't a particularly desirable property for this function, but it is the only way (I believe) to return a valid pointer in O(1) without making any additional changes to the registry data structures.  