### PR TITLE
Fix, recording the wrong size for `expand`

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1575,6 +1575,9 @@ enum class JitFlag : uint32_t {
     /// Set to \c true when Dr.Jit is recording a frozen function
     FreezingScope = 1 << 21,
 
+    /// Set to \c true when traversing inputs or outputs of a frozen function
+    EnableObjectTraversal = 1 << 22,
+
     /// Default flags
     Default = (uint32_t) ConstantPropagation | (uint32_t) ValueNumbering |
               (uint32_t) FastMath | (uint32_t) SymbolicLoops |
@@ -1615,7 +1618,8 @@ enum JitFlag {
     JitFlagScatterReduceLocal = 1 << 18,
     JitFlagSymbolic = 1 << 19,
     KernelFreezing = 1 << 20,
-    FreezingScope = 1 << 21
+    FreezingScope = 1 << 21,
+    EnableObjectTraversal = 1 << 22
 };
 #endif
 

--- a/include/drjit-core/texture.h
+++ b/include/drjit-core/texture.h
@@ -73,6 +73,21 @@ extern JIT_EXPORT void jit_cuda_tex_get_shape(size_t ndim,
                                               size_t *shape);
 
 /**
+ * \brief Retrieves the JIT indices of the underlying texture objects. This can
+ * be used to traverse a texture for frozen function recording.
+ *
+ * \param texture_handle
+ *     Texture handle (returned value of \ref jit_cuda_tex_create())
+ *
+ * \param indices
+ *     Pointer to an array of size
+ *     <tt>n_textures = 1 + ((m_channels - 1) / 4)</tt>, to which
+ *     the JIT variable indices of the underlying textures will be written.
+ */
+extern JIT_EXPORT void
+jit_cuda_tex_get_indices(const void *texture_handle, uint32_t *indices);
+
+/**
  * \brief Copy from device to texture memory
  *
  * Fills the texture with data from device memory at \c src_ptr. The other

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1097,6 +1097,11 @@ void jit_cuda_tex_get_shape(size_t ndim, const void *texture_handle,
     jitc_cuda_tex_get_shape(ndim, texture_handle, shape);
 }
 
+void jit_cuda_tex_get_indices(const void *texture_handle, uint32_t *indices) {
+    lock_guard guard(state.lock);
+    jitc_cuda_tex_get_indices(texture_handle, indices);
+}
+
 void jit_cuda_tex_memcpy_d2t(size_t ndim, const size_t *shape,
                              const void *src_ptr, void *dst_texture) {
     lock_guard guard(state.lock);

--- a/src/cuda_tex.h
+++ b/src/cuda_tex.h
@@ -7,6 +7,8 @@ extern void *jitc_cuda_tex_create(size_t ndim, const size_t *shape,
                                   int filter_mode, int wrap_mode);
 extern void jitc_cuda_tex_get_shape(size_t ndim, const void *texture_handle,
                                     size_t *shape);
+extern void jitc_cuda_tex_get_indices(const void *texture_handle,
+                                      uint32_t *indices);
 extern void jitc_cuda_tex_memcpy_d2t(size_t ndim, const size_t *shape,
                                      const void *src_ptr,
                                      void *dst_texture_handle);


### PR DESCRIPTION
Just a one liner to fix the wrong size being recorded for jitc_var_expand calls.