### PR TITLE
Added notify_expand to track all expand cases when recording a thread…

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -762,4 +762,4 @@ void ThreadState::reset_state() {
 #endif
 }
 void ThreadState::notify_free(const void *) { }
-void ThreadState::notify_expanded(uint32_t index) { }
+void ThreadState::notify_expand(uint32_t index) { }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -762,3 +762,4 @@ void ThreadState::reset_state() {
 #endif
 }
 void ThreadState::notify_free(const void *) { }
+void ThreadState::notify_expanded(uint32_t index) { }

--- a/src/internal.h
+++ b/src/internal.h
@@ -711,6 +711,10 @@ struct ThreadState : public ThreadStateBase {
     // Enqueue a function to be run on the host once backend computation is done
     virtual void enqueue_host_func(void (*callback)(void *), void *payload) = 0;
 
+    /// LLVM: Notify the thread state, that a variable has been expanded using
+    /// \c jitc_var_expand. This is required to record the ThreadState.
+    virtual void notify_expanded(uint32_t index);
+
     /// LLVM: reduce a variable that was previously expanded due to
     /// dr.ReduceOp.Expand
     virtual void reduce_expanded(VarType vt, ReduceOp op, void *data,

--- a/src/internal.h
+++ b/src/internal.h
@@ -713,7 +713,7 @@ struct ThreadState : public ThreadStateBase {
 
     /// LLVM: Notify the thread state, that a variable has been expanded using
     /// \c jitc_var_expand. This is required to record the ThreadState.
-    virtual void notify_expanded(uint32_t index);
+    virtual void notify_expand(uint32_t index);
 
     /// LLVM: reduce a variable that was previously expanded due to
     /// dr.ReduceOp.Expand

--- a/src/record_ts.cpp
+++ b/src/record_ts.cpp
@@ -1015,7 +1015,7 @@ int Recording::replay_expand(Operation &op) {
 
 /// LLVM: Notify the thread state, that a variable has been expanded using
 /// \c jitc_var_expand. This is required to record the ThreadState.
-void RecordThreadState::notify_expanded(uint32_t index){
+void RecordThreadState::notify_expand(uint32_t index){
     // Reductions in LLVM might be split into three operations. First the
     // variable is expanded by its size times the number of workers + 1 Then the
     // kernel writes into the expanded variable with some offset, and finally

--- a/src/record_ts.h
+++ b/src/record_ts.h
@@ -421,7 +421,7 @@ public:
 
     /// LLVM: Notify the thread state, that a variable has been expanded using
     /// \c jitc_var_expand. This is required to record the ThreadState.
-    void notify_expanded(uint32_t index) override;
+    void notify_expand(uint32_t index) override;
 
     /// LLVM: reduce a variable that was previously expanded due to
     /// dr.ReduceOp.Expand

--- a/src/record_ts.h
+++ b/src/record_ts.h
@@ -419,6 +419,10 @@ public:
     /// This should only occur outside of frozen functions.
     void enqueue_host_func(void (*callback)(void *), void *payload) override;
 
+    /// LLVM: Notify the thread state, that a variable has been expanded using
+    /// \c jitc_var_expand. This is required to record the ThreadState.
+    void notify_expanded(uint32_t index) override;
+
     /// LLVM: reduce a variable that was previously expanded due to
     /// dr.ReduceOp.Expand
     void reduce_expanded(VarType vt, ReduceOp reduce_op, void *data,

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -2455,7 +2455,7 @@ std::pair<uint32_t, uint32_t> jitc_var_expand(uint32_t index, ReduceOp op) {
              new_size / size);
 
     uint32_t dst_index = dst.release();
-    thread_state_llvm->notify_expanded(dst_index);
+    thread_state_llvm->notify_expand(dst_index);
 
     return { dst_index, index_scale };
 }

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -2454,7 +2454,10 @@ std::pair<uint32_t, uint32_t> jitc_var_expand(uint32_t index, ReduceOp op) {
              type_name[(int) vt], (uint32_t) dst, new_size, index,
              new_size / size);
 
-    return { dst.release(), index_scale };
+    uint32_t dst_index = dst.release();
+    thread_state_llvm->notify_expanded(dst_index);
+
+    return { dst_index, index_scale };
 }
 
 void jitc_var_reduce_expanded(uint32_t index) {


### PR DESCRIPTION
This PR fixes a bug with the `RecordThreadState` frozen function feature.
When `jitc_var_expand` is used on LLVM to scatter-reduce on an array, and the pointer to that array is  not directly passed to the kernel through it's arguments, but through the data buffer generated from an `aggregate` call, it was not possible to determine that this variable should be expanded when recording the ThreadState.
Therefore, a `notify_expand` function is added to the ThreadState, that is called at the end of `jitc_var_expand` to notify the RecordThreadState of this.