### PR TITLE
Fix android 32-bit build errors

### DIFF
--- a/include/drjit-core/intrin.h
+++ b/include/drjit-core/intrin.h
@@ -12,7 +12,7 @@
 #if defined(_MSC_VER)
 #  include <intrin.h>
 #else
-#  if defined(__aarch64__)
+#  if defined(__arm__) || defined(__aarch64__)
 #    include <arm_neon.h>
 #    include <arm_fp16.h>
 #  elif !defined(DRJIT_DISABLE_AVX512) || !defined(__AVX512F__)


### PR DESCRIPTION
I found that building for Android 32-bit was failing due to the use of `__arch64__` for checking ARM platforms, which is only defined for 64-bit Android architectures. To fix this, I've updated the code to also check for `__arm__`, ensuring that our project can correctly identify and build for both 32-bit and 64-bit ARM-based Android platforms.

Related PR: https://github.com/mitsuba-renderer/drjit/pull/389