### PR TITLE
Frozen ThreadState Fixes

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -494,15 +494,11 @@ extern JIT_EXPORT void jit_registry_remove(const void *ptr);
 extern JIT_EXPORT uint32_t jit_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
-/// If the \c domain is \c nullptr, it returns the number of active entries in
-/// all domains for the given variant. If the \c variant is empty as well, it
-/// traverses all registry entries.
 extern JIT_EXPORT uint32_t jit_registry_id_bound(const char *variant,
                                                  const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry.
 /// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
-/// If variant is \c nullptr, it traverses all registry entries.
 extern JIT_EXPORT void jit_registry_get_pointers(const char *variant,
                                                  const char *domain_name,
                                                  void **dest);

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -503,7 +503,9 @@ extern JIT_EXPORT uint32_t jit_registry_id_bound(const char *variant,
 /// Fills the \c dest pointer array with all pointers registered in the registry.
 /// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
 /// If variant is \c nullptr, it traverses all registry entries.
-extern JIT_EXPORT void jit_registry_get_pointers(const char *variant, void **dest);
+extern JIT_EXPORT void jit_registry_get_pointers(const char *variant,
+                                                 const char *domain_name,
+                                                 void **dest);
 
 /// Return the pointer value associated with a given instance ID
 extern JIT_EXPORT void *jit_registry_ptr(const char *variant,

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -2360,8 +2360,14 @@ extern JIT_EXPORT const char *jit_type_name(JIT_ENUM VarType type) JIT_NOEXCEPT;
 struct VarInfo {
     JitBackend backend;
     VarType type;
+    VarState state;
     size_t size;
+    union{
+        uint64_t literal;
+        void *data;
+    };
     bool is_array;
+    bool unaligned;
 };
 
 /**

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -495,12 +495,14 @@ extern JIT_EXPORT uint32_t jit_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
 /// If the \c domain is \c nullptr, it returns the number of active entries in
-/// all domains for the given variant.
+/// all domains for the given variant. If the \c variant is empty as well, it
+/// traverses all registry entries.
 extern JIT_EXPORT uint32_t jit_registry_id_bound(const char *variant,
                                                  const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry.
 /// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
+/// If variant is \c nullptr, it traverses all registry entries.
 extern JIT_EXPORT void jit_registry_get_pointers(const char *variant, void **dest);
 
 /// Return the pointer value associated with a given instance ID

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -977,9 +977,10 @@ uint32_t jit_registry_id_bound(const char *variant, const char *domain) {
     return jitc_registry_id_bound(variant, domain);
 }
 
-void jit_registry_get_pointers(const char *variant, void **dest) {
+void jit_registry_get_pointers(const char *variant, const char *domain_name,
+                               void **dest) {
     lock_guard guard(state.lock);
-    return jitc_registry_get_pointers(variant, dest);
+    return jitc_registry_get_pointers(variant, domain_name, dest);
 }
 
 void *jit_registry_ptr(const char *variant, const char *domain, uint32_t id) {

--- a/src/record_ts.cpp
+++ b/src/record_ts.cpp
@@ -163,12 +163,14 @@ struct ReplayVariable {
             // Copy the variable, so that it isn't changed by this recording.
             // Captured variables are only used for vcall offset buffers, which
             // are not supposed to change between replay calls.
-            index = jitc_var_copy(index);
 
             Variable *v = jitc_var(index);
-            data        = v->data;
             alloc_size  = v->size * type_size[v->type];
             data_size   = alloc_size;
+            if (!dry_run) {
+                index = jitc_var_copy(index);
+                data  = v->data;
+            }
         }
     }
 

--- a/src/record_ts.cpp
+++ b/src/record_ts.cpp
@@ -1933,6 +1933,7 @@ Recording *jitc_freeze_stop(JitBackend backend, const uint32_t *outputs,
  *     The size of the offset buffer in bytes.
  */
 uint32_t RecordThreadState::capture_call_offset(const void *ptr, size_t dsize) {
+    jitc_log(LogLevel::Debug, "capture_call_offset(ptr=%p, dsize=%zu)", ptr, dsize);
     uint32_t size = dsize / type_size[(uint32_t) VarType::UInt64];
 
     AllocType atype =
@@ -2149,6 +2150,13 @@ void jitc_freeze_destroy(Recording *recording) {
     for (RecordedVariable &rv : recording->recorded_variables) {
         if (rv.init == RecordedVarInit::Captured) {
             jitc_var_dec_ref(rv.index);
+        }
+    }
+    for (Operation &op : recording->operations){
+        if (op.uses_optix){
+            jitc_free(op.sbt->hitgroupRecordBase);
+            jitc_free(op.sbt->missRecordBase);
+            delete op.sbt;
         }
     }
     delete recording;

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -159,7 +159,7 @@ uint32_t jitc_registry_id_bound(const char *variant, const char *domain) {
     if (!domain) {
         uint32_t n = 0;
         for (Domain &d : r.domains) {
-            if (strcmp(d.variant, variant) == 0)
+            if (variant == nullptr || strcmp(d.variant, variant) == 0)
                 for (auto ptr : d.fwd_map)
                     if (ptr.active)
                         n++;
@@ -178,7 +178,7 @@ void jitc_registry_get_pointers(const char *variant, void **dest) {
 
     uint32_t n = 0;
     for (const Domain &domain : r.domains) {
-        if (strcmp(domain.variant, variant) == 0)
+        if (variant == nullptr || strcmp(domain.variant, variant) == 0)
             for (auto ptr : domain.fwd_map) {
                 if (ptr.active) {
                     dest[n] = ptr.ptr;

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -155,17 +155,8 @@ uint32_t jitc_registry_id(const void *ptr) {
 
 uint32_t jitc_registry_id_bound(const char *variant, const char *domain) {
     assert(variant != nullptr);
+    assert(domain != nullptr);
     Registry &r = registry;
-    if (!domain) {
-        uint32_t n = 0;
-        for (Domain &d : r.domains) {
-            if (variant == nullptr || strcmp(d.variant, variant) == 0)
-                for (auto ptr : d.fwd_map)
-                    if (ptr.active)
-                        n++;
-        }
-        return n;
-    }
     auto it = r.domain_ids.find(DomainKey{ variant, domain });
     if (it == r.domain_ids.end())
         return 0;
@@ -173,21 +164,22 @@ uint32_t jitc_registry_id_bound(const char *variant, const char *domain) {
         return r.domains[it->second].id_bound;
 }
 
-void jitc_registry_get_pointers(const char *variant, const char *domain_name,
+void jitc_registry_get_pointers(const char *variant, const char *domain,
                                 void **dest) {
+    assert(variant != nullptr);
+    assert(domain != nullptr);
     const Registry &r = registry;
-
-    uint32_t n = 0;
-    for (const Domain &domain : r.domains) {
-        if (variant == nullptr ||
-            (strcmp(domain.variant, variant) == 0 &&
-             (domain_name == nullptr || strcmp(domain.name, domain_name) == 0)))
-            for (auto ptr : domain.fwd_map) {
-                if (ptr.active) {
-                    dest[n] = ptr.ptr;
-                    n++;
-                }
+    auto it = r.domain_ids.find(DomainKey{ variant, domain });
+    if (it == r.domain_ids.end())
+        return;
+    else{
+        const Domain &d = r.domains[it->second];
+        for (uint32_t i = 0; i < d.fwd_map.size(); i++) {
+            auto ptr = d.fwd_map[i];
+            if (ptr.active) {
+                dest[i] = ptr.ptr;
             }
+        }
     }
 }
 

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -173,12 +173,15 @@ uint32_t jitc_registry_id_bound(const char *variant, const char *domain) {
         return r.domains[it->second].id_bound;
 }
 
-void jitc_registry_get_pointers(const char *variant, void **dest) {
+void jitc_registry_get_pointers(const char *variant, const char *domain_name,
+                                void **dest) {
     const Registry &r = registry;
 
     uint32_t n = 0;
     for (const Domain &domain : r.domains) {
-        if (variant == nullptr || strcmp(domain.variant, variant) == 0)
+        if (variant == nullptr ||
+            (strcmp(domain.variant, variant) == 0 &&
+             (domain_name == nullptr || strcmp(domain.name, domain_name) == 0)))
             for (auto ptr : domain.fwd_map) {
                 if (ptr.active) {
                     dest[n] = ptr.ptr;

--- a/src/registry.h
+++ b/src/registry.h
@@ -23,12 +23,14 @@ extern uint32_t jitc_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
 /// If the \c domain is \c nullptr, it returns the number of active entries in
-/// all domains for the given variant.
+/// all domains for the given variant. If the \c variant is empty as well, it
+/// traverses all registry entries.
 extern uint32_t jitc_registry_id_bound(const char *variant, const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry
 /// for this \c variant.
 /// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
+/// If variant is \c nullptr, it traverses all registry entries.
 void extern jitc_registry_get_pointers(const char *variant, void **dest);
 
 /// Return the pointer value associated with a given instance ID

--- a/src/registry.h
+++ b/src/registry.h
@@ -31,7 +31,8 @@ extern uint32_t jitc_registry_id_bound(const char *variant, const char *domain);
 /// for this \c variant.
 /// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
 /// If variant is \c nullptr, it traverses all registry entries.
-void extern jitc_registry_get_pointers(const char *variant, void **dest);
+void extern jitc_registry_get_pointers(const char *variant,
+                                       const char *domain_name, void **dest);
 
 /// Return the pointer value associated with a given instance ID
 extern void *jitc_registry_ptr(const char *variant, const char *domain,

--- a/src/registry.h
+++ b/src/registry.h
@@ -22,15 +22,11 @@ extern void jitc_registry_remove(const void *ptr);
 extern uint32_t jitc_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
-/// If the \c domain is \c nullptr, it returns the number of active entries in
-/// all domains for the given variant. If the \c variant is empty as well, it
-/// traverses all registry entries.
 extern uint32_t jitc_registry_id_bound(const char *variant, const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry
 /// for this \c variant.
 /// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
-/// If variant is \c nullptr, it traverses all registry entries.
 void extern jitc_registry_get_pointers(const char *variant,
                                        const char *domain_name, void **dest);
 

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -1344,6 +1344,24 @@ uint32_t jitc_var_data(uint32_t index, bool eval_dirty, void **ptr_out) {
     return index;
 }
 
+VarState jitc_var_state(uint32_t index) {
+    if (index == 0)
+        return VarState::Invalid;
+    const Variable *v = jitc_var(index);
+    if (v->symbolic)
+        return VarState::Symbolic;
+    else if (v->is_dirty())
+        return VarState::Dirty;
+    else if (v->is_evaluated())
+        return VarState::Evaluated;
+    else if (v->is_literal())
+        return VarState::Literal;
+    else if (v->is_undefined())
+        return VarState::Undefined;
+    else
+        return VarState::Unevaluated;
+}
+
 /// Schedule a variable \c index for future evaluation via \ref jit_eval()
 int jitc_var_schedule(uint32_t index) {
     if (index == 0)

--- a/src/var.h
+++ b/src/var.h
@@ -168,6 +168,8 @@ extern int jitc_var_eval(uint32_t index, bool raise_dirty_error = true);
 /// Return the pointer location of the variable, evaluate if needed
 extern uint32_t jitc_var_data(uint32_t index, bool eval_dirty, void **ptr_out);
 
+extern VarState jitc_var_state(uint32_t index);
+
 /// Return a human-readable summary of registered variables
 extern const char *jitc_var_whos();
 

--- a/tests/test.h
+++ b/tests/test.h
@@ -373,7 +373,7 @@ public:
 
         make_opaque(args...);
 
-        // Make input opaque and add it to \c input_vector, borrowing it
+        // Add input to \c input_vector, borrowing it
         std::vector<uint32_t> input_vector;
         auto op = [&input_vector](uint32_t index) {
             // Borrow from the index and add it to the input_vector

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -1362,7 +1362,7 @@ TEST_BOTH(14_frozen_vcall) {
             Backend, backend_name(Backend), domain, false, self.index(), mask.index(), f_call,
             vcall_inputs, vcall_outputs);
 
-        auto result = UInt32::borrow(vcall_outputs[0]);
+        auto result = UInt32::steal(vcall_outputs[0]);
 
         return result;
     };


### PR DESCRIPTION
This PR adds various fixes to the `Frozen ThreadState` #107 PR, that appeared after merging.

- Adds logging function for `capture_call_offset` function
- Fix memory leak in `vcall` tests by freeing the copied OptiX SBT and changing `borrow` to `steal` in test
- Adds the ability to traverse the whole registry without a variant string