### PR TITLE
Fix build for DRJIT_DYNAMIC_CUDA=OFF

### DIFF
--- a/src/cuda_api.h
+++ b/src/cuda_api.h
@@ -26,6 +26,8 @@ extern void jitc_cuda_sync_stream(uintptr_t stream);
 #if !defined(DRJIT_DYNAMIC_CUDA)
 #  include <cuda.h>
 #  include <cudaProfiler.h>
+// Internal function that is not in <cuda.h>, but gets loaded by the driver.
+extern CUresult (*cuStreamWaitEvent_ptsz)(CUstream, CUevent, unsigned int);
 #else
 #  define CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR 75
 #  define CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR 76


### PR DESCRIPTION
Fixes issue #149 by adding the missing symbol to the cuda_api.h