### PR TITLE
CUDA Scatter Reduce NoConflicts - address missing fmt argument

### DIFF
--- a/src/cuda_scatter.cpp
+++ b/src/cuda_scatter.cpp
@@ -295,7 +295,7 @@ void jitc_cuda_render_scatter_reduce(const Variable *v,
             "        $s.$s %tmp, %tmp, $v;\n"
             "        st.global.$s [%rd3], %tmp;\n"
             "    }\n",
-            tp, tp, op_name, tp, value, tp);
+            tp, tp_b, op_name, tp, value, tp_b);
     } else if (mode == ReduceMode::Local && (reduce_bfly_32 || reduce_bfly_64)) {
         uint32_t shiftamt = log2i_ceil(type_size[(int) vt]);
         if (reduce_bfly_32)

--- a/src/cuda_scatter.cpp
+++ b/src/cuda_scatter.cpp
@@ -288,6 +288,7 @@ void jitc_cuda_render_scatter_reduce(const Variable *v,
                           (vt == VarType::UInt64 || vt == VarType::Int64 || vt == VarType::Float64);
 
     if (mode == ReduceMode::NoConflicts) {
+        const char *tp_b = type_name_ptx_bin[(int) vt];
         fmt("    {\n"
             "        .reg.$s %tmp;\n"
             "        ld.global.$s %tmp, [%rd3];\n"

--- a/src/cuda_scatter.cpp
+++ b/src/cuda_scatter.cpp
@@ -291,10 +291,10 @@ void jitc_cuda_render_scatter_reduce(const Variable *v,
         fmt("    {\n"
             "        .reg.$s %tmp;\n"
             "        ld.global.$s %tmp, [%rd3];\n"
-            "        $s.$s %tmp, %tmp, $v;"
+            "        $s.$s %tmp, %tmp, $v;\n"
             "        st.global.$s [%rd3], %tmp;\n"
             "    }\n",
-            tp, tp, op_name, tp, value);
+            tp, tp, op_name, tp, value, tp);
     } else if (mode == ReduceMode::Local && (reduce_bfly_32 || reduce_bfly_64)) {
         uint32_t shiftamt = log2i_ceil(type_size[(int) vt]);
         if (reduce_bfly_32)


### PR DESCRIPTION
Fixes an issue in the scatter_reduce implementation when using ReduceMode.NoConflicts. The problem was caused by a missing argument in the call to the formatting function (fmt).


Reproducer:
```python
import drjit as dr
from drjit.auto import Int32, UInt32
dr.set_flag(dr.JitFlag.PrintIR, True)

a = Int32([-3, -62, 5])

dr.scatter_add(target=a,
               value=Int32([0, 1, 2]), 
               index=dr.arange(UInt32, 3), 
               mode=dr.ReduceMode.NoConflicts)

print(a)
```