### PR TITLE
Fix for loading fp16 vectors in LLVM

### DIFF
--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -143,8 +143,13 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
 
             if (size != 1) {
                 // Load a packet of values
-                fmt("    $v$s = load $M, {$M*} $v_p5, align $A, !alias.scope !2, !nontemporal !3\n",
-                    v, vt == VarType::Bool ? "_0" : "", v, v, v, v);
+
+                // See  https://github.com/llvm/llvm-project/issues/102611
+                const char *nontemporal =
+                    vt == VarType::Float16 ? "" : ", !nontemporal !3";
+
+                fmt("    $v$s = load $M, {$M*} $v_p5, align $A, !alias.scope !2$s\n",
+                    v, vt == VarType::Bool ? "_0" : "", v, v, v, v, nontemporal);
                 if (vt == VarType::Bool)
                     fmt("    $v = trunc $M $v_0 to $T\n", v, v, v, v);
             } else {


### PR DESCRIPTION
Tiny fix for half-precision floating point vectors that seems to affect all releases of LLVM.

All "passing" CI runs were just relying on UB, but should/could have been crashing. The current LLVM 18 build on `master` fails, where as this PR passes.

More details (and maybe an upcoming fix) are tracked here in the LLVM project: https://github.com/llvm/llvm-project/issues/102611