### PR TITLE
Call: allow isolation per (variant, domain)

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -480,8 +480,8 @@ extern JIT_EXPORT void *jit_malloc_migrate(void *ptr, JIT_ENUM AllocType type,
  * Raises an exception when ``ptr`` is ``nullptr``, or when it has already been
  * registered with *any* domain.
  */
-extern JIT_EXPORT uint32_t jit_registry_put(JIT_ENUM JitBackend backend,
-                                            const char *domain, void *ptr);
+extern JIT_EXPORT uint32_t jit_registry_put(const char *variant, const char *domain,
+                                            uint32_t scope, void *ptr);
 
 /**
  * \brief Remove a pointer from the registry
@@ -494,21 +494,24 @@ extern JIT_EXPORT void jit_registry_remove(const void *ptr);
 extern JIT_EXPORT uint32_t jit_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
-/// If the \c domain is a nullptr, it returns the number of active entries in
-/// all domains for the given backend
-extern JIT_EXPORT uint32_t jit_registry_id_bound(JitBackend backend,
-                                                 const char *domain);
+/// If the \c domain is \c nullptr, it returns the number of active entries in
+/// all domains for the given variant.
+extern JIT_EXPORT uint32_t jit_registry_id_bound(const char *variant,
+                                                 const char *domain,
+                                                 uint32_t scope);
 
-/// Fills the \c dest pointer array with all pointers registered in the registry
-/// \c dest has to point to an array with \c jit_registry_id_bound(backend, nullptr) entries
-extern JIT_EXPORT void jit_registry_get_pointers(JitBackend backend, void **dest);
+/// Fills the \c dest pointer array with all pointers registered in the registry.
+/// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
+extern JIT_EXPORT void jit_registry_get_pointers(const char *variant, void **dest);
 
 /// Return the pointer value associated with a given instance ID
-extern JIT_EXPORT void *jit_registry_ptr(JitBackend backend,
-                                         const char *domain, uint32_t id);
+extern JIT_EXPORT void *jit_registry_ptr(const char *variant,
+                                         const char *domain, uint32_t scope,
+                                         uint32_t id);
 
 /// Return an arbitrary pointer value associated with a given domain
-extern JIT_EXPORT void *jit_registry_peek(JitBackend backend, const char *domain);
+extern JIT_EXPORT void *jit_registry_peek(const char *variant,
+                                          const char *domain, uint32_t scope);
 
 /// Disable any instances that are currently registered in the registry
 extern JIT_EXPORT void jit_registry_clear();
@@ -2175,8 +2178,9 @@ struct CallBucket {
  * set of instances.
  */
 extern JIT_EXPORT struct CallBucket *
-jit_var_call_reduce(JIT_ENUM JitBackend backend, const char *domain,
-                     uint32_t index, uint32_t *bucket_count_inout);
+jit_var_call_reduce(JIT_ENUM JitBackend backend, const char *variant,
+                    const char *domain, uint32_t scope, uint32_t index,
+                    uint32_t *bucket_count_inout);
 
 /**
  * \brief Insert a function call to a ray tracing functor into the LLVM program

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -467,10 +467,10 @@ extern JIT_EXPORT void *jit_malloc_migrate(void *ptr, JIT_ENUM AllocType type,
  *
  * This function registers the specified pointer \c ptr with the registry,
  * returning the associated ID value, which is guaranteed to be unique within
- * the specified domain \c domain. The domain is normally an identifier that is
- * associated with the "flavor" of the pointer (e.g. instances of a particular
- * class), and which ensures that the returned ID values are as low as
- * possible.
+ * the specified domain identified by the \c (variant, domain) strings.
+ * The domain is normally an identifier that is associated with the "flavor"
+ * of the pointer (e.g. instances of a particular class), and which ensures
+ * that the returned ID values are as low as possible.
  *
  * Caution: for reasons of efficiency, the \c domain parameter is assumed to a
  * static constant that will remain alive. The RTTI identifier
@@ -480,8 +480,8 @@ extern JIT_EXPORT void *jit_malloc_migrate(void *ptr, JIT_ENUM AllocType type,
  * Raises an exception when ``ptr`` is ``nullptr``, or when it has already been
  * registered with *any* domain.
  */
-extern JIT_EXPORT uint32_t jit_registry_put(const char *variant, const char *domain,
-                                            uint32_t scope, void *ptr);
+extern JIT_EXPORT uint32_t jit_registry_put(const char *variant,
+                                            const char *domain, void *ptr);
 
 /**
  * \brief Remove a pointer from the registry
@@ -497,8 +497,7 @@ extern JIT_EXPORT uint32_t jit_registry_id(const void *ptr);
 /// If the \c domain is \c nullptr, it returns the number of active entries in
 /// all domains for the given variant.
 extern JIT_EXPORT uint32_t jit_registry_id_bound(const char *variant,
-                                                 const char *domain,
-                                                 uint32_t scope);
+                                                 const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry.
 /// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
@@ -506,12 +505,11 @@ extern JIT_EXPORT void jit_registry_get_pointers(const char *variant, void **des
 
 /// Return the pointer value associated with a given instance ID
 extern JIT_EXPORT void *jit_registry_ptr(const char *variant,
-                                         const char *domain, uint32_t scope,
-                                         uint32_t id);
+                                         const char *domain, uint32_t id);
 
 /// Return an arbitrary pointer value associated with a given domain
 extern JIT_EXPORT void *jit_registry_peek(const char *variant,
-                                          const char *domain, uint32_t scope);
+                                          const char *domain);
 
 /// Disable any instances that are currently registered in the registry
 extern JIT_EXPORT void jit_registry_clear();
@@ -2155,13 +2153,14 @@ struct CallBucket {
  *
  * This function expects an array of integers, whose entries correspond to
  * pointers that have previously been registered by calling \ref
- * jit_registry_put() with domain \c domain. It then invokes \ref jit_mkperm()
- * to compute a permutation that reorders the array into coherent buckets. The
- * buckets are returned using an array of type \ref CallBucket, which contains
- * both the resolved pointer address (obtained via \ref
- * jit_registry_get_ptr()) and the variable index of an unsigned 32 bit array
- * containing the corresponding entries of the input array. The total number of
- * buckets is returned via the \c bucket_count_inout argument.
+ * jit_registry_put() with domain \c (variant, domain).
+ * It then invokes \ref jit_mkperm() to compute a permutation that reorders
+ * the array into coherent buckets. The buckets are returned using an array
+ * of type \ref CallBucket, which contains both the resolved pointer address
+ * (obtained via \ref jit_registry_get_ptr()) and the variable index of an
+ * unsigned 32 bit array containing the corresponding entries of the
+ * input array.
+ * The total number of buckets is returned via the \c bucket_count_inout argument.
  *
  * Alternatively, this function can be used to to dispatch using an arbitrary
  * index list. In this case, \c domain should be set to \c nullptr and the
@@ -2179,7 +2178,7 @@ struct CallBucket {
  */
 extern JIT_EXPORT struct CallBucket *
 jit_var_call_reduce(JIT_ENUM JitBackend backend, const char *variant,
-                    const char *domain, uint32_t scope, uint32_t index,
+                    const char *domain, uint32_t index,
                     uint32_t *bucket_count_inout);
 
 /**

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -963,9 +963,10 @@ uint32_t jit_mkperm(JitBackend backend, const uint32_t *values, uint32_t size,
     return jitc_mkperm(backend, values, size, bucket_count, perm, offsets);
 }
 
-uint32_t jit_registry_put(JitBackend backend, const char *domain, void *ptr) {
+uint32_t jit_registry_put(const char *variant, const char *domain,
+                          uint32_t scope, void *ptr) {
     lock_guard guard(state.lock);
-    return jitc_registry_put(backend, domain, ptr);
+    return jitc_registry_put(variant, domain, scope, ptr);
 }
 
 void jit_registry_remove(const void *ptr) {
@@ -978,24 +979,27 @@ uint32_t jit_registry_id(const void *ptr) {
     return jitc_registry_id(ptr);
 }
 
-uint32_t jit_registry_id_bound(JitBackend backend, const char *domain) {
+uint32_t jit_registry_id_bound(const char *variant, const char *domain,
+                               uint32_t scope) {
     lock_guard guard(state.lock);
-    return jitc_registry_id_bound(backend, domain);
+    return jitc_registry_id_bound(variant, domain, scope);
 }
 
-void jit_registry_get_pointers(JitBackend backend, void **dest) {
+void jit_registry_get_pointers(const char *variant, void **dest) {
     lock_guard guard(state.lock);
-    return jitc_registry_get_pointers(backend, dest);
+    return jitc_registry_get_pointers(variant, dest);
 }
 
-void *jit_registry_ptr(JitBackend backend, const char *domain, uint32_t id) {
+void *jit_registry_ptr(const char *variant, const char *domain, uint32_t scope,
+                       uint32_t id) {
     lock_guard guard(state.lock);
-    return jitc_registry_ptr(backend, domain, id);
+    return jitc_registry_ptr(variant, domain, scope, id);
 }
 
-void *jit_registry_peek(JitBackend backend, const char *domain) {
+void *jit_registry_peek(const char *variant, const char *domain,
+                        uint32_t scope) {
     lock_guard guard(state.lock);
-    return jitc_registry_peek(backend, domain);
+    return jitc_registry_peek(variant, domain, scope);
 }
 
 void jit_registry_clear() {
@@ -1030,11 +1034,13 @@ void jit_aggregate(JitBackend backend, void *dst, AggregationEntry *agg,
     return jitc_aggregate(backend, dst, agg, size);
 }
 
-struct CallBucket *
-jit_var_call_reduce(JitBackend backend, const char *domain, uint32_t index,
-                     uint32_t *bucket_count_inout) {
+struct CallBucket *jit_var_call_reduce(JitBackend backend, const char *variant,
+                                       const char *domain, uint32_t scope,
+                                       uint32_t index,
+                                       uint32_t *bucket_count_inout) {
     lock_guard guard(state.lock);
-    return jitc_var_call_reduce(backend, domain, index, bucket_count_inout);
+    return jitc_var_call_reduce(backend, variant, domain, scope, index,
+                                bucket_count_inout);
 }
 
 void jit_kernel_history_clear() {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -963,10 +963,9 @@ uint32_t jit_mkperm(JitBackend backend, const uint32_t *values, uint32_t size,
     return jitc_mkperm(backend, values, size, bucket_count, perm, offsets);
 }
 
-uint32_t jit_registry_put(const char *variant, const char *domain,
-                          uint32_t scope, void *ptr) {
+uint32_t jit_registry_put(const char *variant, const char *domain, void *ptr) {
     lock_guard guard(state.lock);
-    return jitc_registry_put(variant, domain, scope, ptr);
+    return jitc_registry_put(variant, domain, ptr);
 }
 
 void jit_registry_remove(const void *ptr) {
@@ -979,10 +978,9 @@ uint32_t jit_registry_id(const void *ptr) {
     return jitc_registry_id(ptr);
 }
 
-uint32_t jit_registry_id_bound(const char *variant, const char *domain,
-                               uint32_t scope) {
+uint32_t jit_registry_id_bound(const char *variant, const char *domain) {
     lock_guard guard(state.lock);
-    return jitc_registry_id_bound(variant, domain, scope);
+    return jitc_registry_id_bound(variant, domain);
 }
 
 void jit_registry_get_pointers(const char *variant, void **dest) {
@@ -990,16 +988,14 @@ void jit_registry_get_pointers(const char *variant, void **dest) {
     return jitc_registry_get_pointers(variant, dest);
 }
 
-void *jit_registry_ptr(const char *variant, const char *domain, uint32_t scope,
-                       uint32_t id) {
+void *jit_registry_ptr(const char *variant, const char *domain, uint32_t id) {
     lock_guard guard(state.lock);
-    return jitc_registry_ptr(variant, domain, scope, id);
+    return jitc_registry_ptr(variant, domain, id);
 }
 
-void *jit_registry_peek(const char *variant, const char *domain,
-                        uint32_t scope) {
+void *jit_registry_peek(const char *variant, const char *domain) {
     lock_guard guard(state.lock);
-    return jitc_registry_peek(variant, domain, scope);
+    return jitc_registry_peek(variant, domain);
 }
 
 void jit_registry_clear() {
@@ -1035,11 +1031,10 @@ void jit_aggregate(JitBackend backend, void *dst, AggregationEntry *agg,
 }
 
 struct CallBucket *jit_var_call_reduce(JitBackend backend, const char *variant,
-                                       const char *domain, uint32_t scope,
-                                       uint32_t index,
+                                       const char *domain, uint32_t index,
                                        uint32_t *bucket_count_inout) {
     lock_guard guard(state.lock);
-    return jitc_var_call_reduce(backend, variant, domain, scope, index,
+    return jitc_var_call_reduce(backend, variant, domain, index,
                                 bucket_count_inout);
 }
 

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -7,18 +7,20 @@
     license that can be found in the LICENSE file.
 */
 
+#include <set>
+#include <string.h>
+
+#include "call.h"
+#include "eval.h"
 #include "internal.h"
 #include "log.h"
-#include "var.h"
-#include "eval.h"
-#include "registry.h"
-#include "util.h"
+#include "loop.h"
 #include "op.h"
 #include "profile.h"
-#include "loop.h"
+#include "registry.h"
 #include "trace.h"
-#include "call.h"
-#include <set>
+#include "util.h"
+#include "var.h"
 
 std::vector<CallData *> calls_assembled;
 
@@ -688,7 +690,8 @@ void jitc_call_upload(ThreadState *ts) {
 }
 
 // Compute a permutation to reorder an array of registered pointers
-CallBucket *jitc_var_call_reduce(JitBackend backend, const char *domain,
+CallBucket *jitc_var_call_reduce(JitBackend backend, const char *variant,
+                                 const char *domain, uint32_t scope,
                                  uint32_t index, uint32_t *bucket_count_inout) {
 
     struct CallReduceRecord {
@@ -711,7 +714,7 @@ CallBucket *jitc_var_call_reduce(JitBackend backend, const char *domain,
 
     uint32_t bucket_count;
     if (domain)
-        bucket_count = jitc_registry_id_bound(backend, domain);
+        bucket_count = jitc_registry_id_bound(variant, domain, scope);
     else
         bucket_count = *bucket_count_inout;
 
@@ -796,7 +799,7 @@ CallBucket *jitc_var_call_reduce(JitBackend backend, const char *domain,
 
         CallBucket bucket_out;
         if (domain)
-            bucket_out.ptr = jitc_registry_ptr(backend, domain, bucket.id);
+            bucket_out.ptr = jitc_registry_ptr(variant, domain, scope, bucket.id);
         else
             bucket_out.ptr = nullptr;
 

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -691,8 +691,8 @@ void jitc_call_upload(ThreadState *ts) {
 
 // Compute a permutation to reorder an array of registered pointers
 CallBucket *jitc_var_call_reduce(JitBackend backend, const char *variant,
-                                 const char *domain, uint32_t scope,
-                                 uint32_t index, uint32_t *bucket_count_inout) {
+                                 const char *domain, uint32_t index,
+                                 uint32_t *bucket_count_inout) {
 
     struct CallReduceRecord {
         CallBucket *buckets;
@@ -714,7 +714,7 @@ CallBucket *jitc_var_call_reduce(JitBackend backend, const char *variant,
 
     uint32_t bucket_count;
     if (domain)
-        bucket_count = jitc_registry_id_bound(variant, domain, scope);
+        bucket_count = jitc_registry_id_bound(variant, domain);
     else
         bucket_count = *bucket_count_inout;
 
@@ -799,7 +799,7 @@ CallBucket *jitc_var_call_reduce(JitBackend backend, const char *variant,
 
         CallBucket bucket_out;
         if (domain)
-            bucket_out.ptr = jitc_registry_ptr(variant, domain, scope, bucket.id);
+            bucket_out.ptr = jitc_registry_ptr(variant, domain, bucket.id);
         else
             bucket_out.ptr = nullptr;
 

--- a/src/call.h
+++ b/src/call.h
@@ -91,7 +91,8 @@ extern void jitc_var_call(const char *domain, bool symbolic, uint32_t self,
 
 extern void jitc_call_upload(ThreadState *ts);
 
-extern CallBucket *jitc_var_call_reduce(JitBackend backend, const char *domain,
+extern CallBucket *jitc_var_call_reduce(JitBackend backend, const char *variant,
+                                        const char *domain, uint32_t scope,
                                         uint32_t index,
                                         uint32_t *bucket_count_out);
 

--- a/src/call.h
+++ b/src/call.h
@@ -92,8 +92,7 @@ extern void jitc_var_call(const char *domain, bool symbolic, uint32_t self,
 extern void jitc_call_upload(ThreadState *ts);
 
 extern CallBucket *jitc_var_call_reduce(JitBackend backend, const char *variant,
-                                        const char *domain, uint32_t scope,
-                                        uint32_t index,
+                                        const char *domain, uint32_t index,
                                         uint32_t *bucket_count_out);
 
 extern void jitc_var_call_assemble(CallData *call, uint32_t call_reg,

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -7,25 +7,33 @@
     license that can be found in the LICENSE file.
 */
 
+#include <queue>
+#include <string.h>
+
 #include "registry.h"
 #include "log.h"
-#include <queue>
 
-// Dr.Jit maintains an ID registry per backend and class. This class separates
-// multiple parallel data structures maintaining this information.
+// Dr.Jit maintains an ID registry per variant, class and scope.
+// This class separates multiple parallel data structures maintaining
+// this information.
 struct DomainKey {
-    JitBackend backend;
+    const char *variant;
     const char *domain;
+    uint32_t scope;
 
     struct Eq {
         bool operator()(DomainKey k1, DomainKey k2) const {
-            return k1.backend == k2.backend && strcmp(k1.domain, k2.domain) == 0;
+            return (strcmp(k1.variant, k2.variant) == 0)
+                && (strcmp(k1.domain, k2.domain) == 0)
+                && (k1.scope == k2.scope);
         }
     };
 
     struct Hash {
         size_t operator()(DomainKey k) const {
-            return hash_str(k.domain, (size_t) k.backend);
+            // TODO: is this a correct way to combine hashes?
+            return hash_str(k.variant, (size_t) k.scope)
+                 ^ hash_str(k.domain, (size_t) k.scope);
         }
     };
 };
@@ -39,7 +47,7 @@ struct Ptr {
 // Per-domain information: a forward map (index-> pointer) and a list of unused entries
 struct Domain {
     const char *name;
-    JitBackend backend;
+    const char *variant;
     uint32_t id_bound;
     std::vector<Ptr> fwd_map;
     std::priority_queue<uint32_t, std::vector<uint32_t>, std::greater<uint32_t>>
@@ -61,7 +69,8 @@ struct Registry {
 static Registry registry;
 
 /// Register a pointer with Dr.Jit's pointer registry
-uint32_t jitc_registry_put(JitBackend backend, const char *domain_name, void *ptr) {
+uint32_t jitc_registry_put(const char *variant, const char *domain_name,
+                           uint32_t scope, void *ptr) {
     Registry &r = registry;
 
     auto [it1, result1] =
@@ -70,14 +79,14 @@ uint32_t jitc_registry_put(JitBackend backend, const char *domain_name, void *pt
         jitc_raise("jit_registry_put(domain=\"%s\", ptr=%p): pointer is "
                    "already registered!", domain_name, ptr);
 
-    // Allocate a domain entry for the key (backend, domain) if unregistered
-    auto [it2, result2] = r.domain_ids.try_emplace(DomainKey{ backend, domain_name },
+    // Allocate a domain entry for the key (variant, domain, scope) if unregistered
+    auto [it2, result2] = r.domain_ids.try_emplace(DomainKey{ variant, domain_name, scope },
                                                    (uint32_t) r.domains.size());
     if (result2) {
         r.domains.emplace_back();
         Domain &domain = r.domains.back();
         domain.name = domain_name;
-        domain.backend = backend;
+        domain.variant = variant;
         domain.id_bound = 0;
     }
 
@@ -149,31 +158,33 @@ uint32_t jitc_registry_id(const void *ptr) {
     return it->second.index + 1;
 }
 
-uint32_t jitc_registry_id_bound(JitBackend backend, const char *domain) {
+uint32_t jitc_registry_id_bound(const char *variant, const char *domain,
+                                uint32_t scope) {
+    assert(variant != nullptr);
     Registry &r = registry;
     if (!domain) {
         uint32_t n = 0;
-        for (Domain &domain : r.domains) {
-            if (domain.backend == backend)
-                for (auto ptr : domain.fwd_map)
+        for (Domain &d : r.domains) {
+            if (strcmp(d.variant, variant) == 0)
+                for (auto ptr : d.fwd_map)
                     if (ptr.active)
                         n++;
         }
         return n;
     }
-    auto it = r.domain_ids.find(DomainKey{ backend, domain });
+    auto it = r.domain_ids.find(DomainKey{ variant, domain, scope });
     if (it == r.domain_ids.end())
         return 0;
     else
         return r.domains[it->second].id_bound;
 }
 
-void jitc_registry_get_pointers(JitBackend backend, void **dest) {
+void jitc_registry_get_pointers(const char *variant, void **dest) {
     const Registry &r = registry;
 
     uint32_t n = 0;
     for (const Domain &domain : r.domains) {
-        if (domain.backend == backend)
+        if (strcmp(domain.variant, variant) == 0)
             for (auto ptr : domain.fwd_map) {
                 if (ptr.active) {
                     dest[n] = ptr.ptr;
@@ -183,20 +194,21 @@ void jitc_registry_get_pointers(JitBackend backend, void **dest) {
     }
 }
 
-void *jitc_registry_ptr(JitBackend backend, const char *domain_name, uint32_t id) {
+void *jitc_registry_ptr(const char *variant, const char *domain_name,
+                        uint32_t scope, uint32_t id) {
     if (id == 0)
         return nullptr;
 
     Registry &r = registry;
-    auto it = r.domain_ids.find(DomainKey{ backend, domain_name });
+    auto it = r.domain_ids.find(DomainKey{ variant, domain_name, scope });
     void *ptr = nullptr;
 
     if (it != r.domain_ids.end()) {
         Domain &domain = r.domains[it->second];
         if (id - 1 >= domain.fwd_map.size())
-            jitc_raise("jit_registry_ptr(domain=\"%s\", id=%u): instance is "
-                       "not registered!",
-                       domain_name, id);
+            jitc_raise("jit_registry_ptr(variant=\"%s\", domain=\"%s\", scope=%u, id=%u):"
+                       " instance is not registered!",
+                       variant, domain_name, scope, id);
         Ptr entry = domain.fwd_map[id - 1];
         if (entry.active)
             ptr = entry.ptr;
@@ -205,9 +217,10 @@ void *jitc_registry_ptr(JitBackend backend, const char *domain_name, uint32_t id
     return ptr;
 }
 
-void *jitc_registry_peek(JitBackend backend, const char *domain_name) {
+void *jitc_registry_peek(const char *variant, const char *domain,
+                         uint32_t scope) {
     Registry &r = registry;
-    auto it = r.domain_ids.find(DomainKey{ backend, domain_name });
+    auto it = r.domain_ids.find(DomainKey{ variant, domain, scope });
     void *ptr = nullptr;
 
     if (it != r.domain_ids.end()) {

--- a/src/registry.h
+++ b/src/registry.h
@@ -13,7 +13,7 @@
 
 /// Register a pointer with Dr.Jit's pointer registry
 extern uint32_t jitc_registry_put(const char *variant, const char *domain,
-                                  uint32_t scope, void *ptr);
+                                  void *ptr);
 
 /// Remove a pointer from the registry
 extern void jitc_registry_remove(const void *ptr);
@@ -24,8 +24,7 @@ extern uint32_t jitc_registry_id(const void *ptr);
 /// Return the largest instance ID for the given domain
 /// If the \c domain is \c nullptr, it returns the number of active entries in
 /// all domains for the given variant.
-extern uint32_t jitc_registry_id_bound(const char *variant, const char *domain,
-                                       uint32_t scope);
+extern uint32_t jitc_registry_id_bound(const char *variant, const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry
 /// for this \c variant.
@@ -34,11 +33,10 @@ void extern jitc_registry_get_pointers(const char *variant, void **dest);
 
 /// Return the pointer value associated with a given instance ID
 extern void *jitc_registry_ptr(const char *variant, const char *domain,
-                               uint32_t scope, uint32_t id);
+                               uint32_t id);
 
 /// Return an arbitrary pointer value associated with a given domain
-extern void *jitc_registry_peek(const char *variant, const char *domain,
-                                uint32_t scope);
+extern void *jitc_registry_peek(const char *variant, const char *domain);
 
 /// Check for leaks in the registry
 extern void jitc_registry_shutdown();

--- a/src/registry.h
+++ b/src/registry.h
@@ -12,8 +12,8 @@
 #include "internal.h"
 
 /// Register a pointer with Dr.Jit's pointer registry
-extern uint32_t jitc_registry_put(JitBackend backend, const char *domain,
-                                  void *ptr);
+extern uint32_t jitc_registry_put(const char *variant, const char *domain,
+                                  uint32_t scope, void *ptr);
 
 /// Remove a pointer from the registry
 extern void jitc_registry_remove(const void *ptr);
@@ -22,19 +22,23 @@ extern void jitc_registry_remove(const void *ptr);
 extern uint32_t jitc_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
-/// If the \c domain is a nullptr, it returns the number of active entries in
-/// all domains for the given backend
-extern uint32_t jitc_registry_id_bound(JitBackend backend, const char *domain);
+/// If the \c domain is \c nullptr, it returns the number of active entries in
+/// all domains for the given variant.
+extern uint32_t jitc_registry_id_bound(const char *variant, const char *domain,
+                                       uint32_t scope);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry
-/// \c dest has to point to an array with \c jit_registry_id_bound(backend, nullptr) entries
-void extern jitc_registry_get_pointers(JitBackend backend, void **dest);
+/// for this \c variant.
+/// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
+void extern jitc_registry_get_pointers(const char *variant, void **dest);
 
 /// Return the pointer value associated with a given instance ID
-extern void *jitc_registry_ptr(JitBackend backend, const char *domain, uint32_t id);
+extern void *jitc_registry_ptr(const char *variant, const char *domain,
+                               uint32_t scope, uint32_t id);
 
 /// Return an arbitrary pointer value associated with a given domain
-extern void *jitc_registry_peek(JitBackend backend, const char *domain);
+extern void *jitc_registry_peek(const char *variant, const char *domain,
+                                uint32_t scope);
 
 /// Check for leaks in the registry
 extern void jitc_registry_shutdown();

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -74,7 +74,6 @@ void symbolic_call(
         JitBackend backend,
         const char* variant,
         const char* domain,
-        uint32_t scope,
         bool symbolic,
         uint32_t self,
         uint32_t mask,
@@ -104,7 +103,7 @@ void symbolic_call(
                 uint32_t call_index =  (uint32_t) i + 1;
 
                 void *ptr =
-                    jit_registry_ptr(variant, domain, scope, call_index);
+                    jit_registry_ptr(variant, domain, call_index);
 
                 scoped_set_self set_self(backend,
                     call_index);
@@ -184,10 +183,8 @@ TEST_BOTH(01_recorded_vcall) {
     const size_t n_inputs       = 1;
     const size_t n_outputs      = 1;
 
-    uint32_t i1 = jit_registry_put(backend_name(Backend),
-                                   domain, /* scope */ 0, &a1);
-    uint32_t i2 = jit_registry_put(backend_name(Backend),
-                                   domain, /* scope */ 0, &a2);
+    uint32_t i1 = jit_registry_put(backend_name(Backend), domain, &a1);
+    uint32_t i2 = jit_registry_put(backend_name(Backend), domain, &a2);
     jit_assert(i1 == 1 && i2 == 2);
 
     using BasePtr = Array<Base *>;
@@ -213,7 +210,6 @@ TEST_BOTH(01_recorded_vcall) {
             Backend,
             backend_name(Backend),
             domain,
-            0, /* scope */
             false, /* symbolic */
             self.index(), mask.index(),
             f_call,
@@ -271,12 +267,9 @@ TEST_BOTH(02_calling_conventions) {
     const size_t n_inputs       = 5;
     const size_t n_outputs      = 5;
 
-    uint32_t i1 =
-        jit_registry_put(backend_name(Backend), "Base", /* scope */ 0, &b1);
-    uint32_t i2 =
-        jit_registry_put(backend_name(Backend), "Base", /* scope */ 0, &b2);
-    uint32_t i3 =
-        jit_registry_put(backend_name(Backend), "Base", /* scope */ 0, &b3);
+    uint32_t i1 = jit_registry_put(backend_name(Backend), "Base", &b1);
+    uint32_t i2 = jit_registry_put(backend_name(Backend), "Base", &b2);
+    uint32_t i3 = jit_registry_put(backend_name(Backend), "Base", &b3);
     (void) i1; (void) i2; (void) i3;
 
     auto f_call = [](void *self2, uint32_t* inputs, uint32_t* outputs) {
@@ -318,7 +311,6 @@ TEST_BOTH(02_calling_conventions) {
             Backend,
             backend_name(Backend),
             domain,
-            0, /* scope */
             false, /* symbolic */
             self.index(), mask.index(),
             f_call,
@@ -375,10 +367,8 @@ TEST_BOTH(03_devirtualize) {
     const size_t n_outputs      = 3;
 
     D1 d1; D2 d2;
-    uint32_t i1 =
-        jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &d1);
-    uint32_t i2 =
-        jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &d2);
+    uint32_t i1 = jit_registry_put(backend_name(Backend), domain, &d1);
+    uint32_t i2 = jit_registry_put(backend_name(Backend), domain, &d2);
     jit_assert(i1 == 1 && i2 == 2);
 
     using BasePtr = Array<Base *>;
@@ -421,7 +411,6 @@ TEST_BOTH(03_devirtualize) {
                 Backend,
                 backend_name(Backend),
                 domain,
-                0, /* scope */
                 false, /* symbolic */
                 self.index(), call_mask.index(),
                 f_call,
@@ -499,10 +488,8 @@ TEST_BOTH(04_extra_data) {
     const size_t n_outputs      = 1;
 
     E1 e1; E2 e2;
-    uint32_t i1 =
-        jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &e1);
-    uint32_t i2 =
-        jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &e2);
+    uint32_t i1 = jit_registry_put(backend_name(Backend), domain, &e1);
+    uint32_t i2 = jit_registry_put(backend_name(Backend), domain, &e2);
     jit_assert(i1 == 1 && i2 == 2);
 
     auto f_call = [](void *self2, uint32_t* inputs, uint32_t* outputs) {
@@ -537,7 +524,6 @@ TEST_BOTH(04_extra_data) {
                 Backend,
                 backend_name(Backend),
                 domain,
-                0, /* scope */
                 false, /* symbolic */
                 self.index(), mask.index(),
                 f_call,
@@ -596,10 +582,8 @@ TEST_BOTH_FP32(05_side_effects) {
         jit_set_flag(JitFlag::OptimizeCalls, i);
 
         F1 f1; F2 f2;
-        uint32_t i1 =
-            jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &f1);
-        uint32_t i2 =
-            jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &f2);
+        uint32_t i1 = jit_registry_put(backend_name(Backend), domain, &f1);
+        uint32_t i2 = jit_registry_put(backend_name(Backend), domain, &f2);
         jit_assert(i1 == 1 && i2 == 2);
 
         Mask mask = Mask::steal(jit_var_bool(Backend, true));
@@ -608,7 +592,6 @@ TEST_BOTH_FP32(05_side_effects) {
             Backend,
             backend_name(Backend),
             domain,
-            0, /* scope */
             false, /* symbolic */
             self.index(), mask.index(),
             f_call,
@@ -669,10 +652,8 @@ TEST_BOTH_FP32(06_side_effects_only_once) {
         jit_set_flag(JitFlag::OptimizeCalls, i);
 
         G1 g1; G2 g2;
-        uint32_t i1 =
-            jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &g1);
-        uint32_t i2 =
-            jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &g2);
+        uint32_t i1 = jit_registry_put(backend_name(Backend), domain, &g1);
+        uint32_t i2 = jit_registry_put(backend_name(Backend), domain, &g2);
         jit_assert(i1 == 1 && i2 == 2);
 
         uint32_t outputs[n_outputs] = { 0 };
@@ -683,7 +664,6 @@ TEST_BOTH_FP32(06_side_effects_only_once) {
             Backend,
             backend_name(Backend),
             domain,
-            0, /* scope */
             false, /* symbolic */
             self.index(), mask.index(),
             f_call,
@@ -739,10 +719,8 @@ TEST_BOTH(07_multiple_calls) {
     Float x = opaque<Float>(10, 1);
 
     H1 h1; H2 h2;
-    uint32_t i1 =
-        jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &h1);
-    uint32_t i2 =
-        jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &h2);
+    uint32_t i1 = jit_registry_put(backend_name(Backend), domain, &h1);
+    uint32_t i2 = jit_registry_put(backend_name(Backend), domain, &h2);
     jit_assert(i1 == 1 && i2 == 2);
 
     auto f_call = [](void *self2, uint32_t* inputs, uint32_t* outputs) {
@@ -766,7 +744,6 @@ TEST_BOTH(07_multiple_calls) {
             Backend,
             backend_name(Backend),
             domain,
-            0, /* scope */
             false, /* symbolic */
             self.index(), mask.index(),
             f_call,
@@ -780,7 +757,6 @@ TEST_BOTH(07_multiple_calls) {
             Backend,
             backend_name(Backend),
             domain,
-            0, /* scope */
             false, /* symbolic */
             self.index(), mask.index(),
             f_call,
@@ -831,14 +807,12 @@ TEST_BOTH(08_big) {
 
     for (int i = 0; i < n1; ++i) {
         v1[i].v = (Float) (float) i;
-        i1[i] = jit_registry_put(backend_name(Backend), domain1, /* scope */ 0,
-                                 &v1[i]);
+        i1[i]   = jit_registry_put(backend_name(Backend), domain1, &v1[i]);
     }
 
     for (int i = 0; i < n2; ++i) {
         v2[i].v = (Float) (100.f + (float) i);
-        i2[i] = jit_registry_put(backend_name(Backend), domain2, /* scope */ 0,
-                                 &v2[i]);
+        i2[i]   = jit_registry_put(backend_name(Backend), domain2, &v2[i]);
     }
 
     using Base1Ptr = Array<Base1 *>;
@@ -878,7 +852,6 @@ TEST_BOTH(08_big) {
             Backend,
             backend_name(Backend),
             domain1,
-            0, /* scope */
             false, /* symbolic */
             self1.index(), mask1.index(),
             f_call1,
@@ -889,7 +862,6 @@ TEST_BOTH(08_big) {
             Backend,
             backend_name(Backend),
             domain2,
-            0, /* scope */
             false, /* symbolic */
             self2.index(), mask2.index(),
             f_call2,
@@ -939,10 +911,8 @@ TEST_BOTH(09_self) {
     const size_t n_outputs      = 1;
 
     I i1, i2;
-    uint32_t i1_id =
-        jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &i1);
-    uint32_t i2_id =
-        jit_registry_put(backend_name(Backend), domain, /* scope */ 0, &i2);
+    uint32_t i1_id = jit_registry_put(backend_name(Backend), domain, &i1);
+    uint32_t i2_id = jit_registry_put(backend_name(Backend), domain, &i2);
 
     UInt32 self(i1_id, i2_id);
 
@@ -961,7 +931,6 @@ TEST_BOTH(09_self) {
         Backend,
         backend_name(Backend),
         domain,
-        0, /* scope */
         false, /* symbolic */
         self.index(), mask.index(),
         f_call,
@@ -1014,7 +983,6 @@ TEST_BOTH(10_recursion) {
                 Backend,
                 backend_name(Backend),
                 "Base1",
-                0, /* scope */
                 true, /* symbolic */
                 ptr.index(), mask.index(),
                 f_call,
@@ -1029,14 +997,10 @@ TEST_BOTH(10_recursion) {
     i11.c = 2;
     i12.c = 3;
     I2 i21, i22;
-    uint32_t i11_id =
-        jit_registry_put(backend_name(Backend), "Base1", /* scope */ 0, &i11);
-    uint32_t i12_id =
-        jit_registry_put(backend_name(Backend), "Base1", /* scope */ 0, &i12);
-    uint32_t i21_id =
-        jit_registry_put(backend_name(Backend), "Base2", /* scope */ 0, &i21);
-    uint32_t i22_id =
-        jit_registry_put(backend_name(Backend), "Base2", /* scope */ 0, &i22);
+    uint32_t i11_id = jit_registry_put(backend_name(Backend), "Base1", &i11);
+    uint32_t i12_id = jit_registry_put(backend_name(Backend), "Base1", &i12);
+    uint32_t i21_id = jit_registry_put(backend_name(Backend), "Base2", &i21);
+    uint32_t i22_id = jit_registry_put(backend_name(Backend), "Base2", &i22);
 
     const size_t n_callables    = 2;
     const size_t n_inputs       = 2;
@@ -1064,7 +1028,6 @@ TEST_BOTH(10_recursion) {
         Backend,
         backend_name(Backend),
         "Base2",
-        0, /* scope */
         false, /* symbolic */
         self2.index(), mask.index(),
         f_call,
@@ -1118,7 +1081,6 @@ TEST_BOTH(11_recursion_with_local) {
                 Backend,
                 backend_name(Backend),
                 "Base1",
-                0, /* scope */
                 true, /* symbolic */
                 ptr.index(), mask.index(),
                 f_call,
@@ -1133,14 +1095,10 @@ TEST_BOTH(11_recursion_with_local) {
     i11.c = dr::opaque<Float>(2);
     i12.c = dr::opaque<Float>(3);
     I2 i21, i22;
-    uint32_t i11_id =
-        jit_registry_put(backend_name(Backend), "Base1", /* scope */ 0, &i11);
-    uint32_t i12_id =
-        jit_registry_put(backend_name(Backend), "Base1", /* scope */ 0, &i12);
-    uint32_t i21_id =
-        jit_registry_put(backend_name(Backend), "Base2", /* scope */ 0, &i21);
-    uint32_t i22_id =
-        jit_registry_put(backend_name(Backend), "Base2", /* scope */ 0, &i22);
+    uint32_t i11_id = jit_registry_put(backend_name(Backend), "Base1", &i11);
+    uint32_t i12_id = jit_registry_put(backend_name(Backend), "Base1", &i12);
+    uint32_t i21_id = jit_registry_put(backend_name(Backend), "Base2", &i21);
+    uint32_t i22_id = jit_registry_put(backend_name(Backend), "Base2", &i22);
 
     const size_t n_callables    = 2;
     const size_t n_inputs       = 2;
@@ -1168,7 +1126,6 @@ TEST_BOTH(11_recursion_with_local) {
         Backend,
         backend_name(Backend),
         "Base2",
-        0, /* scope */
         false, /* symbolic */
         self2.index(), mask.index(),
         f_call,
@@ -1213,7 +1170,6 @@ TEST_BOTH_FP32(12_nested_with_side_effects) {
                 Backend,
                 backend_name(Backend),
                 "Base",
-                0, /* scope */
                 true, /* symbolic */
                 self.index(), mask.index(),
                 f_call,
@@ -1251,10 +1207,8 @@ TEST_BOTH_FP32(12_nested_with_side_effects) {
         jit_set_flag(JitFlag::OptimizeCalls, i);
 
         F1 f1; F2 f2;
-        uint32_t i1 =
-            jit_registry_put(backend_name(Backend), "Base", /* scope */ 0, &f1);
-        uint32_t i2 =
-            jit_registry_put(backend_name(Backend), "Base", /* scope */ 0, &f2);
+        uint32_t i1 = jit_registry_put(backend_name(Backend), "Base", &f1);
+        uint32_t i2 = jit_registry_put(backend_name(Backend), "Base", &f2);
         jit_assert(i1 == 1 && i2 == 2);
 
         Mask mask = Mask::steal(jit_var_bool(Backend, true));
@@ -1263,7 +1217,6 @@ TEST_BOTH_FP32(12_nested_with_side_effects) {
             Backend,
             backend_name(Backend),
             "Base",
-            0, /* scope */
             false, /* symbolic */
             self.index(), mask.index(),
             f_call,
@@ -1322,10 +1275,8 @@ TEST_BOTH(13_load_bool_data) {
         jit_set_flag(JitFlag::OptimizeCalls, i);
 
         F1 f1; F2 f2;
-        uint32_t i1 =
-            jit_registry_put(backend_name(Backend), "Base", /* scope */ 0, &f1);
-        uint32_t i2 =
-            jit_registry_put(backend_name(Backend), "Base", /* scope */ 0, &f2);
+        uint32_t i1 = jit_registry_put(backend_name(Backend), "Base", &f1);
+        uint32_t i2 = jit_registry_put(backend_name(Backend), "Base", &f2);
         jit_assert(i1 == 1 && i2 == 2);
 
         uint32_t outputs[n_outputs] = { 0 };
@@ -1336,7 +1287,6 @@ TEST_BOTH(13_load_bool_data) {
             Backend,
             backend_name(Backend),
             "Base",
-            0, /* scope */
             false, /* symbolic */
             self.index(), mask.index(),
             f_call,

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -72,7 +72,9 @@ namespace drjit {
 template <size_t n_callables, size_t n_inputs, size_t n_outputs>
 void symbolic_call(
         JitBackend backend,
+        const char* variant,
         const char* domain,
+        uint32_t scope,
         bool symbolic,
         uint32_t self,
         uint32_t mask,
@@ -101,10 +103,10 @@ void symbolic_call(
 
                 uint32_t call_index =  (uint32_t) i + 1;
 
-                void *ptr = jit_registry_ptr(backend, domain,
-                    call_index);
+                void *ptr =
+                    jit_registry_ptr(variant, domain, scope, call_index);
 
-                scoped_set_self set_self(backend, 
+                scoped_set_self set_self(backend,
                     call_index);
 
                 call(ptr, call_inputs, &rv_values[i * n_outputs]);
@@ -201,7 +203,7 @@ TEST_BOTH(01_recorded_vcall) {
 
         Float y = Float::steal(outputs[0]);
 
-        jit_assert(strcmp(y.str(), 
+        jit_assert(strcmp(y.str(),
             "[0, 22, 204, 0, 28, 210, 0, 34, 216, 0]") == 0);
     }
 
@@ -286,7 +288,7 @@ TEST_BOTH(02_calling_conventions) {
 
         Mask mask = Mask::steal(jit_var_bool(Backend, true));
 
-        uint32_t inputs[n_inputs] = { 
+        uint32_t inputs[n_inputs] = {
             p0.index(), p1.index(), p2.index(), p3.index(), p4.index() };
         uint32_t outputs[n_outputs] = { 0 };
 
@@ -508,7 +510,7 @@ TEST_BOTH(04_extra_data) {
                 outputs);
 
             Float result = Float::steal(outputs[0]);
-            jit_assert(strcmp(result.str(), 
+            jit_assert(strcmp(result.str(),
                 "[0, 9, 13, 0, 21, 28, 0, 33, 43, 0]") == 0);
         }
     }


### PR DESCRIPTION
In the registry, the `backend` part of the key is replaced by a string-typed `variant`.

See https://github.com/mitsuba-renderer/drjit/pull/313.