### PR TITLE
scatter_inc: return correct width even in fully masked case

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1011,6 +1011,7 @@ extern JIT_EXPORT void jit_var_scatter_add_kahan(uint32_t *target_1,
  * The main difference is that this variant returns the *old* value before the
  * atomic write (in contrast to the more general scatter reduction, where doing
  * so would be rather complicated).
+ * Note that the value returned for masked lanes is undefined.
  *
  * This operation is a building block for stream compaction: threads can
  * scatter-increment a global counter to request a spot in an array.

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -2085,8 +2085,16 @@ uint32_t jitc_var_scatter_inc(uint32_t *target_p, uint32_t index, uint32_t mask)
     if ((VarType) index_v->type != VarType::UInt32)
         jitc_raise("jit_var_scatter_inc(): 'index' must be an unsigned 32-bit array.");
 
-    if (mask_v->is_literal() && mask_v->literal == 0)
-        return 0;
+    if (mask_v->is_literal() && mask_v->literal == 0) {
+        // The return value is undefined (no need to gather the current
+        // values at these indices), but at least let's return an array
+        // of the correct width. We use a large value to make it clear
+        // that it is an arbitrary number, not the previous value of
+        // the target array.
+        uint64_t minus_one = (uint64_t) -1;
+        return jitc_var_literal(var_info.backend, VarType::UInt32, &minus_one,
+                                var_info.size, 0);
+    }
 
     uint32_t flags = jitc_flags();
     var_info.symbolic |= (flags & (uint32_t) JitFlag::SymbolicScope) != 0;

--- a/tests/mem.cpp
+++ b/tests/mem.cpp
@@ -317,4 +317,11 @@ TEST_BOTH(18_scatter_inc_mask) {
             abort();
         }
     }
+
+    // With an all-false literal mask, an array of
+    // the correct width should still be returned.
+    UInt32 idx = zeros<UInt32>(7);
+    Mask all_false = Mask(false);
+    UInt32 arbitrary = scatter_inc(counter, idx, all_false);
+    jit_assert(jit_var_size(arbitrary.index()) == 7);
 }

--- a/tests/test.h
+++ b/tests/test.h
@@ -216,7 +216,7 @@ template <typename... Args> static void make_opaque(Args &&...args) {
 /// Constructable type, used to construct frozen function outputs
 template <typename T, typename = void> struct constructable {
     static constexpr bool value = false;
-    static T construct(const std::function<uint32_t()> &cb) {
+    static T construct(const std::function<uint32_t()> & /*cb*/) {
         static_assert(sizeof(T) == 0, "Could not construct type!");
     }
 };


### PR DESCRIPTION
With a small unit test.

Closes https://github.com/mitsuba-renderer/drjit-core/issues/113.