### PR TITLE
jit_var_migrate: don't copy dependencies of source variable

### DIFF
--- a/src/var.cpp
+++ b/src/var.cpp
@@ -1787,6 +1787,7 @@ uint32_t jitc_var_migrate(uint32_t src_index, AllocType dst_type) {
     v = jitc_var(src_index);
     if (src_ptr != dst_ptr) {
         Variable v2 = *v;
+        memset(v2.dep, 0, sizeof(v2.dep));
         v2.kind = (uint32_t) VarKind::Evaluated;
         v2.data = dst_ptr;
         v2.retain_data = false;


### PR DESCRIPTION
When the result of `jit_var_migrate` is a new (evaluated) variable, we don't want to copy over the dependencies of the source variable.
It looks to me like they were copied accidentally, since the ref count of the dependencies was not increased.

This issue came up when doing:

```py
a = mi.Float([1, 2, 3])
b = dr.reshape(mi.Float, a, 2, shrink=True)
c = b.numpy()
```

When `c` gets de-allocated, it tried to decrease the dependencies of `b`, which have already been freed.