### PR TITLE
Fix support for disabling ray tracing op in OptiX

### DIFF
--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -1005,6 +1005,8 @@ static void jitc_cuda_render_trace(const Variable *v,
     if (disabled) {
         for (uint32_t i = 0; i < 32; ++i)
             fmt("    mov.b32 $v_out_$u, 0;\n", v, i);
+        if (some_masked)
+            fmt("\nl_masked_$u:\n", v->reg_index);
         return;
     }
 


### PR DESCRIPTION
This partially addresses the issue https://github.com/mitsuba-renderer/mitsuba3/issues/1349 in Mitsuba.

Currently, invalid PTX is generated if a ray tracing op is intended to be disabled. This PR adds the missing label for the generated code to be valid.

Alternatively, we could also just disable this jump if ray tracing is anyway disabled. Not sure what's the cost of the jump vs setting a number of registers to 0.