### PR TITLE
Use std::shared_mutex in favor of std::mutex on Windows

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -52,9 +52,14 @@ inline void lock_destroy(Lock &) { }
 inline void lock_acquire(Lock &lock) { os_unfair_lock_lock(&lock);  }
 inline void lock_release(Lock &lock) { os_unfair_lock_unlock(&lock); }
 #else
+#if defined(_WIN32)
+#include <shared_mutex>
+using Lock = std::shared_mutex; // Based on the faster Win7 SRWLOCK
+#else
 #include <mutex>
-
 using Lock = std::mutex;
+#endif
+
 inline void lock_init(Lock &) { }
 inline void lock_destroy(Lock &) { }
 inline void lock_acquire(Lock &lock) { lock.lock(); }


### PR DESCRIPTION
For reasons of ABI compatibility, std::mutex uses a legacy locking API on Windows that is significantly slower than std::shared_mutex.

https://stackoverflow.com/questions/69990339/why-is-stdmutex-so-much-worse-than-stdshared-mutex-in-visual-c