### PR TITLE
Fixed OptiX kernel hashing bug

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -500,10 +500,9 @@ Task *jitc_run(ThreadState *ts, ScheduledGroup group) {
     }
 #endif
 
-    KernelKey kernel_key((char *) buffer.get(), ts->device, flags);
-    auto it = state.kernel_cache.find(
-        kernel_key,
-        KernelHash::compute_hash(kernel_hash.high64, ts->device, flags));
+    KernelKey kernel_key((char *) buffer.get(), kernel_hash.high64, ts->device,
+                         flags);
+    auto it = state.kernel_cache.find(kernel_key);
     Kernel kernel;
     memset(&kernel, 0, sizeof(Kernel)); // quench uninitialized variable warning on MSVC
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -746,8 +746,11 @@ struct KernelKey {
     char *str = nullptr;
     int device = 0;
     uint64_t flags = 0;
+    // upper 64 bit of the hashed kernel source code
+    uint64_t high64 = 0;
 
-    KernelKey(char *str, int device, uint64_t flags) : str(str), device(device), flags(flags) { }
+    KernelKey(char *str, uint64_t high64, int device, uint64_t flags)
+        : str(str), device(device), flags(flags), high64(high64) {}
 
     bool operator==(const KernelKey &k) const {
         return strcmp(k.str, str) == 0 && device == k.device && flags == k.flags;
@@ -757,12 +760,8 @@ struct KernelKey {
 /// Helper class to hash KernelKey instances
 struct KernelHash {
     size_t operator()(const KernelKey &k) const {
-        return compute_hash(hash_kernel(k.str).high64, k.device, k.flags);
-    }
-
-    static size_t compute_hash(size_t kernel_hash, int device, uint64_t flags) {
-        size_t hash = kernel_hash;
-        hash_combine(hash, (size_t) flags + size_t(device + 1));
+        size_t hash = k.high64;
+        hash_combine(hash, (size_t) k.flags + size_t(k.device + 1));
         return hash;
     }
 };

--- a/src/record_ts.cpp
+++ b/src/record_ts.cpp
@@ -707,14 +707,13 @@ void RecordThreadState::record_launch(
     op.dependency_range = std::pair(start, end);
 
     op.kernel.kernel   = kernel;
-    op.kernel.precomputed_hash =
-        KernelHash::compute_hash(hash.high64, key->device, key->flags);
     op.kernel.key      = (KernelKey *) std::malloc(sizeof(KernelKey));
     size_t str_size    = buffer.size() + 1;
     op.kernel.key->str = (char *) malloc_check(str_size);
     std::memcpy(op.kernel.key->str, key->str, str_size);
     op.kernel.key->device = key->device;
     op.kernel.key->flags  = key->flags;
+    op.kernel.key->high64 = key->high64;
 
     op.size = size;
 
@@ -1846,8 +1845,7 @@ bool Recording::check_kernel_cache() {
         Operation &op = operations[i];
         if (op.type == OpType::KernelLaunch) {
             // Test if this kernel is still in the cache
-            auto it = state.kernel_cache.find(*op.kernel.key,
-                                              op.kernel.precomputed_hash);
+            auto it = state.kernel_cache.find(*op.kernel.key);
             if (it == state.kernel_cache.end())
                 return false;
         }

--- a/src/record_ts.h
+++ b/src/record_ts.h
@@ -59,7 +59,6 @@ struct Operation {
         /// Additional information of a kernel launch
         struct {
             KernelKey *key;
-            size_t precomputed_hash;
             Kernel kernel;
             XXH128_hash_t hash;
         } kernel;


### PR DESCRIPTION
Commit [0c9c54e](https://github.com/mitsuba-renderer/drjit-core/commit/0c9c54ec5c2963dd576c5a16d10fb2d63d67166f) accidentally introduced a bug, that caused the precomputed hash of a `KernelKey` to no longer be equivalent to the actual hash of that kernel key.
This PR adds the upper 64 bits of the kernel hash to the `KernelKey` struct, memoizing the computation of the hash of the kernel string. The actual hash function is also modified to use this stored hash instead of re-computing the hash of the string.