### PR TITLE
Opaque Width

### DIFF
--- a/include/drjit-core/array.h
+++ b/include/drjit-core/array.h
@@ -253,6 +253,11 @@ template <JitBackend Backend_, typename Value_> struct JitArray {
         return jit_var_size(m_index);
     }
 
+    auto opaque_width_() {
+        using UInt32 = JitArray<Backend_, uint32_t>;
+        return UInt32::steal(jit_var_opaque_width(m_index));
+    }
+
     void resize(size_t size) {
         uint32_t index = jit_var_resize(m_index, size);
         jit_var_dec_ref(m_index);

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1130,6 +1130,18 @@ JIT_INLINE void jit_var_dec_ref(uint32_t index) JIT_NOEXCEPT {
 #define jit_var_inc_ref jit_var_inc_ref_impl
 #endif
 
+/**
+ * \brief Lock the recursive state mutex.
+ * This can improve performance when a single thread performs a large number of
+ * Dr.Jit operations in sequence.
+ */
+extern JIT_EXPORT void jit_state_lock();
+/**
+ * \brief Unlock the recursive state mutex.
+ * This should never be called from a thread that has not locked the mutex.
+ */
+extern JIT_EXPORT void jit_state_unlock();
+
 /// Query the a variable's reference count (used by the test suite)
 extern JIT_EXPORT uint32_t jit_var_ref(uint32_t index);
 
@@ -1187,6 +1199,9 @@ extern JIT_EXPORT uint32_t jit_var_data(uint32_t index, void **ptr_out);
 
 /// Query the size of a given variable
 extern JIT_EXPORT size_t jit_var_size(uint32_t index);
+
+/// Query the size of a given variable, as an opaque variable.
+extern JIT_EXPORT uint32_t jit_var_opaque_width(uint32_t index);
 
 /// Query the type of a given variable
 extern JIT_EXPORT JIT_ENUM VarType jit_var_type(uint32_t index);
@@ -1632,9 +1647,9 @@ enum JitFlag {
     JitFlagForbidSynchronization = 1 << 17,
     JitFlagScatterReduceLocal = 1 << 18,
     JitFlagSymbolic = 1 << 19,
-    KernelFreezing = 1 << 20,
-    FreezingScope = 1 << 21,
-    EnableObjectTraversal = 1 << 22,
+    JitFlagKernelFreezing = 1 << 20,
+    JitFlagFreezingScope = 1 << 21,
+    JitFlagEnableObjectTraversal = 1 << 22,
     JitFlagShaderExecutionReordering = 1 << 23
 };
 #endif
@@ -2436,6 +2451,10 @@ struct VarInfo {
  * generic code that works on various different backends.
  */
 extern JIT_EXPORT VarInfo jit_set_backend(uint32_t index) JIT_NOEXCEPT;
+
+/// Same as \c jit_set_backend without setting the backend.
+/// This improves performance, as no tls access is performed.
+extern JIT_EXPORT VarInfo jit_var_info(uint32_t index) JIT_NOEXCEPT;
 
 /**
  * \brief Inform Dr.Jit about the current source code location

--- a/include/drjit-core/nanostl.h
+++ b/include/drjit-core/nanostl.h
@@ -172,11 +172,11 @@ public:
         m_size++;
     }
 
-    template <typename... Args> void emplace_back(Args &&...args) {
+    template <typename... Args> T &emplace_back(Args &&...args) {
         if (m_size == m_capacity)
             expand();
         new (&m_data[m_size]) T(std::forward<Args>(args)...);
-        m_size++;
+        return m_data[m_size++];
     }
 
     bool operator==(const vector &s) const {

--- a/src/internal.h
+++ b/src/internal.h
@@ -742,6 +742,23 @@ struct ThreadState : public ThreadStateBase {
                                const MatrixDescr *in_d, void *out,
                                const MatrixDescr *out_d) = 0;
 
+    /// Reduces an array of booleans by filling trailing elements and applying a
+    /// UInt32 reduction.
+    virtual void block_reduce_bool(uint8_t *values, uint32_t size, uint8_t *out,
+                                   ReduceOp op);
+
+    /// Some kernels use the width of an array in a computation. When using the
+    /// kernel freezing feature, this requires special precautions to ensure
+    /// that the resulting capture remains usable with different array sizes.
+    /// This notification function exists so that this special-case handling can
+    /// be realized.
+    virtual void notify_opaque_width(uint32_t index, uint32_t width_index);
+
+    /// Notifies the thread state that an allocation should not be initialized
+    /// as part of the evaluation of an undefined variable. This is required for
+    /// frozen functions to handle undefined variables.
+    virtual void notify_init_undefined(uint32_t index);
+
     /// Notify the \c ThreadState that \c jitc_free has been called on a pointer.
     /// This is required for kernel freezing.
     virtual void notify_free(const void *ptr);

--- a/src/lock.h
+++ b/src/lock.h
@@ -2,35 +2,134 @@
 
 #if defined(__linux__) && !defined(DRJIT_USE_STD_MUTEX)
 #include <pthread.h>
-using Lock = pthread_spinlock_t;
+
+/*
+ * This recursive spinlock improves the efficiency of @dr.freeze and operations
+ * that acquire a lock recursively to avoid repeated atomic memory transactions
+ * when accessing JIT variables.
+ *
+ * The code contains unprotected reads/writes of members (`lock.owner`,
+ * `lock.recursion_count`) that are likely to be flagged as data races when using
+ * thread sanitizers or similar infrastructure. Here is a rationale on why this is
+ * safe even on architectures with weakly ordered memory semantics like ARM:
+ *
+ * The check `lock.owner == self` in lock_acquire avoids taking out the lock if
+ * the current thread already holds it. However, the read from `lock.owner` is a
+ * data race. Other threads might be reading/writing this value, and there are no
+ * guarantees of how these operations are ordered with respect to each other.
+ *
+ * However, only one possible value of this field matters, which is when
+ * `lock.owner` matches the value of `pthread_self()`. This value can only be read
+ * if the current thread wrote it, which means that it is still holding the lock.
+ * This means that the body of the conditionals is effectively part of a previous
+ * critical section.
+ */
+
+struct Lock {
+    pthread_spinlock_t lock;
+    pthread_t owner;
+    int recursion_count;
+};
 
 // Danger zone: the drjit-core locks are held for an extremely short amount of
 // time and normally uncontended. Switching to a spin lock cuts tracing time 8-10%
-inline void lock_init(Lock &lock) { pthread_spin_init(&lock, PTHREAD_PROCESS_PRIVATE); }
-inline void lock_destroy(Lock &lock) { pthread_spin_destroy(&lock); }
-inline void lock_acquire(Lock &lock) { pthread_spin_lock(&lock); }
-inline void lock_release(Lock &lock) { pthread_spin_unlock(&lock); }
+inline void lock_init(Lock &lock) {
+    pthread_spin_init(&lock.lock, PTHREAD_PROCESS_PRIVATE);
+    lock.owner           = 0;
+    lock.recursion_count = 0;
+}
+inline void lock_destroy(Lock &lock) { pthread_spin_destroy(&lock.lock); }
+inline void lock_acquire(Lock &lock) {
+    pthread_t self = pthread_self();
+    if (lock.owner == self) {
+        lock.recursion_count++;
+        return;
+    }
+
+    pthread_spin_lock(&lock.lock);
+    lock.owner           = self;
+    lock.recursion_count = 1;
+}
+inline void lock_release(Lock &lock) {
+    lock.recursion_count--;
+    if (lock.recursion_count == 0) {
+        lock.owner = 0;
+        pthread_spin_unlock(&lock.lock);
+    }
+}
 #elif defined(__APPLE__) && !defined(DRJIT_USE_STD_MUTEX)
 #include <os/lock.h>
 
-using Lock = os_unfair_lock_s;
-inline void lock_init(Lock &lock) { lock = OS_UNFAIR_LOCK_INIT; }
-inline void lock_destroy(Lock &) { }
-inline void lock_acquire(Lock &lock) { os_unfair_lock_lock(&lock);  }
-inline void lock_release(Lock &lock) { os_unfair_lock_unlock(&lock); }
+struct Lock {
+    os_unfair_lock_s lock;
+    pthread_t owner;
+    int recursion_count;
+};
+
+inline void lock_init(Lock &lock) {
+    lock.lock            = OS_UNFAIR_LOCK_INIT;
+    lock.owner           = 0;
+    lock.recursion_count = 0;
+}
+inline void lock_destroy(Lock &) {}
+inline void lock_acquire(Lock &lock) {
+    pthread_t self = pthread_self();
+    if (pthread_equal(lock.owner, self)) {
+        lock.recursion_count++;
+        return;
+    }
+
+    os_unfair_lock_lock(&lock.lock);
+    lock.owner           = self;
+    lock.recursion_count = 1;
+}
+inline void lock_release(Lock &lock) {
+    lock.recursion_count--;
+    if (lock.recursion_count == 0) {
+        lock.owner = 0;
+        os_unfair_lock_unlock(&lock.lock);
+    }
+}
 #else
 #if defined(_WIN32)
 #include <shared_mutex>
-using Lock = std::shared_mutex; // Based on the faster Win7 SRWLOCK
+struct Lock {
+    std::shared_mutex lock; // Based on the faster Win7 SRWLOCK
+    std::thread::id owner;
+    int recursion_count;
+};
 #else
 #include <mutex>
-using Lock = std::mutex;
+struct Lock {
+    std::mutex lock;
+    std::thread::id owner;
+    int recursion_count;
+};
 #endif
 
-inline void lock_init(Lock &) { }
-inline void lock_destroy(Lock &) { }
-inline void lock_acquire(Lock &lock) { lock.lock(); }
-inline void lock_release(Lock &lock) { lock.unlock(); }
+inline void lock_init(Lock &lock) {
+    lock.owner           = std::thread::id();
+    lock.recursion_count = 0;
+}
+inline void lock_destroy(Lock &) {}
+inline void lock_acquire(Lock &lock) {
+    std::thread::id self = std::this_thread::get_id();
+    if (lock.owner == self) {
+        lock.recursion_count++;
+        return;
+    }
+
+    lock.lock.lock();
+    lock.owner           = self;
+    lock.recursion_count = 1;
+}
+inline void lock_release(Lock &lock) {
+    lock.recursion_count--;
+    if (lock.recursion_count == 0) {
+        lock.owner = std::thread::id();
+        lock.lock.unlock();
+    }
+}
 #endif
 
 extern void jitc_sanitation_checkpoint();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -72,44 +72,12 @@ void jitc_reduce_dot(JitBackend backend, VarType type,
 
 /// 'All' reduction for boolean arrays (internal)
 void jitc_all_async_4(JitBackend backend, uint8_t *values, uint32_t size, uint8_t *out) {
-    /* When \c size is not a multiple of 4, the implementation will initialize up
-       to 3 bytes beyond the end of the supplied range so that an efficient 32 bit
-       reduction algorithm can be used. This is fine for allocations made using
-       \ref jit_malloc(), which allow for this. */
-
-    uint32_t size_4    = ceil_div(size, 4),
-             trailing  = size_4 * 4 - size;
-
-    jitc_log(Debug, "jit_all(" DRJIT_PTR ", size=%u)", (uintptr_t) values, size);
-
-    if (trailing) {
-        bool filler = true;
-        jitc_memset_async(backend, values + size, trailing, sizeof(bool), &filler);
-    }
-
-    jitc_block_reduce(backend, VarType::UInt32, ReduceOp::And, size_4,
-                      size_4, values, out);
+    thread_state(backend)->block_reduce_bool(values, size, out, ReduceOp::And);
 }
 
 /// 'Any' reduction for boolean arrays (asynchronous)
 void jitc_any_async_4(JitBackend backend, uint8_t *values, uint32_t size, uint8_t *out) {
-    /* When \c size is not a multiple of 4, the implementation will initialize up
-       to 3 bytes beyond the end of the supplied range so that an efficient 32 bit
-       reduction algorithm can be used. This is fine for allocations made using
-       \ref jit_malloc(), which allow for this. */
-
-    uint32_t size_4   = ceil_div(size, 4),
-             trailing = size_4 * 4 - size;
-
-    jitc_log(Debug, "jit_any(" DRJIT_PTR ", size=%u)", (uintptr_t) values, size);
-
-    if (trailing) {
-        bool filler = false;
-        jitc_memset_async(backend, values + size, trailing, sizeof(bool), &filler);
-    }
-
-    jitc_block_reduce(backend, VarType::UInt32, ReduceOp::Or, size_4,
-                      size_4, values, out);
+    thread_state(backend)->block_reduce_bool(values, size, out, ReduceOp::Or);
 }
 
 void jitc_any_async(JitBackend backend, uint8_t *values, uint32_t size, uint8_t *out) {

--- a/src/var.h
+++ b/src/var.h
@@ -170,6 +170,8 @@ extern int jitc_var_eval(uint32_t index, bool raise_dirty_error = true);
 extern uint32_t jitc_var_data(uint32_t index, bool eval_dirty, void **ptr_out);
 /// Return the evaluation state of the variable
 extern VarState jitc_var_state(uint32_t index);
+/// Query details about a variable
+extern VarInfo jitc_var_info(uint32_t index);
 
 /// Return a human-readable summary of registered variables
 extern const char *jitc_var_whos();


### PR DESCRIPTION
This PR adds a new function `jit_var_opaque_width`, that constructs an opaque variable, corresponding to the width of another variable. It also notifies the ThreadState, to record and replay this operation.