### PR TITLE
Added ``JitFlag::ForbidSynchronization`` to catch synchronization issues

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1550,18 +1550,21 @@ enum class JitFlag : uint32_t {
        along with the KernelHistory feature. */
     LaunchBlocking = 1 << 16,
 
+    /// Treat any kind of synchronization as a failure and raise an exception
+    ForbidSynchronization = 1 << 17,
+
     /// Perform a local (warp/SIMD) reduction before issuing global atomics
-    ScatterReduceLocal = 1 << 17,
+    ScatterReduceLocal = 1 << 18,
 
     /// Set to \c true when Dr.Jit is capturing symbolic computation. This flag
     /// is managed automatically and should not be set by application code.
-    SymbolicScope = 1 << 18,
+    SymbolicScope = 1 << 19,
 
     /// Freeze functions annotated with dr.freeze
-    KernelFreezing = 1 << 19,
+    KernelFreezing = 1 << 20,
 
     /// Set to \c true when Dr.Jit is recording a frozen function
-    FreezingScope = 1 << 20,
+    FreezingScope = 1 << 21,
 
     /// Default flags
     Default = (uint32_t) ConstantPropagation | (uint32_t) ValueNumbering |
@@ -1599,10 +1602,11 @@ enum JitFlag {
     JitFlagPrintIR = 1 << 14,
     JitFlagKernelHistory = 1 << 15,
     JitFlagLaunchBlocking = 1 << 16,
-    JitFlagScatterReduceLocal = 1 << 17,
-    JitFlagSymbolic = 1 << 18
-    KernelFreezing = 1 << 19,
-    FreezingScope = 1 << 20,
+    JitFlagForbidSynchronization = 1 << 17,
+    JitFlagScatterReduceLocal = 1 << 18,
+    JitFlagSymbolic = 1 << 19
+    KernelFreezing = 1 << 20,
+    FreezingScope = 1 << 21,
 };
 #endif
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -455,6 +455,11 @@ void jitc_cuda_set_device(int device_id) {
 void jitc_sync_thread(ThreadState *ts) {
     if (!ts)
         return;
+
+    if (jitc_flag(JitFlag::ForbidSynchronization))
+        jitc_raise("Attempted to synchronize in a context, where "
+                   "synchronization was explicitly forbidden!");
+
     if (ts->backend == JitBackend::CUDA) {
         scoped_set_context guard(ts->context);
         CUstream stream = ts->stream;


### PR DESCRIPTION
There can sometimes be lingering issues in a codebase (e.g., forgotten leftovers from a prior debugging session) that trigger costly CPU<->GPU.

The new ``JitFlag.ForbidSynchronization`` flag will raise an exception in ``jitc_sync_thread()`` to immediately identify such problems.