### PR TITLE
Frozen ThreadState prep

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1210,6 +1210,9 @@ extern JIT_EXPORT int jit_var_is_zero_literal(uint32_t index);
 /// Check if a variable represents a normal (not NaN/infinity) literal
 extern JIT_EXPORT int jit_var_is_finite_literal(uint32_t index);
 
+/// Check if the data field of a variable is unaligned
+extern JIT_EXPORT int jit_var_is_unaligned(uint32_t index);
+
 /**
  * \brief Resize a scalar variable to a new size
  *

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1533,13 +1533,20 @@ enum class JitFlag : uint32_t {
     /// is managed automatically and should not be set by application code.
     SymbolicScope = 1 << 18,
 
+    /// Freeze functions annotated with dr.freeze
+    KernelFreezing = 1 << 19,
+
+    /// Set to \c true when Dr.Jit is recording a frozen function
+    FreezingScope = 1 << 20,
+
     /// Default flags
     Default = (uint32_t) ConstantPropagation | (uint32_t) ValueNumbering |
               (uint32_t) FastMath | (uint32_t) SymbolicLoops |
               (uint32_t) OptimizeLoops | (uint32_t) SymbolicCalls |
               (uint32_t) MergeFunctions | (uint32_t) OptimizeCalls |
               (uint32_t) SymbolicConditionals | (uint32_t) ReuseIndices |
-              (uint32_t) ScatterReduceLocal | (uint32_t) PacketOps,
+              (uint32_t) ScatterReduceLocal | (uint32_t) PacketOps |
+              (uint32_t) KernelFreezing,
 
     // Deprecated aliases, will be removed in a future version of Dr.Jit
     LoopRecord = SymbolicLoops,
@@ -1570,6 +1577,8 @@ enum JitFlag {
     JitFlagLaunchBlocking = 1 << 16,
     JitFlagScatterReduceLocal = 1 << 17,
     JitFlagSymbolic = 1 << 18
+    KernelFreezing = 1 << 19,
+    FreezingScope = 1 << 20,
 };
 #endif
 

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1210,7 +1210,12 @@ extern JIT_EXPORT int jit_var_is_zero_literal(uint32_t index);
 /// Check if a variable represents a normal (not NaN/infinity) literal
 extern JIT_EXPORT int jit_var_is_finite_literal(uint32_t index);
 
-/// Check if the data field of a variable is unaligned
+/**
+ * \breif Check if the data field of a variable is unaligned
+ *
+ * This function returns true if the data pointer of the variable is not
+ * properly aligned in memory. Otherwise it returns false.
+ */
 extern JIT_EXPORT int jit_var_is_unaligned(uint32_t index);
 
 /**

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -677,6 +677,17 @@ int jit_var_is_finite_literal(uint32_t index) {
     }
 }
 
+int jit_var_is_unaligned(uint32_t index) {
+    if (index == 0)
+        return 0;
+
+    lock_guard guard(state.lock);
+    Variable *var = jitc_var(index);
+
+    return (JitBackend) var->backend == JitBackend::LLVM &&
+           (VarKind) var->kind == VarKind::Evaluated && var->unaligned;
+}
+
 uint32_t jit_var_resize(uint32_t index, size_t size) {
     lock_guard guard(state.lock);
     return jitc_var_resize(index, size);

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -684,8 +684,7 @@ int jit_var_is_unaligned(uint32_t index) {
     lock_guard guard(state.lock);
     Variable *var = jitc_var(index);
 
-    return (JitBackend) var->backend == JitBackend::LLVM &&
-           (VarKind) var->kind == VarKind::Evaluated && var->unaligned;
+    return (VarKind) var->kind == VarKind::Evaluated && var->unaligned;
 }
 
 uint32_t jit_var_resize(uint32_t index, size_t size) {

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -20,7 +20,7 @@
 #include "call.h"
 #include <set>
 
-static std::vector<CallData *> calls_assembled;
+std::vector<CallData *> calls_assembled;
 
 extern void jitc_var_call_analyze(CallData *call, uint32_t inst_id,
                                   uint32_t index, uint32_t &data_offset);

--- a/src/call.h
+++ b/src/call.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "internal.h"
 
 /// Encodes information about a virtual function call
@@ -75,6 +77,8 @@ struct CallData {
         checkpoints.clear();
     }
 };
+
+extern std::vector<CallData *> calls_assembled;
 
 extern uint32_t jitc_var_loop_init(uint32_t *indices, uint32_t n_indices);
 

--- a/src/cuda_ts.cpp
+++ b/src/cuda_ts.cpp
@@ -1,9 +1,12 @@
 #include "cuda_ts.h"
+#include "util.h"
 #include "var.h"
 #include "log.h"
 #include "optix.h"
 #include "eval.h"
 #include "util.h"
+
+static uint8_t *kernel_params_global = nullptr;
 
 static void submit_gpu(KernelType type, CUfunction kernel, uint32_t block_count,
                        uint32_t thread_count, uint32_t shared_mem_bytes,
@@ -38,10 +41,26 @@ static void submit_gpu(KernelType type, CUfunction kernel, uint32_t block_count,
     }
 }
 
-Task *CUDAThreadState::launch(Kernel kernel, uint32_t size,
-                              std::vector<void *> *kernel_params,
-                              uint32_t kernel_param_count,
-                              const uint8_t *kernel_params_global) {
+Task *CUDAThreadState::launch(Kernel kernel, KernelKey *, XXH128_hash_t,
+                              uint32_t size, std::vector<void *> *kernel_params,
+                              const std::vector<uint32_t> *) {
+
+    uint32_t kernel_param_count = kernel_params->size();
+
+    // Pass parameters through global memory if too large or using OptiX
+    if (uses_optix || kernel_param_count > DRJIT_CUDA_ARG_LIMIT) {
+        size_t param_size = kernel_param_count * sizeof(void *);
+        uint8_t *tmp =
+            (uint8_t *) jitc_malloc(AllocType::HostPinned, param_size);
+        kernel_params_global =
+            (uint8_t *) jitc_malloc(AllocType::Device, param_size);
+        memcpy(tmp, kernel_params->data(), param_size);
+        jitc_memcpy_async(backend, kernel_params_global, tmp, param_size);
+        jitc_free(tmp);
+        kernel_params->clear();
+        kernel_params->push_back(kernel_params_global);
+    }
+
 #if defined(DRJIT_ENABLE_OPTIX)
     if (unlikely(uses_optix))
         jitc_optix_launch(this, kernel, size, kernel_params_global,
@@ -77,6 +96,11 @@ Task *CUDAThreadState::launch(Kernel kernel, uint32_t size,
 
     if (unlikely(jit_flag(JitFlag::LaunchBlocking)))
         cuda_check(cuStreamSynchronize(stream));
+
+
+    // Cleanup global kernel parameters
+    jitc_free(kernel_params_global);
+    kernel_params_global = nullptr;
 
     return nullptr;
 }

--- a/src/cuda_ts.cpp
+++ b/src/cuda_ts.cpp
@@ -41,9 +41,11 @@ static void submit_gpu(KernelType type, CUfunction kernel, uint32_t block_count,
     }
 }
 
-Task *CUDAThreadState::launch(Kernel kernel, KernelKey *, XXH128_hash_t,
-                              uint32_t size, std::vector<void *> *kernel_params,
-                              const std::vector<uint32_t> *) {
+Task *
+CUDAThreadState::launch(Kernel kernel, KernelKey * /*key*/,
+                        XXH128_hash_t /*hash*/, uint32_t size,
+                        std::vector<void *> *kernel_params,
+                        const std::vector<uint32_t> * /*kernel_param_ids*/) {
 
     uint32_t kernel_param_count = kernel_params->size();
 

--- a/src/cuda_ts.h
+++ b/src/cuda_ts.h
@@ -64,5 +64,7 @@ struct CUDAThreadState: ThreadState{
       jitc_raise("jitc_reduce_expanded(): unsupported by CUDAThreadState!");
     }
 
+    void notify_free(const void *) override {};
+
     ~CUDAThreadState(){}
 };

