### PR TITLE
Frozen functions: Avoid invalid memory read for literals

### DIFF
--- a/src/record_ts.cpp
+++ b/src/record_ts.cpp
@@ -2250,11 +2250,11 @@ bool RecordThreadState::has_variable(const void *ptr) {
  * accessed.
  */
 void RecordThreadState::add_param(AccessInfo info) {
-    RecordedVariable &rv = m_recording.recorded_variables[info.slot];
     if (info.type == ParamType::Output) {
 
         jitc_log(LogLevel::Debug, " <- param s%u", info.slot);
 
+        RecordedVariable &rv = m_recording.recorded_variables[info.slot];
         if (info.vtype != VarType::Void)
             rv.type = info.vtype;
 
@@ -2264,6 +2264,7 @@ void RecordThreadState::add_param(AccessInfo info) {
 
         jitc_log(LogLevel::Debug, " -> param s%u", info.slot);
 
+        RecordedVariable &rv = m_recording.recorded_variables[info.slot];
         if (info.test_uninit && rv.state == RecordedVarState::Uninitialized)
             jitc_raise("record(): Variable at slot s%u was read by "
                        "operation o%u, but it had not yet been initialized! "


### PR DESCRIPTION
This fixes a small issue in record_ts: For literal variables, the `slot` field is undefined. Therefore, we need to make sure to only use `info.slot` if we are not in the case where `type == ParamType::Register`.

The current code likely "works" due to zero initialization of memory, but doesn't work when running with a sanitizer that explicitly does not zero initialize