### PR TITLE
Frozen Functions Fixes

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -497,8 +497,10 @@ extern JIT_EXPORT uint32_t jit_registry_id(const void *ptr);
 extern JIT_EXPORT uint32_t jit_registry_id_bound(const char *variant,
                                                  const char *domain);
 
-/// Fills the \c dest pointer array with all pointers registered in the registry.
-/// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
+/// Fills the \c dest pointer array with all pointers registered in the registry
+/// for this \c variant.
+/// \c dest must point to an array with \c jit_registry_id_bound(variant,
+/// domain, nullptr) entries.
 extern JIT_EXPORT void jit_registry_get_pointers(const char *variant,
                                                  const char *domain_name,
                                                  void **dest);

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -494,14 +494,14 @@ extern JIT_EXPORT void jit_registry_remove(const void *ptr);
 extern JIT_EXPORT uint32_t jit_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
-/// If the \c domain is \c nullptr, it returns the number of active entries in
-/// all domains for the given variant.
 extern JIT_EXPORT uint32_t jit_registry_id_bound(const char *variant,
                                                  const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry.
 /// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
-extern JIT_EXPORT void jit_registry_get_pointers(const char *variant, void **dest);
+extern JIT_EXPORT void jit_registry_get_pointers(const char *variant,
+                                                 const char *domain_name,
+                                                 void **dest);
 
 /// Return the pointer value associated with a given instance ID
 extern JIT_EXPORT void *jit_registry_ptr(const char *variant,
@@ -2360,8 +2360,14 @@ extern JIT_EXPORT const char *jit_type_name(JIT_ENUM VarType type) JIT_NOEXCEPT;
 struct VarInfo {
     JitBackend backend;
     VarType type;
+    VarState state;
     size_t size;
+    union{
+        uint64_t literal;
+        void *data;
+    };
     bool is_array;
+    bool unaligned;
 };
 
 /**

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -615,19 +615,7 @@ VarState jit_var_state(uint32_t index) {
         return VarState::Invalid;
 
     lock_guard guard(state.lock);
-    const Variable *v = jitc_var(index);
-    if (v->symbolic)
-        return VarState::Symbolic;
-    else if (v->is_dirty())
-        return VarState::Dirty;
-    else if (v->is_evaluated())
-        return VarState::Evaluated;
-    else if (v->is_literal())
-        return VarState::Literal;
-    else if (v->is_undefined())
-        return VarState::Undefined;
-    else
-        return VarState::Unevaluated;
+    return jitc_var_state(index);
 }
 
 int jit_var_is_zero_literal(uint32_t index) {
@@ -977,9 +965,10 @@ uint32_t jit_registry_id_bound(const char *variant, const char *domain) {
     return jitc_registry_id_bound(variant, domain);
 }
 
-void jit_registry_get_pointers(const char *variant, void **dest) {
+void jit_registry_get_pointers(const char *variant, const char *domain_name,
+                               void **dest) {
     lock_guard guard(state.lock);
-    return jitc_registry_get_pointers(variant, dest);
+    return jitc_registry_get_pointers(variant, domain_name, dest);
 }
 
 void *jit_registry_ptr(const char *variant, const char *domain, uint32_t id) {
@@ -1343,11 +1332,24 @@ const char *jit_type_name(VarType type) noexcept {
 }
 
 VarInfo jit_set_backend(uint32_t index) noexcept {
+    VarInfo info;
+
     lock_guard guard(state.lock);
     Variable *var = jitc_var(index);
     default_backend = (JitBackend) var->backend;
-    return VarInfo{ (JitBackend) var->backend, (VarType) var->type,
-                    var->size, var->is_array() };
+
+    info.backend = (JitBackend)var->backend;
+    info.type = (VarType)var->type;
+    info.state = jitc_var_state(index);
+    info.size = var->size;
+    info.is_array = var->is_array();
+    info.unaligned = var->unaligned;
+    if(info.state == VarState::Literal)
+        info.literal = var->literal;
+    else if (info.state == VarState::Evaluated)
+        info.data = var->data;
+
+    return info;
 }
 
 uint32_t jit_var_loop_start(const char *name, bool symbolic, size_t n_indices, uint32_t *indices) {

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -155,17 +155,8 @@ uint32_t jitc_registry_id(const void *ptr) {
 
 uint32_t jitc_registry_id_bound(const char *variant, const char *domain) {
     assert(variant != nullptr);
+    assert(domain != nullptr);
     Registry &r = registry;
-    if (!domain) {
-        uint32_t n = 0;
-        for (Domain &d : r.domains) {
-            if (strcmp(d.variant, variant) == 0)
-                for (auto ptr : d.fwd_map)
-                    if (ptr.active)
-                        n++;
-        }
-        return n;
-    }
     auto it = r.domain_ids.find(DomainKey{ variant, domain });
     if (it == r.domain_ids.end())
         return 0;
@@ -173,18 +164,22 @@ uint32_t jitc_registry_id_bound(const char *variant, const char *domain) {
         return r.domains[it->second].id_bound;
 }
 
-void jitc_registry_get_pointers(const char *variant, void **dest) {
+void jitc_registry_get_pointers(const char *variant, const char *domain,
+                                void **dest) {
+    assert(variant != nullptr);
+    assert(domain != nullptr);
     const Registry &r = registry;
-
-    uint32_t n = 0;
-    for (const Domain &domain : r.domains) {
-        if (strcmp(domain.variant, variant) == 0)
-            for (auto ptr : domain.fwd_map) {
-                if (ptr.active) {
-                    dest[n] = ptr.ptr;
-                    n++;
-                }
+    auto it = r.domain_ids.find(DomainKey{ variant, domain });
+    if (it == r.domain_ids.end())
+        return;
+    else{
+        const Domain &d = r.domains[it->second];
+        for (uint32_t i = 0; i < d.fwd_map.size(); i++) {
+            auto ptr = d.fwd_map[i];
+            if (ptr.active) {
+                dest[i] = ptr.ptr;
             }
+        }
     }
 }
 

--- a/src/registry.h
+++ b/src/registry.h
@@ -22,14 +22,13 @@ extern void jitc_registry_remove(const void *ptr);
 extern uint32_t jitc_registry_id(const void *ptr);
 
 /// Return the largest instance ID for the given domain
-/// If the \c domain is \c nullptr, it returns the number of active entries in
-/// all domains for the given variant.
 extern uint32_t jitc_registry_id_bound(const char *variant, const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry
 /// for this \c variant.
 /// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
-void extern jitc_registry_get_pointers(const char *variant, void **dest);
+void extern jitc_registry_get_pointers(const char *variant,
+                                       const char *domain_name, void **dest);
 
 /// Return the pointer value associated with a given instance ID
 extern void *jitc_registry_ptr(const char *variant, const char *domain,

--- a/src/registry.h
+++ b/src/registry.h
@@ -26,7 +26,8 @@ extern uint32_t jitc_registry_id_bound(const char *variant, const char *domain);
 
 /// Fills the \c dest pointer array with all pointers registered in the registry
 /// for this \c variant.
-/// \c dest must point to an array with \c jit_registry_id_bound(variant, nullptr) entries.
+/// \c dest must point to an array with \c jit_registry_id_bound(variant,
+/// domain, nullptr) entries.
 void extern jitc_registry_get_pointers(const char *variant,
                                        const char *domain_name, void **dest);
 

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -1344,6 +1344,24 @@ uint32_t jitc_var_data(uint32_t index, bool eval_dirty, void **ptr_out) {
     return index;
 }
 
+VarState jitc_var_state(uint32_t index) {
+    if (index == 0)
+        return VarState::Invalid;
+    const Variable *v = jitc_var(index);
+    if (v->symbolic)
+        return VarState::Symbolic;
+    else if (v->is_dirty())
+        return VarState::Dirty;
+    else if (v->is_evaluated())
+        return VarState::Evaluated;
+    else if (v->is_literal())
+        return VarState::Literal;
+    else if (v->is_undefined())
+        return VarState::Undefined;
+    else
+        return VarState::Unevaluated;
+}
+
 /// Schedule a variable \c index for future evaluation via \ref jit_eval()
 int jitc_var_schedule(uint32_t index) {
     if (index == 0)

--- a/src/var.h
+++ b/src/var.h
@@ -168,6 +168,8 @@ extern int jitc_var_eval(uint32_t index, bool raise_dirty_error = true);
 /// Return the pointer location of the variable, evaluate if needed
 extern uint32_t jitc_var_data(uint32_t index, bool eval_dirty, void **ptr_out);
 
+extern VarState jitc_var_state(uint32_t index);
+
 /// Return a human-readable summary of registered variables
 extern const char *jitc_var_whos();
 

--- a/src/var.h
+++ b/src/var.h
@@ -167,7 +167,7 @@ extern int jitc_var_eval(uint32_t index, bool raise_dirty_error = true);
 
 /// Return the pointer location of the variable, evaluate if needed
 extern uint32_t jitc_var_data(uint32_t index, bool eval_dirty, void **ptr_out);
-
+/// Return the evaluation state of the variable
 extern VarState jitc_var_state(uint32_t index);
 
 /// Return a human-readable summary of registered variables

--- a/tests/test.h
+++ b/tests/test.h
@@ -373,7 +373,7 @@ public:
 
         make_opaque(args...);
 
-        // Make input opaque and add it to \c input_vector, borrowing it
+        // Add input to \c input_vector, borrowing it
         std::vector<uint32_t> input_vector;
         auto op = [&input_vector](uint32_t index) {
             // Borrow from the index and add it to the input_vector

--- a/tests/vcall.cpp
+++ b/tests/vcall.cpp
@@ -1362,7 +1362,7 @@ TEST_BOTH(14_frozen_vcall) {
             Backend, backend_name(Backend), domain, false, self.index(), mask.index(), f_call,
             vcall_inputs, vcall_outputs);
 
-        auto result = UInt32::borrow(vcall_outputs[0]);
+        auto result = UInt32::steal(vcall_outputs[0]);
 
         return result;
     };


### PR DESCRIPTION
This PR adds various fixes to the `Frozen ThreadState` #107 PR, that appeared after merging.

- Adds logging function for `capture_call_offset` function
- Fix memory leak in `vcall` tests by freeing the copied OptiX SBT and changing `borrow` to `steal` in test
- Adds the ability to traverse the whole registry without a variant string

This PR replaces #115, and changes the source branch. 