### PR TITLE
Renaming `LogCallback` to avoid name conflicts

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -293,9 +293,9 @@ extern JIT_EXPORT JIT_ENUM LogLevel jit_log_level_stderr();
  * invoked with the contents of library log messages, whose severity matches or
  * exceeds the specified \c level.
  */
-typedef void (*LogCallback)(JIT_ENUM LogLevel, const char *);
+typedef void (*JitLogCallback)(JIT_ENUM LogLevel, const char *);
 extern JIT_EXPORT void jit_set_log_level_callback(JIT_ENUM LogLevel level,
-                                                  LogCallback callback);
+                                                  JitLogCallback callback);
 
 /// Return the currently set minimum log level for output to a callback
 extern JIT_EXPORT JIT_ENUM LogLevel jit_log_level_callback();

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -116,7 +116,7 @@ LogLevel jit_log_level_stderr() {
     return state.log_level_stderr;
 }
 
-void jit_set_log_level_callback(LogLevel level, LogCallback callback) {
+void jit_set_log_level_callback(LogLevel level, JitLogCallback callback) {
     lock_guard guard(state.lock);
     state.log_level_callback = callback ? level : Disable;
     state.log_callback = callback;

--- a/src/internal.h
+++ b/src/internal.h
@@ -834,7 +834,7 @@ struct State {
     LogLevel log_level_callback = LogLevel::Disable;
 
     /// Callback for log messages
-    LogCallback log_callback = nullptr;
+    JitLogCallback log_callback = nullptr;
 
     /// Bit-mask of successfully initialized backends
     uint32_t backends = 0;


### PR DESCRIPTION
`LogCallback` is a relatively common name that may cause naming conflicts with other libraries when defined in the global scope. To avoid this issue, please consider prefixing it with a unique identifier, such as `Jit`, to create a more distinctive name like `JitLogCallback`. Thanks!