### PR TITLE
Various minor fixes

### DIFF
--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -1179,7 +1179,7 @@ void jitc_var_call_assemble_cuda(CallData *call, uint32_t call_reg,
 
     for (uint32_t i = 0; i < call->n_out; ++i) {
         const Variable *v = jitc_var(call->outer_out[i]);
-        if (!v || !v->reg_index)
+        if (!v || !v->reg_index || v->param_type == ParamType::Input)
             continue;
 
         const char *tname = type_name_ptx_bin[v->type],

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -1608,7 +1608,7 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
 
     for (uint32_t i = 0; i < call->n_out; ++i) {
         const Variable *v = jitc_var(call->outer_out[i]);
-        if (!v || !v->reg_index)
+        if (!v || !v->reg_index || v->param_type == ParamType::Input)
             continue;
 
         bool is_bool = (VarType) v->type == VarType::Bool;

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -1874,7 +1874,9 @@ void jitc_var_gather_packet(size_t n, uint32_t src_, uint32_t index, uint32_t ma
         (mask_v->is_literal() && mask_v->literal == 0) ||   // Masked load
         src_v->size == 1 ||                                 // Scalar load
         (var_info.size == 1 && var_info.literal) ||         // Memcpy
-        src_v->unaligned) {                                 // Source must be aligned
+        src_v->unaligned ||                                 // Source must be aligned
+        src_v->is_literal() ||                              // Literal values
+        src_v->is_undefined()) {                            // Uninitialized memory
         for (size_t i = 0; i < n; ++i) {
             Ref index2 = steal(jitc_var_u32(var_info.backend, (uint32_t) i));
             Ref index3 = steal(jitc_var_fma(index, scale, index2));

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -2256,6 +2256,13 @@ jitc_var_infer_reduce_mode(const char *name, JitBackend backend, Ref &target,
             reduce_expanded =
                 jitc_var(target)->reduce_op == (uint32_t) ReduceOp::Identity;
 
+            // When capturing symbolic loops, side effects might be deleted
+            // and re-recorded. So, even if `jit_var_expand` was already called
+            // once, its corresponding side effect might have been deleted. We
+            // therefore always mark this as the first time it's being called
+            // when inside a symbolic scope.
+            reduce_expanded |= jit_flag(JitFlag::SymbolicScope);
+
             auto [target_i, expand_i] = jitc_var_expand(target, op);
             target = steal(target_i);
 


### PR DESCRIPTION
This PR has 3 fixes:
* Vectorized call outputs would be assembled twice if they had been evaluated in a previous kernel. This would produce illegal IR with the LLVM backend.
* The new gather of packets didn't support literals. It will now fallback to the simple `gather` implementation which already handles all of the optimizations for literals.
* With LLVM a `scatter_reduce` with the `ReduceMode.Expand` could fail when used in a symbolic scope. The symbolic computation might roll back side-effects which in turn deleted some necessary callbacks for the reduction of the expanded arrays.

This PR doesn't hold any tests. Regression tests were added in `drjit`. 