### PR TITLE
Fix LLVM symbolic loops with evaluated outputs

### DIFF
--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -985,7 +985,7 @@ static void jitc_llvm_render(Variable *v) {
                          *outer_out = jitc_var(ld->outer_out[l]);
                 fmt("    $v = phi $T [ $v, %l_$u_before ], [ $v, %l_$u_end ]\n",
                     v, v, outer_in, a0->reg_index, inner_out, a0->reg_index);
-                if (outer_out)
+                if (outer_out && (VarKind) outer_out->kind == VarKind::LoopOutput)
                     outer_out->reg_index = inner_in->reg_index;
             }
             break;


### PR DESCRIPTION
This PR introduces a small fix to LLVM symbolic loops. 

When a loop's state is partially evaluated and then re-used in some other evaluation, it could produce illegal LLVM IR.
Here's an example:

```python
import drjit as dr
m = dr.llvm

@dr.syntax
def func():
    idx = dr.zeros(m.UInt32)
    val = dr.zeros(m.UInt32)

    while dr.hint(idx < 3, mode='symbolic'):
        idx += 1
        val += 2 + idx

    return idx, val

idx, val = func()

# Only evaluate idx
print('size: ', idx)

# Need to re-compute previous values of `idx` (at each iteration of the loop) and can re-use final value of `idx`
print('sum: ', val + idx)
```
(I will add this as a test case to Dr.Jit.)

During assembly, we incorrectly assume that loop outputs are still of kind `LoopOutput` which are never assembled explicitly. In reality, loop outputs could have been evaluated and hence would be assembled to a `load` statement leading to a duplicate definition of a register name.