### PR TITLE
Bump OptiX ABI version to 87 (OptiX 8.0)

### DIFF
--- a/src/optix_api.h
+++ b/src/optix_api.h
@@ -72,12 +72,11 @@ struct OptixModuleCompileOptions {
     const void *boundValues;
     unsigned int numBoundValues;
     unsigned int numPayloadTypes;
-    OptixPayloadType *payloadTypes;
+    const OptixPayloadType *payloadTypes;
 };
 
 struct OptixPipelineLinkOptions {
     unsigned int maxTraceDepth;
-    OptixCompileDebugLevel debugLevel;
 };
 
 struct OptixProgramGroupSingleModule {
@@ -140,11 +139,11 @@ DR_OPTIX_SYM(
     OptixResult (*optixDeviceContextSetCacheEnabled)(OptixDeviceContext, int));
 DR_OPTIX_SYM(OptixResult (*optixDeviceContextSetCacheLocation)(
     OptixDeviceContext, const char *));
-DR_OPTIX_SYM(OptixResult (*optixModuleCreateFromPTX)(
+DR_OPTIX_SYM(OptixResult (*optixModuleCreate)(
     OptixDeviceContext, const OptixModuleCompileOptions *,
     const OptixPipelineCompileOptions *, const char *, size_t, char *, size_t *,
     OptixModule *));
-DR_OPTIX_SYM(OptixResult (*optixModuleCreateFromPTXWithTasks)(
+DR_OPTIX_SYM(OptixResult (*optixModuleCreateWithTasks)(
     OptixDeviceContext, const OptixModuleCompileOptions *,
     const OptixPipelineCompileOptions *, const char *, size_t, char *, size_t *,
     OptixModule *, OptixTask *));
@@ -170,4 +169,5 @@ DR_OPTIX_SYM(OptixResult (*optixSbtRecordPackHeader)(OptixProgramGroup,
 DR_OPTIX_SYM(OptixResult (*optixPipelineSetStackSize)(
     OptixPipeline, unsigned int, unsigned int, unsigned int, unsigned int));
 DR_OPTIX_SYM(OptixResult (*optixProgramGroupGetStackSize)(OptixProgramGroup,
-                                                          OptixStackSizes *));
+                                                          OptixStackSizes *,
+                                                          OptixPipeline));

--- a/src/optix_core.cpp
+++ b/src/optix_core.cpp
@@ -103,7 +103,7 @@ OptixDeviceContext jitc_optix_context() {
         size_t log_size = sizeof(log);
 
         OptixModule mod;
-        jitc_optix_check(optixModuleCreateFromPTX(
+        jitc_optix_check(optixModuleCreate(
             ctx, &mco, &pco, minimal, strlen(minimal), log, &log_size, &mod));
 
         OptixProgramGroupDesc pgd { };
@@ -229,7 +229,7 @@ bool jitc_optix_compile(ThreadState *ts, const char *buf, size_t buf_size,
                         const char *kern_name, Kernel &kernel) {
     char error_log[16384];
 
-    if (!optixModuleCreateFromPTXWithTasks)
+    if (!optixModuleCreateWithTasks)
         jitc_fail("jit_optix_compile(): OptiX not initialized, make sure "
                   "evaluation happens before Optix shutdown!");
 
@@ -253,13 +253,13 @@ bool jitc_optix_compile(ThreadState *ts, const char *buf, size_t buf_size,
 
     OptixTask task;
     error_log[0] = '\0';
-    int rv = optixModuleCreateFromPTXWithTasks(
+    int rv = optixModuleCreateWithTasks(
         optix_context, &mco, &pipeline.compile_options, buf, buf_size,
         error_log, &log_size, &kernel.optix.mod, &task);
 
     if (rv) {
         jitc_log(Error, "jit_optix_compile(): "
-                 "optixModuleCreateFromPTXWithTasks() failed. Please see the "
+                 "optixModuleCreateWithTasks() failed. Please see the "
                  "PTX assembly listing and error message below:\n\n%s\n\n%s",
                  buf, error_log);
         jitc_optix_check(rv);
@@ -362,11 +362,6 @@ bool jitc_optix_compile(ThreadState *ts, const char *buf, size_t buf_size,
 
     OptixPipelineLinkOptions link_options {};
     link_options.maxTraceDepth = 1;
-#ifndef DRJIT_ENABLE_OPTIX_DEBUG_VALIDATION_ON
-    link_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_NONE;
-#else
-    link_options.debugLevel = OPTIX_COMPILE_DEBUG_LEVEL_FULL;
-#endif
 
     size_t size_before = pipeline.program_groups.size();
 
@@ -400,7 +395,8 @@ bool jitc_optix_compile(ThreadState *ts, const char *buf, size_t buf_size,
     OptixStackSizes ssp = {};
     for (size_t i = 0; i < pipeline.program_groups.size(); ++i) {
         OptixStackSizes ss;
-        rv = optixProgramGroupGetStackSize(pipeline.program_groups[i], &ss);
+        rv = optixProgramGroupGetStackSize(pipeline.program_groups[i], &ss,
+                                           kernel.optix.pipeline);
         if (rv) {
             jitc_log(Error, "jit_optix_compile(): optixProgramGroupGetStackSize() "
                             "failed:\n\n%s", error_log);

--- a/tests/optix_stubs.cpp
+++ b/tests/optix_stubs.cpp
@@ -10,7 +10,7 @@ void init_optix_api() {
     L(optixAccelComputeMemoryUsage);
     L(optixAccelBuild);
     L(optixAccelCompact);
-    L(optixModuleCreateFromPTX);
+    L(optixModuleCreate);
     L(optixModuleDestroy)
     L(optixProgramGroupCreate);
     L(optixProgramGroupDestroy)

--- a/tests/optix_stubs.h
+++ b/tests/optix_stubs.h
@@ -29,6 +29,9 @@ using OptixProgramGroupKind  = int;
 #define OPTIX_SBT_RECORD_HEADER_SIZE        32
 
 #define OPTIX_COMPILE_DEBUG_LEVEL_NONE      0x2350
+#define OPTIX_COMPILE_DEBUG_LEVEL_FULL      0x2352
+#define OPTIX_COMPILE_OPTIMIZATION_LEVEL_0  0x2340
+#define OPTIX_COMPILE_OPTIMIZATION_LEVEL_3  0x2343
 
 #define OPTIX_BUILD_FLAG_ALLOW_COMPACTION   2
 #define OPTIX_BUILD_FLAG_PREFER_FAST_TRACE  4
@@ -186,7 +189,7 @@ D(optixAccelComputeMemoryUsage, OptixDeviceContext,
 D(optixAccelBuild, OptixDeviceContext, CUstream, const OptixAccelBuildOptions *,
   const OptixBuildInput *, unsigned int, CUdeviceptr, size_t, CUdeviceptr,
   size_t, OptixTraversableHandle *, const OptixAccelEmitDesc *, unsigned int);
-D(optixModuleCreateFromPTX, OptixDeviceContext,
+D(optixModuleCreate, OptixDeviceContext,
   const OptixModuleCompileOptions *, const OptixPipelineCompileOptions *,
   const char *, size_t, char *, size_t *, OptixModule *);
 D(optixModuleDestroy, OptixModule);


### PR DESCRIPTION
This PR contains the minimum set of changes to bump OptiX from version 7.3 to 8.0.

SER and a refactoring of the ray tracing intrinsics will be in another PR.