### PR TITLE
Fix implicit FP32 casts

### DIFF
--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -1252,6 +1252,7 @@ static void jitc_llvm_render(Variable *v) {
 
         fmt("    %h$u = fptrunc <$w x float> %f$u to <$w x half>\n",
             v->reg_index, v->reg_index);
+        b->ssa_f32_cast = 1;
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue where a LLVM register could be defined twice when two FP16 operations which depend on eachother required FP32 upcasting, like `dr.minimum()` or `dr.maximum()`. A typical example of this is a call to `dr.clip()`.