### PR TITLE
Adapt ``jit_var_inc_ref()`` signature

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1072,18 +1072,21 @@ extern JIT_EXPORT uint32_t jit_var_mem_copy(JIT_ENUM JitBackend backend,
                                             size_t size);
 
 /// Increase the reference count of a given variable
-extern JIT_EXPORT void jit_var_inc_ref_impl(uint32_t index) JIT_NOEXCEPT;
+extern JIT_EXPORT uint32_t jit_var_inc_ref_impl(uint32_t index) JIT_NOEXCEPT;
 
 /// Decrease the reference count of a given variable
 extern JIT_EXPORT void jit_var_dec_ref_impl(uint32_t index) JIT_NOEXCEPT;
 
 #if defined(__GNUC__)
-JIT_INLINE void jit_var_inc_ref(uint32_t index) JIT_NOEXCEPT {
+JIT_INLINE uint32_t jit_var_inc_ref(uint32_t index) JIT_NOEXCEPT {
     /* If 'index' is known at compile time, it can only be zero, in
        which case we can skip the redundant call to jit_var_dec_ref */
-    if (!__builtin_constant_p(index))
-        jit_var_inc_ref_impl(index);
+    if (__builtin_constant_p(index))
+        return 0;
+    else
+        return jit_var_inc_ref_impl(index);
 }
+
 JIT_INLINE void jit_var_dec_ref(uint32_t index) JIT_NOEXCEPT {
     if (!__builtin_constant_p(index))
         jit_var_dec_ref_impl(index);

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -578,12 +578,13 @@ uint32_t jit_var_call_input(uint32_t index) {
     return jitc_var_call_input(index);
 }
 
-void jit_var_inc_ref_impl(uint32_t index) noexcept {
+uint32_t jit_var_inc_ref_impl(uint32_t index) noexcept {
     if (index == 0)
-        return;
+        return 0;
 
     lock_guard guard(state.lock);
     jitc_var_inc_ref(index);
+    return index;
 }
 
 void jit_var_dec_ref_impl(uint32_t index) noexcept {

--- a/tests/array.cpp
+++ b/tests/array.cpp
@@ -7,7 +7,7 @@ template <typename Value> struct Arr {
 
     Arr() { m_index = 0; }
     Arr(Arr &&a) : m_index(a.m_index) { a.m_index = 0; }
-    Arr(const Arr &a) : m_index(a.m_index) { jit_var_inc_ref(m_index); }
+    Arr(const Arr &a) { m_index = jit_var_inc_ref(a.m_index); }
 
     Arr &operator=(const Arr &) = delete;
     Arr &operator=(Arr &&) = delete;

--- a/tests/basics.cpp
+++ b/tests/basics.cpp
@@ -216,8 +216,7 @@ template <typename T> bool test_const_prop() {
         for (uint32_t i = 0; i < Size2; ++i) {
             uint32_t index = 0;
             if ((op == JitOp::Rcp) && values[i] == 0) {
-                index = in[i];
-                jit_var_inc_ref(index);
+                index = jit_var_inc_ref(in[i]);
             } else {
                 index = jit_var_op(op, in + i);
             }
@@ -308,8 +307,7 @@ template <typename T> bool test_const_prop() {
 
                 if (((op == JitOp::Div || op == JitOp::Mod) && values[k] == 0) ||
                     ((op == JitOp::Shr || op == JitOp::Shl) && values[k] < Value(0))) {
-                    index = in[k];
-                    jit_var_inc_ref(index);
+                    index = jit_var_inc_ref(in[k]);
                 } else {
                     index = jit_var_op(op, deps);
                 }

--- a/tests/loop.cpp
+++ b/tests/loop.cpp
@@ -75,8 +75,7 @@ inline Ref steal(uint32_t index) {
 
 inline Ref borrow(uint32_t index) {
     Ref r;
-    r.index = index;
-    jit_var_inc_ref(index);
+    r.index = jit_var_inc_ref(index);
     return r;
 }
 


### PR DESCRIPTION
This commit changes the signature of ``jit_var_inc_ref(uint32_t index)`` to return the input ``index``. This is of course redundant, but it shortens simultaneous assignments + refcounting operations:

```
variable = jit_var_inc_ref(index);
```

This is an improvement to the current pattern

```
variable = index;
jit_var_inc_ref(index);
```

which is found quite often. The change also makes AD and JIT-level reference counting more similar to each other.

Finally, there is also a small potential code generation improvement since the compiler does not have to stash the index on the stack if it is needed after the call.