### PR TITLE
Scatter: Avoid evaluation within a symbolic scope

### DIFF
--- a/src/op.cpp
+++ b/src/op.cpp
@@ -2385,10 +2385,12 @@ uint32_t jitc_var_scatter(uint32_t target_, uint32_t value, uint32_t index_,
     // operation like dr.if_stmt()), then use that instead.
     target_v = jitc_var(target);
 
+    // Flush any potential conflicting writes by evaluating the target before the scatter
     if (target_v->is_dirty() && op == ReduceOp::Identity
                              && mode != ReduceMode::Permute
                              && mode != ReduceMode::NoConflicts) {
-        jitc_var_eval(target);
+        bool raise_dirty_error = !jit_flag(JitFlag::SymbolicScope);
+        jitc_var_eval(target, raise_dirty_error);
         target_v = jitc_var(target);
     }
 
@@ -2499,10 +2501,12 @@ uint32_t jitc_var_scatter_packet(size_t n, uint32_t target_,
     const uint32_t target_size = target_v->size;
     const JitBackend backend = var_info.backend;
 
+    // Flush any potential conflicting writes by evaluating the target before the scatter
     if (target_v->is_dirty() && op == ReduceOp::Identity
                              && mode != ReduceMode::Permute
                              && mode != ReduceMode::NoConflicts) {
-        jitc_var_eval(target);
+        bool raise_dirty_error = !jit_flag(JitFlag::SymbolicScope);
+        jitc_var_eval(target, raise_dirty_error);
         jitc_var_eval(index_);
         jitc_var_eval(mask);
 

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -1405,7 +1405,7 @@ uint32_t jitc_var_schedule_force(uint32_t index, int *rv) {
 
 
 /// Evaluate the variable \c index right away if it is unevaluated/dirty.
-int jitc_var_eval(uint32_t index) {
+int jitc_var_eval(uint32_t index, bool raise_dirty_error) {
     if (!jitc_var_schedule(index))
         return 0;
 
@@ -1413,7 +1413,7 @@ int jitc_var_eval(uint32_t index) {
     jitc_eval(thread_state(v->backend));
 
     v = jitc_var(index);
-    if (unlikely(v->is_dirty()))
+    if (unlikely(v->is_dirty() && raise_dirty_error))
         jitc_raise_dirty_error(index);
     else if (unlikely(!v->is_evaluated() || !v->data))
         jitc_raise("jit_var_eval(): invalid/uninitialized variable r%u!", index);

--- a/src/var.h
+++ b/src/var.h
@@ -163,7 +163,7 @@ extern void jitc_var_eval_literal(uint32_t index, Variable *v);
 extern void jitc_var_eval_undefined(uint32_t index, Variable *v);
 
 /// Evaluate the variable \c index right away, if it is unevaluated/dirty.
-extern int jitc_var_eval(uint32_t index);
+extern int jitc_var_eval(uint32_t index, bool raise_dirty_error = true);
 
 /// Return the pointer location of the variable, evaluate if needed
 extern uint32_t jitc_var_data(uint32_t index, bool eval_dirty, void **ptr_out);


### PR DESCRIPTION
When performing scatters within symbolic loops, there is already an implied precondition that writes are non-conflicting across iterations.

So if a user want to call `scatter` multiple times in the loop body the same precondition should be assumed.