### PR TITLE
Add missing include when dynamic CUDA is disabled

### DIFF
--- a/src/cuda_api.h
+++ b/src/cuda_api.h
@@ -25,6 +25,7 @@ extern void jitc_cuda_sync_stream(uintptr_t stream);
 
 #if !defined(DRJIT_DYNAMIC_CUDA)
 #  include <cuda.h>
+#  include <cudaProfiler.h>
 #else
 #  define CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR 75
 #  define CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR 76


### PR DESCRIPTION
When compiling without dynamic CUDA, we need to include `cudaProfiler.h` for the profiler API to be available.