### PR TITLE
Fixes to `jitc_var_reduce_dot` and `jitc_var_call_analyze`

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -598,6 +598,8 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
         LoopData *loop = (LoopData *) jitc_var(v->dep[0])->data;
         for (uint32_t index_2: loop->inner_out)
             jitc_var_call_analyze(call, inst_id, index_2, data_offset);
+        for (uint32_t index_2: loop->outer_in)
+            jitc_var_call_analyze(call, inst_id, index_2, data_offset);
     } else if (kind == VarKind::TraceRay) {
         TraceData *td = (TraceData *) v->data;
         for (uint32_t index_2: td->indices)

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -2025,10 +2025,12 @@ uint32_t jitc_var_reduce_dot(uint32_t index_1,
         uint32_t size = v1->size;
 
         // Fast path
-        if (jitc_var_eval(index_1))
+        bool eval = jitc_var_eval(index_1);
+        eval |= jitc_var_eval(index_2);
+        if (eval) {
             v1 = jitc_var(index_1);
-        if (jitc_var_eval(index_2))
             v2 = jitc_var(index_2);
+        }
 
         void *ptr_1 = v1->data,
              *ptr_2 = v2->data,


### PR DESCRIPTION
This PR introduces two fixes:

* 0419185c67427dcbc2dc4232ec8e8c6e61eacd8f is a fix for yet another case where we might have used an invalidated `Variable*`
* 4623c62d4e2e7b75d7aecaaa016d7211ec7e92be is a fix for vectorized calls, where we previously might not have completely filled their data map if a callable contained a loop.