### PR TITLE
Fix assembly of local memory uses in symbolic loops

### DIFF
--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -891,6 +891,10 @@ static void jitc_cuda_render(Variable *v) {
             break;
 
         case VarKind::LoopPhi:
+            if (v->is_array())
+                v->reg_index = a3->reg_index;
+            break;
+
         case VarKind::LoopOutput:
             // No code generated for this node
             break;

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -982,16 +982,20 @@ static void jitc_llvm_render(Variable *v) {
             break;
 
         case VarKind::LoopPhi: {
-                const LoopData *ld = (LoopData *) a0->data;
-                size_t l = (size_t) v->literal;
-                Variable *inner_in  = jitc_var(ld->inner_in[l]),
-                         *outer_in  = jitc_var(ld->outer_in[l]),
-                         *inner_out = jitc_var(ld->inner_out[l]),
-                         *outer_out = jitc_var(ld->outer_out[l]);
-                fmt("    $v = phi $T [ $v, %l_$u_before ], [ $v, %l_$u_end ]\n",
-                    v, v, outer_in, a0->reg_index, inner_out, a0->reg_index);
-                if (outer_out && (VarKind) outer_out->kind == VarKind::LoopOutput)
-                    outer_out->reg_index = inner_in->reg_index;
+                if (v->is_array()) {
+                    v->reg_index = a3->reg_index;
+                } else {
+                    const LoopData *ld = (LoopData *) a0->data;
+                    size_t l = (size_t) v->literal;
+                    Variable *inner_in  = jitc_var(ld->inner_in[l]),
+                             *outer_in  = jitc_var(ld->outer_in[l]),
+                             *inner_out = jitc_var(ld->inner_out[l]),
+                             *outer_out = jitc_var(ld->outer_out[l]);
+                    fmt("    $v = phi $T [ $v, %l_$u_before ], [ $v, %l_$u_end ]\n",
+                        v, v, outer_in, a0->reg_index, inner_out, a0->reg_index);
+                    if (outer_out && (VarKind) outer_out->kind == VarKind::LoopOutput)
+                        outer_out->reg_index = inner_in->reg_index;
+                }
             }
             break;
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -75,24 +75,19 @@ uint32_t jitc_var_loop_start(const char *name, bool symbolic, size_t n_indices, 
         Variable *v2 = jitc_var(index);
         jitc_var_inc_ref(index, v2);
         jitc_var_inc_ref(index, v2);
+        ld->outer_in.push_back(index);
 
-        if (v2->is_array()) {
-            ld->outer_in.push_back(index);
-            ld->inner_in.push_back(index);
-            jitc_var_inc_ref(index, v2);
-        } else {
-            ld->outer_in.push_back(index);
-
-            v_phi.type = v2->type;
-            v_phi.literal = (uint64_t) i;
-            v_phi.size = v2->size;
-            v_phi.dep[3] = index;
-            jitc_var_inc_ref(ld->loop_start);
-            uint32_t index_new = jitc_var_new(v_phi, true);
-            ld->inner_in.push_back(index_new);
-            jitc_var_inc_ref(index_new);
-            indices[i] = index_new;
-        }
+        v_phi.type = v2->type;
+        v_phi.literal = (uint64_t) i;
+        v_phi.array_state = v2->array_state;
+        v_phi.array_length = v2->array_length;
+        v_phi.size = v2->size;
+        v_phi.dep[3] = index;
+        jitc_var_inc_ref(ld->loop_start);
+        uint32_t index_new = jitc_var_new(v_phi, true);
+        ld->inner_in.push_back(index_new);
+        jitc_var_inc_ref(index_new);
+        indices[i] = index_new;
     }
 
     jitc_new_scope(backend);


### PR DESCRIPTION
This PR fixes a bug when assembling local memory operations inside of a symbolic loop. In particular, it would not assemble operations that could modify the local memory variable. 

Here's an example:
```python
import drjit as dr
from drjit.cuda import UInt32

@dr.syntax()
def func():
    local = dr.alloc_local(UInt32, size=8, value=UInt32(0))

    size = UInt32(0)
    val = UInt32(0)

    while size < 5:
        val += local[size]
        size += 1
        local[size] = UInt32(4) # Never gets assembled

    print(val) # Prints '0' currently, should be 16
func()
```
(Will be added as a Dr.Jit test case)

Currently, the write operation at the end of the loop is not traversed during `jitc_var_traverse()`.
Typically, when a loop input variable (`kind == VarKind::LoopPhi`) is traversed, we also traverse its corresponding loop output variable such that we capture all the modifications done to that state variable. However, this was not done for local memory arrays. This PR adds a few changes to support that same mechanism. 