### PR TITLE
Make sure structs are fully zero initialized

### DIFF
--- a/tests/triangle.cpp
+++ b/tests/triangle.cpp
@@ -54,7 +54,8 @@ void demo() {
     // =====================================================
 
     const uint32_t triangle_input_flags[1] = { OPTIX_GEOMETRY_FLAG_DISABLE_ANYHIT };
-    OptixBuildInput triangle_input {};
+    OptixBuildInput triangle_input;
+    memset(&triangle_input, 0, sizeof(triangle_input)); // Use memset due to union member.
     triangle_input.type                        = OPTIX_BUILD_INPUT_TYPE_TRIANGLES;
     triangle_input.triangleArray.vertexFormat  = OPTIX_VERTEX_FORMAT_FLOAT3;
     triangle_input.triangleArray.numVertices   = 3;
@@ -162,7 +163,8 @@ void demo() {
     // =====================================================
 
     OptixProgramGroupOptions pgo { };
-    OptixProgramGroupDesc pgd[2] { };
+    OptixProgramGroupDesc pgd[2];
+    memset(pgd, 0, sizeof(pgd)); // Use memset due to union member.
     OptixProgramGroup pg[2];
 
     pgd[0].kind                         = OPTIX_PROGRAM_GROUP_KIND_MISS;


### PR DESCRIPTION
I learned today that C++ value initialization of a struct will only initialize the first union member.

E.g., the following code does not guarantee that all union members are zero:

```cpp
struct A {
...
}
struct B {
...
}

struct C {
  union {
    A a;
    B b;
  }
}
...

C c {};
// --> c.b might not be 0 entirely
```

This causes issues when relying on it to zero-initialize complex OptiX API structs (in particular, those with pointer members). I am running Mitsuba & Dr.Jit with a sanitizer that appears to make sure to fill any non-initialized memory with a sequence of non-zero bits to surface those issues. This makes code that relies on this initialization segfault.

This PR fixes these issues in `triangle.cpp`, I will follow up with a PR to fix the same problem in Mitsuba