### PR TITLE
Fix bug in symbolic CUDA loops

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -224,8 +224,8 @@ struct alignas(64) Variable {
     /// How many times has this variable entry been (re-) used?
     uint32_t counter;
 
-    /// Unused
-    uint32_t unused;
+    /// Free-use field temporarily used by various parts of Dr.Jit
+    uint32_t scratch;
 
     // ================  Essential flags used in the LVN key  =================
     // (+15 bits)

--- a/src/lock.h
+++ b/src/lock.h
@@ -33,6 +33,8 @@ inline void lock_acquire(Lock &lock) { lock.lock(); }
 inline void lock_release(Lock &lock) { lock.unlock(); }
 #endif
 
+extern void jitc_sanitation_checkpoint();
+
 /// RAII helper for scoped lock acquisition
 class lock_guard {
 public:

--- a/src/loop.h
+++ b/src/loop.h
@@ -1,13 +1,14 @@
 #include <stdint.h>
+#include <drjit-core/nanostl.h>
 
 struct LoopData {
     std::string name;
     size_t size;
     uint32_t loop_start;
-    std::vector<uint32_t> outer_in;
-    std::vector<uint32_t> inner_in;
-    std::vector<uint32_t> inner_out;
-    std::vector<WeakRef> outer_out;
+    drjit::vector<uint32_t> outer_in;
+    drjit::vector<uint32_t> inner_in;
+    drjit::vector<uint32_t> inner_out;
+    drjit::vector<WeakRef> outer_out;
     bool symbolic;
     bool retry;
 


### PR DESCRIPTION
This PR is a fix for symbolic loops when state variables get assigned to other state variables, for example: 
```python
@dr.syntax
def f():
   previous, current = ...
    while cond(...): # both `previous` and `current` are state variables in this loop
        previous = current
        current = g(...)
        ...
```

In symbolic mode, with the CUDA backend, the variable getting assigned an other state variable (`previous` in the example above) would potentially be assigned the new value of the state variable (`g(...)` in the example)  rather than its original value (`current`'s value at the beginning of the loop).

When assembling a `LoopEnd` node in CUDA, for a loop with two state variable `a` and `b`, we'd generate something like this:
```
    mov.b32 %inner_in_a, %inner_out_a;
    mov.b32 %inner_in_b, %inner_out_b;
    bra l_cond;
l_done:
```

This is fine as long as the `inner_out` registers are not the same as any of the `inner_in` ones. However, for the original Python example, it would generate:
```
    mov.b32 %inner_in_a, %inner_out_a;
    mov.b32 %inner_in_b, %inner_in_a; // Wrong ! Should use `%inner_in_a` before it's updated
```

This PR adds temporary copies of state variables that get assigned to other variables, and uses these copies in the final assignment when needed. With this extra copy, we can guarantee that the final assignment will not use a value that has already been overridden.

Once this PR is merged, I'll add a test to `drjit`.