--- a/src/cuda_ts.h
+++ b/src/cuda_ts.h
@@ -3,10 +3,9 @@
 
 struct CUDAThreadState: ThreadState{
 
-    Task *launch(Kernel kernel, uint32_t size,
-                 std::vector<void *> *kernel_params,
-                 uint32_t kernel_param_count,
-                 const uint8_t *kernel_params_global) override;
+    Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
+                 uint32_t size, std::vector<void *> *kernel_params,
+                 const std::vector<uint32_t> *) override;
 
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/cuda_ts.h
+++ b/src/cuda_ts.h
@@ -3,6 +3,8 @@
 
 struct CUDAThreadState: ThreadState{
 
+    void barrier() override{}
+
     Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                  uint32_t size, std::vector<void *> *kernel_params,
                  const std::vector<uint32_t> *) override;

--- a/src/cuda_ts.h
+++ b/src/cuda_ts.h
@@ -1,13 +1,13 @@
 #include "internal.h"
 #include "log.h"
 
-struct CUDAThreadState: ThreadState{
+struct CUDAThreadState : ThreadState {
 
-    void barrier() override{}
+    void barrier() override {}
 
     Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                  uint32_t size, std::vector<void *> *kernel_params,
-                 const std::vector<uint32_t> *) override;
+                 const std::vector<uint32_t> *kernel_param_ids) override;
 
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,
@@ -18,12 +18,11 @@ struct CUDAThreadState: ThreadState{
                 void *out) override;
 
     /// Reduce elements within blocks
