### PR TITLE
Fix `jit_var_tile`. Thanks to @mcrescas

### DIFF
--- a/src/var.cpp
+++ b/src/var.cpp
@@ -2144,10 +2144,10 @@ uint32_t jitc_var_tile(uint32_t index, uint32_t block_size) {
 
     jitc_check_size("jit_var_tile", out_size);
 
-    uint64_t bsize_u64 = block_size, one_u64 = 1;
+    uint64_t vsize_u64 = size, one_u64 = 1;
     Ref counter = steal(jitc_var_counter(backend, out_size, true)),
-        bsize   = steal(jitc_var_literal(backend, VarType::UInt32, &bsize_u64, 1, 0)),
-        offset  = steal(jitc_var_div(counter, bsize)),
+        vsize   = steal(jitc_var_literal(backend, VarType::UInt32, &vsize_u64, 1, 0)),
+        offset  = steal(jitc_var_mod(counter, vsize)),
         t_mask  = steal(jitc_var_literal(backend, VarType::Bool, &one_u64, 1, 0));
 
     return jitc_var_gather(index, offset, t_mask);

--- a/tests/array.cpp
+++ b/tests/array.cpp
@@ -391,3 +391,11 @@ TEST_BOTH_FLOAT_AGNOSTIC(13_mask_conflict) {
 
     jit_assert(ctr_1.read(0) == 1 && ctr_2.read(0) == 2);
 }
+
+TEST_BOTH_FLOAT_AGNOSTIC(14_tile_simple) {
+    UInt32 x = tile(arange<UInt32>(3), 1);
+    jit_assert(strcmp(x.str(), "[0, 1, 2]") == 0);
+
+    x = tile(arange<UInt32>(3), 3);
+    jit_assert(strcmp(x.str(), "[0, 1, 2, 0, 1, 2, 0, 1, 2]") == 0);
+}

--- a/tests/test.h
+++ b/tests/test.h
@@ -144,3 +144,8 @@ private:
     LogLevel m_stderr_level;
 };
 
+template <typename Array>
+Array tile(const Array &source, uint32_t count) {
+    return Array::steal(jit_var_tile(source.index(), count));
+}
+


### PR DESCRIPTION
Previously, `dr::tile` behaviour wasn't consistent with Python counterpart

```
dr.tile(dr.arange(dr.llvm.UInt32, 3), 3)
[0, 1, 2, 0, 1, 2, 0, 1, 2]
```

```
dr::tile(dr::arange<UInt32>(3), 3))
[0, 0, 0, 1, 1, 1, 2, 2, 2]
```

and seemed to be performing a repeat instead.  Added some small tests as well.