### PR TITLE
Fix erronous bounds checking on vectorized calls

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1809,6 +1809,13 @@ extern JIT_EXPORT void jit_var_self(JIT_ENUM JitBackend backend,
  * \param n_inst
  *     The number of instances (must be >= 1)
  *
+ * \param max_inst_id
+ *     Maximum instance index that might be referenced
+ *
+ * \param inst_id
+ *     Pointer to an array of all possible instance indices that might be
+ *     referenced
+ *
  * \param n_in
  *     The number of input variables
  *
@@ -1832,7 +1839,8 @@ extern JIT_EXPORT void jit_var_self(JIT_ENUM JitBackend backend,
  *     are written into this argument (size <tt>n_out_nested / n_inst</tt>)
  */
 extern JIT_EXPORT void jit_var_call(const char *name, int symbolic,
-                                    uint32_t self, uint32_t mask, uint32_t n_inst,
+                                    uint32_t self, uint32_t mask,
+                                    uint32_t n_inst, uint32_t max_inst_id,
                                     const uint32_t *inst_id, uint32_t n_in,
                                     const uint32_t *in, uint32_t n_out_nested,
                                     const uint32_t *out_nested,

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -992,13 +992,14 @@ void jit_var_self(JitBackend backend, uint32_t *value, uint32_t *index) {
 }
 
 void jit_var_call(const char *name, int symbolic, uint32_t self, uint32_t mask,
-                  uint32_t n_inst, const uint32_t *inst_id, uint32_t n_in,
+                  uint32_t n_inst, uint32_t max_inst_id,
+                  const uint32_t *inst_id, uint32_t n_in,
                   const uint32_t *in, uint32_t n_out_nested,
                   const uint32_t *out_nested, const uint32_t *se_offset,
                   uint32_t *out) {
     lock_guard guard(state.lock);
-    jitc_var_call(name, (bool) symbolic, self, mask, n_inst, inst_id, n_in, in,
-                  n_out_nested, out_nested, se_offset, out);
+    jitc_var_call(name, (bool) symbolic, self, mask, n_inst, max_inst_id,
+                  inst_id, n_in, in, n_out_nested, out_nested, se_offset, out);
 }
 
 void jit_aggregate(JitBackend backend, void *dst, AggregationEntry *agg,

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -27,10 +27,10 @@ extern void jitc_var_call_analyze(CallData *call, uint32_t inst_id,
 
 /// Weave a virtual function call into the computation graph
 void jitc_var_call(const char *name, bool symbolic, uint32_t self,
-                   uint32_t mask_, uint32_t n_inst, const uint32_t *inst_id,
-                   uint32_t n_in, const uint32_t *in, uint32_t n_inner_out,
-                   const uint32_t *inner_out, const uint32_t *checkpoints,
-                   uint32_t *out) {
+                   uint32_t mask_, uint32_t n_inst, uint32_t max_inst_id,
+                   const uint32_t *inst_id, uint32_t n_in, const uint32_t *in,
+                   uint32_t n_inner_out, const uint32_t *inner_out,
+                   const uint32_t *checkpoints, uint32_t *out) {
 
     const uint32_t checkpoint_mask = 0x7fffffff;
 
@@ -154,7 +154,7 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
 
         if (debug)
             mask = steal(jitc_var_check_bounds(BoundsCheckType::Call, self,
-                                               mask, n_inst + 1));
+                                               mask, max_inst_id + 1));
     }
 
     // =====================================================

--- a/src/call.h
+++ b/src/call.h
@@ -79,7 +79,7 @@ struct CallData {
 extern uint32_t jitc_var_loop_init(uint32_t *indices, uint32_t n_indices);
 
 extern void jitc_var_call(const char *domain, bool symbolic, uint32_t self,
-                          uint32_t mask, uint32_t n_inst,
+                          uint32_t mask, uint32_t n_inst, uint32_t max_inst_id,
                           const uint32_t *inst_id, uint32_t n_in,
                           const uint32_t *in, uint32_t n_inner_out,
                           const uint32_t *inner_out,

--- a/tests/triangle.cpp
+++ b/tests/triangle.cpp
@@ -34,6 +34,7 @@ using Mask = dr::CUDAArray<bool>;
 
 void demo() {
     OptixDeviceContext context = jit_optix_context();
+    jit_cuda_push_context(jit_cuda_context());
 
     // =====================================================
     // Copy vertex data to device
@@ -267,6 +268,7 @@ void demo() {
     // Cleanup
     // =====================================================
 
+    jit_cuda_pop_context();
     jit_free(d_gas);
 }
 

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -119,6 +119,7 @@ void symbolic_call(
             domain, symbolic,
             self, mask,
             (uint32_t) n_callables,
+            (uint32_t) n_callables,
             inst_id,
             (uint32_t) n_inputs,
             call_inputs,


### PR DESCRIPTION
This PR fixes an issue where the bounds checking for vectorized calls was using the effective number of targets rather than the maximum target callable ID.

Note: In symbolic vectorized calls, we still cannot detect indices that correspond to empty/freed values in the registry - we only check against the maximum possible value. Only in evaluated mode  will there be a check that the index corresponds to a valid registry entry.

A test will be added to `drjit`.