-    void block_reduce(VarType type, ReduceOp op, const void *in,
-                      uint32_t size, uint32_t block_size, void *out) override;
+    void block_reduce(VarType type, ReduceOp op, const void *in, uint32_t size,
+                      uint32_t block_size, void *out) override;
 
     /// Compute a dot product of two equal-sized arrays
-    void reduce_dot(VarType type, const void *ptr_1,
-                    const void *ptr_2,
+    void reduce_dot(VarType type, const void *ptr_1, const void *ptr_2,
                     uint32_t size, void *out) override;
 
     /// 'All' reduction for boolean arrays
@@ -58,13 +57,14 @@ struct CUDAThreadState: ThreadState{
     // Enqueue a function to be run on the host once backend computation is done
     void enqueue_host_func(void (*callback)(void *), void *payload) override;
 
-    /// LLVM: reduce a variable that was previously expanded due to dr.ReduceOp.Expand
+    /// LLVM: reduce a variable that was previously expanded due to
+    /// dr.ReduceOp.Expand
     void reduce_expanded(VarType, ReduceOp, void *, uint32_t,
                          uint32_t) override {
-      jitc_raise("jitc_reduce_expanded(): unsupported by CUDAThreadState!");
+        jitc_raise("jitc_reduce_expanded(): unsupported by CUDAThreadState!");
     }
 
     void notify_free(const void *) override {};
 
-    ~CUDAThreadState(){}
+    ~CUDAThreadState() {}
 };

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -56,10 +56,9 @@ struct VisitedKeyHash {
 /// Auxiliary data structure needed to compute 'schedule' and 'schedule_groups'
 static tsl::robin_set<VisitedKey, VisitedKeyHash> visited;
 
-/// Kernel parameter buffer and device copy
+/// Kernel parameter buffer and variable ids
 static std::vector<void *> kernel_params;
-static uint8_t *kernel_params_global = nullptr;
-static uint32_t kernel_param_count = 0;
+static std::vector<uint32_t> kernel_param_ids;
 
 /// Ensure uniqueness of globals/callables arrays
 GlobalsMap globals_map;
@@ -231,6 +230,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
     JitBackend backend = ts->backend;
 
     kernel_params.clear();
+    kernel_param_ids.clear();
     globals.clear();
     globals_map.clear();
     alloca_size = alloca_align = -1;
@@ -320,6 +320,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
             n_params_in++;
             v->param_type = ParamType::Input;
             kernel_params.push_back(v->data);
+            kernel_param_ids.push_back(index);
         } else if (v->output_flag && v->size == group.size) {
             n_params_out++;
             v->param_type = ParamType::Output;
@@ -343,10 +344,12 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
                 dsize); // Note: unsafe to access 'v' after jitc_malloc().
 
             kernel_params.push_back(sv.data);
+            kernel_param_ids.push_back(index);
         } else if (v->is_literal() && (VarType) v->type == VarType::Pointer) {
             n_params_in++;
             v->param_type = ParamType::Input;
             kernel_params.push_back((void *) v->literal);
+            kernel_param_ids.push_back(index);
         } else {
             n_side_effects += (uint32_t) v->side_effect;
             v->param_type = ParamType::Register;
@@ -372,21 +375,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
                  "periodically running jit_eval() to break the computation "
                  "into smaller chunks.", kernel_params.size());
 
