### PR TITLE
Properly compile ``rsqrt`` intrinsic on LLVM

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -762,4 +762,4 @@ void ThreadState::reset_state() {
 #endif
 }
 void ThreadState::notify_free(const void *) { }
-void ThreadState::notify_expand(uint32_t index) { }
+void ThreadState::notify_expand(uint32_t) { }

--- a/src/llvm.h
+++ b/src/llvm.h
@@ -73,6 +73,11 @@ extern char *jitc_llvm_u32_width_str;
 
 extern uint32_t jitc_llvm_block_size;
 
+/// Various hardware capabilities
+extern bool jitc_llvm_has_avx;
+extern bool jitc_llvm_has_avx512;
+extern bool jitc_llvm_has_neon;
+
 /// Try to load initialize LLVM backend
 extern bool jitc_llvm_init();
 

--- a/src/llvm_core.cpp
+++ b/src/llvm_core.cpp
@@ -66,6 +66,11 @@ LLVMTargetMachineRef jitc_llvm_tm = nullptr;
 /// Number of work items per block handed to nanothread
 uint32_t jitc_llvm_block_size = 16384;
 
+/// Various hardware capabilities
+bool jitc_llvm_has_avx = false;
+bool jitc_llvm_has_avx512 = false;
+bool jitc_llvm_has_neon = false;
+
 void jitc_llvm_update_strings();
 
 bool jitc_llvm_init() {
@@ -129,12 +134,18 @@ bool jitc_llvm_init() {
 
     if (strstr(jitc_llvm_target_features, "+sse4.2"))
         jitc_llvm_vector_width = 4;
-    if (strstr(jitc_llvm_target_features, "+avx"))
+    if (strstr(jitc_llvm_target_features, "+avx")) {
         jitc_llvm_vector_width = 8;
-    if (strstr(jitc_llvm_target_features, "+avx512vl"))
+        jitc_llvm_has_avx = true;
+    }
+    if (strstr(jitc_llvm_target_features, "+avx512vl")) {
         jitc_llvm_vector_width = 16;
-    if (strstr(jitc_llvm_target_features, "+neon"))
+        jitc_llvm_has_avx512 = true;
+    }
+    if (strstr(jitc_llvm_target_features, "+neon")) {
         jitc_llvm_vector_width = 4;
+        jitc_llvm_has_neon = true;
+    }
 
 #if defined(__APPLE__) && defined(__aarch64__)
     jitc_llvm_vector_width = 4;

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -1359,12 +1359,10 @@ uint32_t jitc_var_rsqrt(uint32_t a0) {
 
     bool fast_math = jit_flags() & (uint32_t) JitFlag::FastMath;
 
-    if (!result && info.backend == JitBackend::CUDA &&
-        info.type == VarType::Float32 && fast_math) {
+    if (!result && info.type == VarType::Float32 && fast_math)
         result =
             jitc_var_new_node_1(info.backend, VarKind::RSqrtApprox, info.type,
                                 info.size, info.symbolic, a0, v0);
-    }
 
     if (!result && info.size) {
         // Reciprocal, then square root (lower error than the other way around)


### PR DESCRIPTION
Dr.Jit provides an approximate ``dr.rsqrt()`` operation that performs a reciprocal square root with a very small amount of rounding error (~1 ULP) when compared to the IEEE 754-compliant version. The main benefit is that this has significantly lower latency.

Previously, only the CUDA backend implemented this operation properly, while an IEEE 754-compliant fallback was used on the LLVM backend. This commit adds a proper implementation for AVX, AVX512, and ARM Neon.