### PR TITLE
Frozen Functions Kernel History

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -2305,6 +2305,25 @@ enum KernelType : uint32_t {
     Other
 };
 
+/**
+ * \brief Indicates, if the kernel was recorded or replayed by a frozen
+ * function.
+ *
+ * A frozen function, records kernel launches, and can replay them later. This
+ * enum indicates if the kernel was recorded or replayed by a frozen function,
+ * or not part of a frozen function at all.
+ */
+enum KernelRecordingMode : uint32_t {
+    /// This kernel was not launched as part of a frozen function.
+    None,
+
+    /// This kernel was recorded by a frozen function.
+    Recorded,
+
+    /// This kernel was replayed by a frozen function.
+    Replayed,
+};
+
 /// Data structure for preserving kernel launch information (debugging, testing)
 struct KernelHistoryEntry {
     /// Jit backend, for which the kernel was compiled
@@ -2312,6 +2331,9 @@ struct KernelHistoryEntry {
 
     /// Kernel type
     KernelType type;
+
+    /// Was this kernel recorded or replayed by a frozen function?
+    KernelRecordingMode recording_mode;
 
     /// Stores the low/high 64 bits of the 128-bit hash kernel identifier
     uint64_t hash[2];

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -2309,7 +2309,7 @@ enum KernelType : uint32_t {
  * \brief Indicates, if the kernel was recorded or replayed by a frozen
  * function.
  *
- * A frozen function, records kernel launches, and can replay them later. This
+ * A frozen function records kernel launches and can replay them later. This
  * enum indicates if the kernel was recorded or replayed by a frozen function,
  * or not part of a frozen function at all.
  */

--- a/src/cuda_ts.cpp
+++ b/src/cuda_ts.cpp
@@ -45,11 +45,12 @@ static void submit_gpu(KernelType type, KernelRecordingMode recording_mode,
     }
 }
 
-Task *CUDAThreadState::launch(
-    Kernel kernel, KernelKey * /*key*/, XXH128_hash_t /*hash*/, uint32_t size,
-    std::vector<void *> *kernel_params,
-    const std::vector<uint32_t> * /*kernel_param_ids*/,
-    KernelHistoryEntry *kernel_history_entry, uint32_t /*operation_count*/) {
+Task *
+CUDAThreadState::launch(Kernel kernel, KernelKey * /*key*/,
+                        XXH128_hash_t /*hash*/, uint32_t size,
+                        std::vector<void *> *kernel_params,
+                        const std::vector<uint32_t> * /*kernel_param_ids*/,
+                        KernelHistoryEntry *kernel_history_entry) {
     if (kernel_history_entry) {
         auto &e = *kernel_history_entry;
         cuda_check(cuEventCreate((CUevent *) &e.event_start, CU_EVENT_DEFAULT));

--- a/src/cuda_ts.h
+++ b/src/cuda_ts.h
@@ -4,7 +4,9 @@
 struct CUDAThreadState : ThreadState {
     Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                  uint32_t size, std::vector<void *> *kernel_params,
-                 const std::vector<uint32_t> *kernel_param_ids) override;
+                 const std::vector<uint32_t> *kernel_param_ids,
+                 KernelHistoryEntry *kernel_history_entry,
+                 uint32_t operation_count) override;
 
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/cuda_ts.h
+++ b/src/cuda_ts.h
@@ -5,8 +5,7 @@ struct CUDAThreadState : ThreadState {
     Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                  uint32_t size, std::vector<void *> *kernel_params,
                  const std::vector<uint32_t> *kernel_param_ids,
-                 KernelHistoryEntry *kernel_history_entry,
-                 uint32_t operation_count) override;
+                 KernelHistoryEntry *kernel_history_entry) override;
 
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -530,6 +530,7 @@ Task *jitc_run(ThreadState *ts, ScheduledGroup group) {
     auto it = state.kernel_cache.find(kernel_key);
     Kernel kernel;
     memset(&kernel, 0, sizeof(Kernel)); // quench uninitialized variable warning on MSVC
+    kernel.operation_count = n_ops_total;
 
     if (it == state.kernel_cache.end()) {
         bool cache_hit = false;
@@ -616,9 +617,8 @@ Task *jitc_run(ThreadState *ts, ScheduledGroup group) {
     if(unlikely(jit_flag(JitFlag::KernelHistory)))
         e = &kernel_history_entry;
 
-    Task *ret_task =
-        ts->launch(kernel, &kernel_key, kernel_hash, group.size, &kernel_params,
-                   &kernel_param_ids, e, n_ops_total);
+    Task *ret_task = ts->launch(kernel, &kernel_key, kernel_hash, group.size,
+                                &kernel_params, &kernel_param_ids, e);
 
     return ret_task;
 }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -494,6 +494,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
     if (unlikely(jit_flag(JitFlag::KernelHistory))) {
         kernel_history_entry.backend = backend;
         kernel_history_entry.type = KernelType::JIT;
+        kernel_history_entry.recording_mode = ts->recording_mode;
         kernel_history_entry.hash[0] = kernel_hash.low64;
         kernel_history_entry.hash[1] = kernel_hash.high64;
         kernel_history_entry.ir = (char *) malloc_check(buffer.size() + 1);

--- a/src/internal.h
+++ b/src/internal.h
@@ -626,6 +626,10 @@ struct ThreadStateBase {
     /// .. and the JIT variable that it will be mapped to
     uint32_t call_self_index = 0;
 
+    /// Indicates, if the thread state is used to record or replay frozen
+    /// functions.
+    KernelRecordingMode recording_mode = KernelRecordingMode::None;
+
     /// ---------------------------- CUDA-specific ----------------------------
 
     /// Redundant copy of the device context

--- a/src/internal.h
+++ b/src/internal.h
@@ -687,7 +687,9 @@ struct ThreadState : public ThreadStateBase {
 
     virtual Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                          uint32_t size, std::vector<void *> *kernel_params,
-                         const std::vector<uint32_t> *kernel_param_ids) = 0;
+                         const std::vector<uint32_t> *kernel_param_ids,
+                         KernelHistoryEntry *kernel_history_entry,
+                         uint32_t operation_count) = 0;
 
     /// Fill a device memory region with constants of a given type
     virtual void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/internal.h
+++ b/src/internal.h
@@ -688,8 +688,7 @@ struct ThreadState : public ThreadStateBase {
     virtual Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                          uint32_t size, std::vector<void *> *kernel_params,
                          const std::vector<uint32_t> *kernel_param_ids,
-                         KernelHistoryEntry *kernel_history_entry,
-                         uint32_t operation_count) = 0;
+                         KernelHistoryEntry *kernel_history_entry) = 0;
 
     /// Fill a device memory region with constants of a given type
     virtual void memset_async(void *ptr, uint32_t size, uint32_t isize,

--- a/src/io.h
+++ b/src/io.h
@@ -23,6 +23,7 @@ enum class JitBackend: uint32_t;
 struct Kernel {
     void *data;
     uint32_t size;
+    uint32_t operation_count;
     union {
         /// 1. CUDA
         struct {

--- a/src/llvm_ts.cpp
+++ b/src/llvm_ts.cpp
@@ -73,11 +73,12 @@ void LLVMThreadState::barrier() {
     scheduled_tasks.clear();
 }
 
-Task *LLVMThreadState::launch(
-    Kernel kernel, KernelKey * /*key*/, XXH128_hash_t /*hash*/, uint32_t size,
-    std::vector<void *> *kernel_params,
-    const std::vector<uint32_t> * /*kernel_param_ids*/,
-    KernelHistoryEntry *kernel_history_entry, uint32_t /*operation_count*/) {
+Task *
+LLVMThreadState::launch(Kernel kernel, KernelKey * /*key*/,
+                        XXH128_hash_t /*hash*/, uint32_t size,
+                        std::vector<void *> *kernel_params,
+                        const std::vector<uint32_t> * /*kernel_param_ids*/,
+                        KernelHistoryEntry *kernel_history_entry) {
     Task *ret_task = nullptr;
 
     uint32_t packet_size = jitc_llvm_vector_width,

--- a/src/llvm_ts.cpp
+++ b/src/llvm_ts.cpp
@@ -73,11 +73,11 @@ void LLVMThreadState::barrier() {
     scheduled_tasks.clear();
 }
 
-Task *
-LLVMThreadState::launch(Kernel kernel, KernelKey * /*key*/,
-                        XXH128_hash_t /*hash*/, uint32_t size,
-                        std::vector<void *> *kernel_params,
-                        const std::vector<uint32_t> * /*kernel_param_ids*/) {
+Task *LLVMThreadState::launch(
+    Kernel kernel, KernelKey * /*key*/, XXH128_hash_t /*hash*/, uint32_t size,
+    std::vector<void *> *kernel_params,
+    const std::vector<uint32_t> * /*kernel_param_ids*/,
+    KernelHistoryEntry *kernel_history_entry, uint32_t /*operation_count*/) {
     Task *ret_task = nullptr;
 
     uint32_t packet_size = jitc_llvm_vector_width,
@@ -166,6 +166,13 @@ LLVMThreadState::launch(Kernel kernel, KernelKey * /*key*/,
         task_wait(ret_task);
 
     scheduled_tasks.push_back(ret_task);
+
+    if (kernel_history_entry) {
+        task_retain(ret_task);
+        kernel_history_entry->task = ret_task;
+        state.kernel_history.append(*kernel_history_entry);
+    }
+
     return ret_task;
 }
 

--- a/src/llvm_ts.cpp
+++ b/src/llvm_ts.cpp
@@ -9,8 +9,8 @@
 
 /// Helper function: enqueue parallel CPU task (synchronous or asynchronous)
 template <typename Func>
-static void submit_cpu(KernelType type, Func &&func, uint32_t width,
-                       uint32_t size = 1) {
+static void submit_cpu(KernelType type, KernelRecordingMode recording_mode,
+                       Func &&func, uint32_t width, uint32_t size = 1) {
 
     struct Payload { Func f; };
     Payload payload{ std::forward<Func>(func) };
@@ -32,6 +32,7 @@ static void submit_cpu(KernelType type, Func &&func, uint32_t width,
         KernelHistoryEntry entry = {};
         entry.backend = JitBackend::LLVM;
         entry.type = type;
+        entry.recording_mode = recording_mode;
         entry.size = width;
         entry.input_count = 1;
         entry.output_count = 1;
@@ -193,7 +194,7 @@ void LLVMThreadState::memset_async(void *ptr, uint32_t size_, uint32_t isize,
     uint8_t src8[8] { };
     std::memcpy(&src8, src, isize);
 
-    submit_cpu(KernelType::Other,
+    submit_cpu(KernelType::Other, this->recording_mode,
         [ptr, src8, size, isize](uint32_t) {
             switch (isize) {
                 case 1:
@@ -303,6 +304,7 @@ void LLVMThreadState::block_reduce(VarType vt, ReduceOp op, uint32_t size,
 
     submit_cpu(
         KernelType::Reduce,
+        this->recording_mode,
         [red, work_unit_size, size, block_size, chunk_size, chunk_count, chunks_per_block, in, buf](uint32_t index) {
             red(index, work_unit_size, size, block_size, chunk_size, chunk_count, chunks_per_block, in, buf);
         },
@@ -387,6 +389,7 @@ void LLVMThreadState::block_prefix_reduce(VarType vt, ReduceOp op,
 
         submit_cpu(
             KernelType::Reduce,
+            this->recording_mode,
             [red_1, work_unit_size, size, block_size, chunk_size, chunk_count,
              chunks_per_block, in, scratch](uint32_t index) {
                 red_1(index, work_unit_size, size, block_size, chunk_size,
@@ -410,6 +413,7 @@ void LLVMThreadState::block_prefix_reduce(VarType vt, ReduceOp op,
 
     submit_cpu(
         KernelType::Reduce,
+        this->recording_mode,
         [red_2, work_unit_size, size, block_size, chunk_size, chunk_count,
          chunks_per_block, exclusive, reverse, in, scratch,
          out](uint32_t index) {
@@ -431,6 +435,7 @@ void LLVMThreadState::poke(void *dst, const void *src, uint32_t size) {
 
     submit_cpu(
         KernelType::Other,
+        this->recording_mode,
         [src8, size, dst](uint32_t) {
             std::memcpy(dst, &src8, size);
         },
@@ -462,6 +467,7 @@ void LLVMThreadState::reduce_dot(VarType type, const void *ptr_1,
     Reduction2 reduction = jitc_reduce_dot_create(type);
     submit_cpu(
         KernelType::Reduce,
+        this->recording_mode,
         [block_size, size, tsize, ptr_1, ptr_2, reduction, target](uint32_t index) {
             reduction(ptr_1, ptr_2, index * block_size,
                       std::min((index + 1) * block_size, size),
@@ -503,6 +509,7 @@ uint32_t LLVMThreadState::compress(const uint8_t *in, uint32_t size,
 
         submit_cpu(
             KernelType::Other,
+            this->recording_mode,
             [block_size, size, in, scratch](uint32_t index) {
                 uint32_t start = index * block_size,
                          end = std::min(start + block_size, size);
@@ -523,6 +530,7 @@ uint32_t LLVMThreadState::compress(const uint8_t *in, uint32_t size,
 
     submit_cpu(
         KernelType::Other,
+        this->recording_mode,
         [block_size, size, scratch, in, out, &count_out](uint32_t index) {
             uint32_t start = index * block_size,
                      end = std::min(start + block_size, size);
@@ -589,6 +597,7 @@ uint32_t LLVMThreadState::mkperm(const uint32_t *ptr, uint32_t size,
     // Phase 1
     submit_cpu(
         KernelType::CallReduce,
+        this->recording_mode,
         [block_size, size, buckets, bucket_count, ptr](uint32_t index) {
             ProfilerPhase profiler(profiler_region_mkperm_phase_1);
             uint32_t start = index * block_size,
@@ -610,6 +619,7 @@ uint32_t LLVMThreadState::mkperm(const uint32_t *ptr, uint32_t size,
     // Local accumulation step
     submit_cpu(
         KernelType::CallReduce,
+        this->recording_mode,
         [bucket_count, blocks, buckets, offsets, &unique_count](uint32_t) {
             uint32_t sum = 0, unique_count_local = 0;
             for (uint32_t i = 0; i < bucket_count; ++i) {
@@ -643,6 +653,7 @@ uint32_t LLVMThreadState::mkperm(const uint32_t *ptr, uint32_t size,
     // Phase 2
     submit_cpu(
         KernelType::CallReduce,
+        this->recording_mode,
         [block_size, size, buckets, perm, ptr](uint32_t index) {
             ProfilerPhase profiler(profiler_region_mkperm_phase_2);
 
@@ -677,6 +688,7 @@ void LLVMThreadState::memcpy(void *dst, const void *src, size_t size) {
 void LLVMThreadState::memcpy_async(void *dst, const void *src, size_t size) {
     submit_cpu(
         KernelType::Other,
+        this->recording_mode,
         [dst, src, size](uint32_t) {
             std::memcpy(dst, src, size);
         },
@@ -700,6 +712,7 @@ void LLVMThreadState::aggregate(void *dst_, AggregationEntry *agg,
 
     submit_cpu(
         KernelType::Other,
+        this->recording_mode,
         [dst_, agg, size, work_unit_size](uint32_t index) {
             uint32_t start = index * work_unit_size,
                      end = std::min(start + work_unit_size, size);
@@ -725,7 +738,8 @@ void LLVMThreadState::aggregate(void *dst_, AggregationEntry *agg,
         size, work_units);
 
     submit_cpu(
-        KernelType::Other, [agg](uint32_t) { free(agg); }, 1, 1);
+        KernelType::Other, this->recording_mode, [agg](uint32_t) { free(agg); },
+        1, 1);
 }
 
 void LLVMThreadState::enqueue_host_func(void (*callback)(void *),
@@ -735,7 +749,8 @@ void LLVMThreadState::enqueue_host_func(void (*callback)(void *),
         callback(payload);
     } else {
         submit_cpu(
-            KernelType::Other, [payload, callback](uint32_t) { callback(payload); }, 1, 1);
+            KernelType::Other, this->recording_mode,
+            [payload, callback](uint32_t) { callback(payload); }, 1, 1);
     }
 }
 
@@ -829,6 +844,7 @@ void LLVMThreadState::reduce_expanded(VarType vt, ReduceOp op, void *ptr,
 
     submit_cpu(
         KernelType::Reduce,
+        this->recording_mode,
         [ptr, block_size, exp, size, kernel](uint32_t index) {
             kernel(ptr, index * block_size,
                    std::min((index + 1) * block_size, size), exp, size);

--- a/src/llvm_ts.h
+++ b/src/llvm_ts.h
@@ -3,7 +3,9 @@
 struct LLVMThreadState : ThreadState {
     Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                  uint32_t size, std::vector<void *> *kernel_params,
-                 const std::vector<uint32_t> *) override;
+                 const std::vector<uint32_t> *,
+                 KernelHistoryEntry *kernel_history_entry,
+                 uint32_t operation_count) override;
 
     void barrier() override;
 

--- a/src/llvm_ts.h
+++ b/src/llvm_ts.h
@@ -4,8 +4,7 @@ struct LLVMThreadState : ThreadState {
     Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                  uint32_t size, std::vector<void *> *kernel_params,
                  const std::vector<uint32_t> *,
-                 KernelHistoryEntry *kernel_history_entry,
-                 uint32_t operation_count) override;
+                 KernelHistoryEntry *kernel_history_entry) override;
 
     void barrier() override;
 

--- a/src/record_ts.h
+++ b/src/record_ts.h
@@ -1,3 +1,11 @@
+/*
+    src/record_ts.h -- Backend for function freezing
+
+    Copyright (c) 2024 Wenzel Jakob <wenzel.jakob@epfl.ch>
+
+    All rights reserved. Use of this source code is governed by a BSD-style
+    license that can be found in the LICENSE file.
+*/
 #include "drjit-core/hash.h"
 #include "drjit-core/jit.h"
 #include "internal.h"
@@ -380,6 +388,8 @@ public:
         this->m_recording.backend = internal->backend;
 
         this->scope = internal->scope;
+
+        this->recording_mode = KernelRecordingMode::Recorded;
     };
 
     void barrier() override;

--- a/src/record_ts.h
+++ b/src/record_ts.h
@@ -72,6 +72,7 @@ struct Operation {
             KernelKey *key;
             Kernel kernel;
             XXH128_hash_t hash;
+            uint32_t operation_count;
         } kernel;
 
         /// The reduce type of a block reduction operation
@@ -396,7 +397,9 @@ public:
 
     Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                  uint32_t size, std::vector<void *> *kernel_params,
-                 const std::vector<uint32_t> *kernel_param_ids) override;
+                 const std::vector<uint32_t> *kernel_param_ids,
+                 KernelHistoryEntry *kernel_history_entry,
+                 uint32_t operation_count) override;
 
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,
@@ -563,7 +566,8 @@ public:
     /// Record a kernel launch
     void record_launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                        uint32_t size, std::vector<void *> *kernel_params,
-                       const std::vector<uint32_t> *kernel_param_ids);
+                       const std::vector<uint32_t> *kernel_param_ids,
+                       uint32_t operation_count);
     void record_memset_async(void *ptr, uint32_t size, uint32_t isize,
                              const void *src);
     void record_compress(const uint8_t *in, uint32_t size, uint32_t *out);

--- a/src/record_ts.h
+++ b/src/record_ts.h
@@ -72,7 +72,6 @@ struct Operation {
             KernelKey *key;
             Kernel kernel;
             XXH128_hash_t hash;
-            uint32_t operation_count;
         } kernel;
 
         /// The reduce type of a block reduction operation
@@ -398,8 +397,7 @@ public:
     Task *launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                  uint32_t size, std::vector<void *> *kernel_params,
                  const std::vector<uint32_t> *kernel_param_ids,
-                 KernelHistoryEntry *kernel_history_entry,
-                 uint32_t operation_count) override;
+                 KernelHistoryEntry *kernel_history_entry) override;
 
     /// Fill a device memory region with constants of a given type
     void memset_async(void *ptr, uint32_t size, uint32_t isize,
@@ -566,8 +564,7 @@ public:
     /// Record a kernel launch
     void record_launch(Kernel kernel, KernelKey *key, XXH128_hash_t hash,
                        uint32_t size, std::vector<void *> *kernel_params,
-                       const std::vector<uint32_t> *kernel_param_ids,
-                       uint32_t operation_count);
+                       const std::vector<uint32_t> *kernel_param_ids);
     void record_memset_async(void *ptr, uint32_t size, uint32_t isize,
                              const void *src);
     void record_compress(const uint8_t *in, uint32_t size, uint32_t *out);


### PR DESCRIPTION
Enables frozen functions to generate kernel history entries, when replaying kernels.