-    kernel_param_count = (uint32_t) kernel_params.size();
     n_ops_total = n_regs;
-
-    // Pass parameters through global memory if too large or using OptiX
-    if (backend == JitBackend::CUDA &&
-        (uses_optix || kernel_param_count > DRJIT_CUDA_ARG_LIMIT)) {
-        size_t size = kernel_param_count * sizeof(void *);
-        uint8_t *tmp = (uint8_t *) jitc_malloc(AllocType::HostPinned, size);
-        kernel_params_global = (uint8_t *) jitc_malloc(AllocType::Device, size);
-        memcpy(tmp, kernel_params.data(), size);
-        jitc_memcpy_async(backend, kernel_params_global, tmp, size);
-        jitc_free(tmp);
-        kernel_params.clear();
-        kernel_params.push_back(kernel_params_global);
-    }
 
     bool trace = std::max(state.log_level_stderr, state.log_level_callback) >=
                  LogLevel::Trace;
@@ -422,7 +411,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
 
     buffer.clear();
     if (backend == JitBackend::CUDA)
-        jitc_cuda_assemble(ts, group, n_regs, kernel_param_count);
+        jitc_cuda_assemble(ts, group, n_regs, kernel_params.size());
     else
         jitc_llvm_assemble(ts, group);
 
@@ -594,9 +583,8 @@ Task *jitc_run(ThreadState *ts, ScheduledGroup group) {
         cuda_check(cuEventRecord((CUevent) e.event_start, ts->stream));
     }
 
