### PR TITLE
All domain Registry Traversal per Backend

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -494,13 +494,14 @@ extern JIT_EXPORT void jit_registry_remove(const void *ptr);
 extern JIT_EXPORT uint32_t jit_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
-/// If the \c domain is a nullptr, it returns the largest instance ID for the given backend
+/// If the \c domain is a nullptr, it returns the number of active entries in
+/// all domains for the given backend
 extern JIT_EXPORT uint32_t jit_registry_id_bound(JitBackend backend,
                                                  const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry
 /// \c dest has to point to an array with \c jit_registry_id_bound(backend, nullptr) entries
-extern JIT_EXPORT void jit_registry_fill_ptrs(JitBackend backend, void **dest);
+extern JIT_EXPORT void jit_registry_get_pointers(JitBackend backend, void **dest);
 
 /// Return the pointer value associated with a given instance ID
 extern JIT_EXPORT void *jit_registry_ptr(JitBackend backend,

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -494,8 +494,13 @@ extern JIT_EXPORT void jit_registry_remove(const void *ptr);
 extern JIT_EXPORT uint32_t jit_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
+/// If the \c domain is a nullptr, it returns the largest instance ID for the given backend
 extern JIT_EXPORT uint32_t jit_registry_id_bound(JitBackend backend,
                                                  const char *domain);
+
+/// Fills the \c dest pointer array with all pointers registered in the registry
+/// \c dest has to point to an array with \c jit_registry_id_bound(backend, nullptr) entries
+extern JIT_EXPORT void jit_registry_fill_ptrs(JitBackend backend, void **dest);
 
 /// Return the pointer value associated with a given instance ID
 extern JIT_EXPORT void *jit_registry_ptr(JitBackend backend,

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -983,6 +983,11 @@ uint32_t jit_registry_id_bound(JitBackend backend, const char *domain) {
     return jitc_registry_id_bound(backend, domain);
 }
 
+void jit_registry_fill_ptrs(JitBackend backend, void **dest) {
+    lock_guard guard(state.lock);
+    return jitc_registry_fill_ptrs(backend, dest);
+}
+
 void *jit_registry_ptr(JitBackend backend, const char *domain, uint32_t id) {
     lock_guard guard(state.lock);
     return jitc_registry_ptr(backend, domain, id);

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -983,9 +983,9 @@ uint32_t jit_registry_id_bound(JitBackend backend, const char *domain) {
     return jitc_registry_id_bound(backend, domain);
 }
 
-void jit_registry_fill_ptrs(JitBackend backend, void **dest) {
+void jit_registry_get_pointers(JitBackend backend, void **dest) {
     lock_guard guard(state.lock);
-    return jitc_registry_fill_ptrs(backend, dest);
+    return jitc_registry_get_pointers(backend, dest);
 }
 
 void *jit_registry_ptr(JitBackend backend, const char *domain, uint32_t id) {

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -152,14 +152,14 @@ uint32_t jitc_registry_id(const void *ptr) {
 uint32_t jitc_registry_id_bound(JitBackend backend, const char *domain) {
     Registry &r = registry;
     if (!domain) {
-        uint32_t i = 0;
+        uint32_t n = 0;
         for (Domain &domain : r.domains) {
             if (domain.backend == backend)
                 for (auto ptr : domain.fwd_map)
                     if (ptr.active)
-                        i++;
+                        n++;
         }
-        return i;
+        return n;
     }
     auto it = r.domain_ids.find(DomainKey{ backend, domain });
     if (it == r.domain_ids.end())
@@ -168,16 +168,16 @@ uint32_t jitc_registry_id_bound(JitBackend backend, const char *domain) {
         return r.domains[it->second].id_bound;
 }
 
-void jitc_registry_fill_ptrs(JitBackend backend, void **dest) {
-    Registry &r = registry;
+void jitc_registry_get_pointers(JitBackend backend, void **dest) {
+    const Registry &r = registry;
 
-    uint32_t i = 0;
-    for (Domain &domain : r.domains) {
+    uint32_t n = 0;
+    for (const Domain &domain : r.domains) {
         if (domain.backend == backend)
             for (auto ptr : domain.fwd_map) {
                 if (ptr.active) {
-                    dest[i] = ptr.ptr;
-                    i++;
+                    dest[n] = ptr.ptr;
+                    n++;
                 }
             }
     }

--- a/src/registry.h
+++ b/src/registry.h
@@ -22,7 +22,12 @@ extern void jitc_registry_remove(const void *ptr);
 extern uint32_t jitc_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
+/// If the \c domain is a nullptr, it returns the largest instance ID for the given backend
 extern uint32_t jitc_registry_id_bound(JitBackend backend, const char *domain);
+
+/// Fills the \c dest pointer array with all pointers registered in the registry
+/// \c dest has to point to an array with \c jit_registry_id_bound(backend, nullptr) entries
+void extern jitc_registry_fill_ptrs(JitBackend backend, void **dest);
 
 /// Return the pointer value associated with a given instance ID
 extern void *jitc_registry_ptr(JitBackend backend, const char *domain, uint32_t id);

--- a/src/registry.h
+++ b/src/registry.h
@@ -22,12 +22,13 @@ extern void jitc_registry_remove(const void *ptr);
 extern uint32_t jitc_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
-/// If the \c domain is a nullptr, it returns the largest instance ID for the given backend
+/// If the \c domain is a nullptr, it returns the number of active entries in
+/// all domains for the given backend
 extern uint32_t jitc_registry_id_bound(JitBackend backend, const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry
 /// \c dest has to point to an array with \c jit_registry_id_bound(backend, nullptr) entries
-void extern jitc_registry_fill_ptrs(JitBackend backend, void **dest);
+void extern jitc_registry_get_pointers(JitBackend backend, void **dest);
 
 /// Return the pointer value associated with a given instance ID
 extern void *jitc_registry_ptr(JitBackend backend, const char *domain, uint32_t id);


### PR DESCRIPTION
The PR adds the option to traverse all registry entries for a backend.

This is required for function freezing, as it is not easily possible to get the domains of a variable representing a pointer, when traversing a C++ class such as a scene.
The fix is to just traverse the whole registry.

This PR makes the following changes:
- modifies the `jitc_registry_id_bound` function to return the bound over all domains in the backend if the `domain` argument is a `nullptr`
- Adds a `jitc_registry_fill_ptrs` function, taking a pointer to a memory region to fill with the registered pointers.
- Adds the backend as a field to the `Domain` struct