-    Task* ret_task = nullptr;
-    ret_task = ts->launch(kernel, group.size, &kernel_params,
-                          kernel_param_count, kernel_params_global);
+    Task *ret_task = ts->launch(kernel, &kernel_key, kernel_hash, group.size,
+                                &kernel_params, &kernel_param_ids);
 
     if (unlikely(jit_flag(JitFlag::KernelHistory))) {
         if (ts->backend == JitBackend::CUDA) {
@@ -739,11 +727,6 @@ void jitc_eval_impl(ThreadState *ts) {
         jitc_assemble(ts, group);
 
         scheduled_tasks.push_back(jitc_run(ts, group));
-
-        if (ts->backend == JitBackend::CUDA) {
-            jitc_free(kernel_params_global);
-            kernel_params_global = nullptr;
-        }
     }
 
     if (ts->backend == JitBackend::LLVM) {

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -725,6 +725,8 @@ void jitc_eval_impl(ThreadState *ts) {
         jitc_run(ts, group);
     }
 
+    // Ensure that subsequent kernel launches are not started before all
+    // currently scheduled tasks have finished.
     ts->barrier();
 
     /* Variables and their dependencies are now computed, hence internal edges

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -725,8 +725,8 @@ void jitc_eval_impl(ThreadState *ts) {
         jitc_run(ts, group);
     }
 
-    // Ensure that subsequent kernel launches are not started before all
-    // currently scheduled tasks have finished.
+    // The barrier ensures that subsequently launched kernel can't start to run
+    // until all kernels in the current launch have finished.
     ts->barrier();
 
     /* Variables and their dependencies are now computed, hence internal edges

--- a/src/internal.h
+++ b/src/internal.h
@@ -653,6 +653,9 @@ struct ThreadState {
     ThreadState() = default;
     ThreadState(const ThreadState &other) = default;
 
+    /// Inserts a barrier task
+    virtual void barrier() = 0;
+
     virtual Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                          uint32_t size, std::vector<void *> *kernel_params,
                          const std::vector<uint32_t> *kernel_param_ids) = 0;

--- a/src/internal.h
+++ b/src/internal.h
@@ -562,6 +562,7 @@ struct WeakRef {
         : index(index), counter(counter) { }
 };
 
+struct KernelKey;
 
 /// Represents a single stream of a parallel communication
 struct ThreadState {
@@ -652,10 +653,9 @@ struct ThreadState {
     ThreadState() = default;
     ThreadState(const ThreadState &other) = default;
 
-    virtual Task *launch(Kernel kernel, uint32_t size,
-                         std::vector<void *> *kernel_params,
-                         uint32_t kernel_param_count,
-                         const uint8_t *kernel_params_global) = 0;
+    virtual Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
+                         uint32_t size, std::vector<void *> *kernel_params,
+                         const std::vector<uint32_t> *kernel_param_ids) = 0;
 
     /// Fill a device memory region with constants of a given type
     virtual void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/internal.h
+++ b/src/internal.h
@@ -714,6 +714,8 @@ struct ThreadState {
     /// dr.ReduceOp.Expand
     virtual void reduce_expanded(VarType vt, ReduceOp op, void *data,
                                  uint32_t exp, uint32_t size) = 0;
+
+    virtual void notify_free(const void *ptr) = 0;
 };
 
 /// Key data structure for kernel source code & device ID

--- a/src/internal.h
+++ b/src/internal.h
@@ -654,10 +654,10 @@ struct ThreadState {
     ThreadState(const ThreadState &other) = default;
 
     /// Schedules a barrier taks.
-    /// Ensures that all kernel kernel launches are executed after all tasks
-    /// scheduled before the barrier.
-    /// This should be called after multiple kernels are scheduled to run in
-    /// parallel, to synchronize execution.
+    /// The barrier ensures that subsequently launched kernel can't start to run
+    /// until all kernels in the current launch have finished.
+    /// This should be called after a set of kernels have been launched in
+    /// parallel.
     virtual void barrier() = 0;
 
     virtual Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,

--- a/src/internal.h
+++ b/src/internal.h
@@ -653,7 +653,11 @@ struct ThreadState {
     ThreadState() = default;
     ThreadState(const ThreadState &other) = default;
 
-    /// Inserts a barrier task
+    /// Schedules a barrier taks.
+    /// Ensures that all kernel kernel launches are executed after all tasks
+    /// scheduled before the barrier.
+    /// This should be called after multiple kernels are scheduled to run in
+    /// parallel, to synchronize execution.
     virtual void barrier() = 0;
 
     virtual Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
@@ -715,6 +719,8 @@ struct ThreadState {
     virtual void reduce_expanded(VarType vt, ReduceOp op, void *data,
                                  uint32_t exp, uint32_t size) = 0;
 
+    /// Notify the \c ThreadState that \c jitc_free has been called on a pointer.
+    /// This is required for kernel freezing.
     virtual void notify_free(const void *ptr) = 0;
 };
 

--- a/src/llvm_ts.cpp
+++ b/src/llvm_ts.cpp
@@ -3,7 +3,6 @@
 #include "var.h"
 #include "common.h"
 #include "profile.h"
-#include "eval.h"
 #include "util.h"
 
 using Reduction = void (*) (const void *ptr, uint32_t start, uint32_t end, void *out);
@@ -287,10 +286,9 @@ static void submit_cpu(KernelType type, Func &&func, uint32_t width,
     jitc_task = new_task;
 }
 
-Task *LLVMThreadState::launch(Kernel kernel, uint32_t size,
-                              std::vector<void *> *kernel_params,
-                              uint32_t /* kernel_param_count */,
-                              const uint8_t* /* kernel_params_global */) {
+Task *LLVMThreadState::launch(Kernel kernel, KernelKey *, XXH128_hash_t,
+                              uint32_t size, std::vector<void *> *kernel_params,
+                              const std::vector<uint32_t> *) {
     Task *ret_task = nullptr;
 
     uint32_t packet_size = jitc_llvm_vector_width,

--- a/src/llvm_ts.cpp
+++ b/src/llvm_ts.cpp
@@ -290,6 +290,11 @@ static void submit_cpu(KernelType type, Func &&func, uint32_t width,
 static std::vector<Task *> scheduled_tasks;
 
 void LLVMThreadState::barrier() {
+    // All tasks in 'scheduled_tasks' have 'jitc_task' (if present) as parent.
+    // To create a barrier, we release 'jitc_task' and initialize it with a new
+    // dummy task that has all members of 'scheduled_tasks' as parents. This
+    // allows groups of kernel launches to run in parallel, while serializing
+    // subsequent groups.
     if (scheduled_tasks.size() == 1) {
         task_release(jitc_task);
         jitc_task = scheduled_tasks[0];

--- a/src/llvm_ts.cpp
+++ b/src/llvm_ts.cpp
@@ -308,9 +308,11 @@ void LLVMThreadState::barrier() {
     scheduled_tasks.clear();
 }
 
-Task *LLVMThreadState::launch(Kernel kernel, KernelKey *, XXH128_hash_t,
-                              uint32_t size, std::vector<void *> *kernel_params,
-                              const std::vector<uint32_t> *) {
+Task *
+LLVMThreadState::launch(Kernel kernel, KernelKey * /*key*/,
+                        XXH128_hash_t /*hash*/, uint32_t size,
+                        std::vector<void *> *kernel_params,
+                        const std::vector<uint32_t> * /*kernel_param_ids*/) {
     Task *ret_task = nullptr;
 
     uint32_t packet_size = jitc_llvm_vector_width,

--- a/src/llvm_ts.h
+++ b/src/llvm_ts.h
@@ -2,10 +2,9 @@
 
 struct LLVMThreadState: ThreadState{
 
-    Task *launch(Kernel kernel, uint32_t size,
-                 std::vector<void *> *kernel_params,
-                 uint32_t kernel_param_count,
-                 const uint8_t *kernel_params_global) override;
+    Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
+                 uint32_t size, std::vector<void *> *kernel_params,
+                 const std::vector<uint32_t> *) override;
 
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/llvm_ts.h
+++ b/src/llvm_ts.h
@@ -2,6 +2,8 @@
 
 struct LLVMThreadState: ThreadState{
 
+    void barrier() override;
+
     Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                  uint32_t size, std::vector<void *> *kernel_params,
                  const std::vector<uint32_t> *) override;

--- a/src/llvm_ts.h
+++ b/src/llvm_ts.h
@@ -62,5 +62,7 @@ struct LLVMThreadState: ThreadState{
     void reduce_expanded(VarType vt, ReduceOp op, void *data, uint32_t exp,
                          uint32_t size) override;
 
+    void notify_free(const void *) override {};
+
     ~LLVMThreadState(){}
 };

--- a/src/llvm_ts.h
+++ b/src/llvm_ts.h
@@ -1,6 +1,6 @@
 #include "internal.h"
 
-struct LLVMThreadState: ThreadState{
+struct LLVMThreadState : ThreadState {
 
     void barrier() override;
 
@@ -17,12 +17,11 @@ struct LLVMThreadState: ThreadState{
                 void *out) override;
 
     /// Reduce elements within blocks
-    void block_reduce(VarType type, ReduceOp op, const void *in,
-                      uint32_t size, uint32_t block_size, void *out) override;
+    void block_reduce(VarType type, ReduceOp op, const void *in, uint32_t size,
+                      uint32_t block_size, void *out) override;
 
     /// Compute a dot product of two equal-sized arrays
-    void reduce_dot(VarType type, const void *ptr_1,
-                    const void *ptr_2,
+    void reduce_dot(VarType type, const void *ptr_1, const void *ptr_2,
                     uint32_t size, void *out) override;
 
     /// 'All' reduction for boolean arrays
@@ -64,5 +63,5 @@ struct LLVMThreadState: ThreadState{
 
     void notify_free(const void *) override {};
 
-    ~LLVMThreadState(){}
+    ~LLVMThreadState() {}
 };

--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -218,6 +218,11 @@ void jitc_free(void *ptr) {
     if (!ptr)
         return;
 
+    if (thread_state_cuda)
+        thread_state_cuda->notify_free(ptr);
+    if (thread_state_llvm)
+        thread_state_llvm->notify_free(ptr);
+
     uintptr_t key = (uintptr_t) ptr;
     size_t hash = UInt64Hasher()(key);
 

--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -376,6 +376,10 @@ static ProfilerRegion profiler_region_flush_malloc_cache("jit_flush_malloc_cache
 
 /// Release all unused memory to the GPU / OS
 void jitc_flush_malloc_cache(bool warn) {
+    if (jitc_flags() & (uint32_t) JitFlag::FreezingScope)
+        jitc_raise(
+            "jit_flush_malloc_cache(): Tried to free the allocation cache "
+            "while recording a frozen function. This is not supported.");
     if (warn && !jitc_flush_malloc_cache_warned) {
         jitc_log(
             Warn,

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -1789,7 +1789,9 @@ uint32_t jitc_var_gather(uint32_t src_, uint32_t index, uint32_t mask) {
         jitc_var_eval(src);
 
     /// Perform a memcpy when this is a size-1 literal load
-    if (!result && var_info.size == 1 && var_info.literal) {
+    /// (if not freezing a function)
+    if (!result && var_info.size == 1 && var_info.literal &&
+        !(jitc_flags() & (uint32_t) JitFlag::FreezingScope)) {
         size_t size = type_size[(int) src_info.type];
         size_t pos = (size_t) jitc_var(index)->literal;
 

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -1789,7 +1789,11 @@ uint32_t jitc_var_gather(uint32_t src_, uint32_t index, uint32_t mask) {
         jitc_var_eval(src);
 
     /// Perform a memcpy when this is a size-1 literal load
-    /// (if not freezing a function)
+    /// (if not in a function freezing scope)
+    /// This optimization cannot be used when kernel freezing, since we are
+    /// copying from an offset within the evaluated variable. Operations in
+    /// \c RecordThreadState can only record if pointers are allocated with
+    /// \c jitc_malloc.
     if (!result && var_info.size == 1 && var_info.literal &&
         !(jitc_flags() & (uint32_t) JitFlag::FreezingScope)) {
         size_t size = type_size[(int) src_info.type];

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -1436,6 +1436,10 @@ void jitc_var_read(uint32_t index, size_t offset, void *dst) {
     if (v->is_literal() || v->is_undefined()) {
         memcpy(dst, &v->literal, isize);
     } else if (v->is_evaluated()) {
+        if (jitc_flags() & (uint32_t) JitFlag::FreezingScope)
+            jitc_raise("jit_var_read(): reading from evaluated variables while "
+                       "recording a frozen function is not supported!");
+
         jitc_memcpy((JitBackend) v->backend, dst,
                     (const uint8_t *) v->data + offset * isize, isize);
     } else {


### PR DESCRIPTION
This PR makes the following changes in order to prepare for frozen functions.
- A `KernelFreezing` and `FreezingScope` flags, and associated tests
- A `jit_var_is_unaligned` function, querying if a variable is unaligned
- Adds kernel_param_ids, kernel hash and kernel key to the `ThreadState::launch` funciton interface
- Moves the code, passing kernel params through global memory on CUDA to the `CudaThreadState`
- Adds a `barrier` function and implements it for `LLVM` that simplifies managing concurrency between `LLVM` kernels
- Adds a `notify_free` function to the ThreadState
- Removes the use of `cuMemcpyAsync` in `jitc_var_mem_copy`