### PR TITLE
Add ``jit_var_mul_wide()`` operation for wide integer multiplication

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -609,7 +609,10 @@ enum class JitOp : uint32_t {
     Add, Sub, Mul, Div, Mod,
 
     // High multiplication
-    Mulhi,
+    MulHi,
+
+    // Wide multiplication
+    MulWide,
 
     // Fused multiply-add
     Fma,
@@ -715,7 +718,10 @@ extern JIT_EXPORT uint32_t jit_var_div(uint32_t a0, uint32_t a1);
 extern JIT_EXPORT uint32_t jit_var_mod(uint32_t a0, uint32_t a1);
 
 /// Compute the high part of `a0 * a1` and return a variable representing the result
-extern JIT_EXPORT uint32_t jit_var_mulhi(uint32_t a0, uint32_t a1);
+extern JIT_EXPORT uint32_t jit_var_mul_hi(uint32_t a0, uint32_t a1);
+
+/// Compute all bits of `a0 * a1` and return a variable representing the result
+extern JIT_EXPORT uint32_t jit_var_mul_wide(uint32_t a0, uint32_t a1);
 
 /// Compute `a0 * a1 + a2` (fused) and return a variable representing the result
 extern JIT_EXPORT uint32_t jit_var_fma(uint32_t a0, uint32_t a1, uint32_t a2);

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1240,9 +1240,14 @@ uint32_t jit_var_mod(uint32_t a0, uint32_t a1) {
     return jitc_var_mod(a0, a1);
 }
 
-uint32_t jit_var_mulhi(uint32_t a0, uint32_t a1) {
+uint32_t jit_var_mul_hi(uint32_t a0, uint32_t a1) {
     lock_guard guard(state.lock);
-    return jitc_var_mulhi(a0, a1);
+    return jitc_var_mul_hi(a0, a1);
+}
+
+uint32_t jit_var_mul_wide(uint32_t a0, uint32_t a1) {
+    lock_guard guard(state.lock);
+    return jitc_var_mul_wide(a0, a1);
 }
 
 uint32_t jit_var_fma(uint32_t a0, uint32_t a1, uint32_t a2) {

--- a/src/common.h
+++ b/src/common.h
@@ -152,7 +152,7 @@ struct divisor {
         }
     }
 
-    uint32_t mulhi(uint32_t a, uint32_t b) const {
+    uint32_t mul_hi(uint32_t a, uint32_t b) const {
         return (uint32_t) (((uint64_t) a * (uint64_t) b) >> 32);
     }
 
@@ -163,7 +163,7 @@ struct divisor {
             div = input >> shift;
             rem = input - (div << shift);
         } else {
-            uint32_t hi = mulhi(input, magic);
+            uint32_t hi = mul_hi(input, magic);
             div = (((input - hi) >> 1) + hi) >> shift;
             rem = input - div * value;
         }

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -543,8 +543,12 @@ static void jitc_cuda_render(Variable *v) {
             fmt("    rem.$t $v, $v, $v;\n", v, v, a0, a1);
             break;
 
-        case VarKind::Mulhi:
+        case VarKind::MulHi:
             fmt("    mul.hi.$t $v, $v, $v;\n", v, v, a0, a1);
+            break;
+
+        case VarKind::MulWide:
+            fmt("    mul.wide.$t $v, $v, $v;\n", a0, v, a0, a1);
             break;
 
         case VarKind::Fma:

--- a/src/internal.h
+++ b/src/internal.h
@@ -43,10 +43,13 @@ enum class VarKind : uint32_t {
     // Common binary arithmetic operations
     Add, Sub, Mul, Div, DivApprox, Mod,
 
-    // High multiplication
-    Mulhi,
+    // High integer multiplication
+    MulHi,
 
-    // Fused multiply-add
+    // Wide integer multiplication
+    MulWide,
+
+    // Fused multiply-add (integers & floats)
     Fma,
 
     // Minimum, maximum

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -673,7 +673,7 @@ static void jitc_llvm_render(Variable *v) {
                 v, a0, a1);
             break;
 
-        case VarKind::Mulhi:
+        case VarKind::MulHi:
             fmt("    $v_0 = $sext $V to $D\n"
                 "    $v_1 = $sext $V to $D\n"
                 "    $v_3 = insertelement $D undef, $d $u, i32 0\n"
@@ -688,6 +688,15 @@ static void jitc_llvm_render(Variable *v) {
                 v, v, v, v,
                 v, v, v, v,
                 v, v, v, v);
+            break;
+
+        case VarKind::MulWide:
+            fmt("    $v_0 = $sext $V to $D\n"
+                "    $v_1 = $sext $V to $D\n"
+                "    $v = mul $D $v_0, $v_1\n",
+                v, jitc_is_uint(v) ? "z" : "s", a0, a0,
+                v, jitc_is_uint(v) ? "z" : "s", a1, a1,
+                v, a0, v, v);
             break;
 
         case VarKind::Fma:

--- a/src/op.h
+++ b/src/op.h
@@ -61,8 +61,9 @@ extern uint32_t jitc_var_mul(uint32_t a0, uint32_t a1);
 extern uint32_t jitc_var_div(uint32_t a0, uint32_t a1);
 extern uint32_t jitc_var_mod(uint32_t a0, uint32_t a1);
 
-// High multiplication
-extern uint32_t jitc_var_mulhi(uint32_t a0, uint32_t a1);
+// High and wide multiplication
+extern uint32_t jitc_var_mul_hi(uint32_t a0, uint32_t a1);
+extern uint32_t jitc_var_mul_wide(uint32_t a0, uint32_t a1);
 
 // Fused multiply-add
 extern uint32_t jitc_var_fma(uint32_t a0, uint32_t a1, uint32_t a2);

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -55,7 +55,7 @@ const char *type_name_llvm[(int) VarType::Count] {
     "i32", "i64", "i64", "i64", "???", "half", "float", "double"
 };
 
-/// Double size integer arrays for mulhi()
+/// Double size integer arrays for mul_hi()
 const char *type_name_llvm_big[(int) VarType::Count] {
     "???", "???",  "i16",  "i16", "i32", "i32", "i64",
     "i64", "i128", "i128", "???", "???", "???", "???", "???"
@@ -148,10 +148,13 @@ const char *var_kind_name[(int) VarKind::Count] {
     // Common binary arithmetic operations
     "add", "sub", "mul", "div", "div.approx", "mod",
 
-    // High multiplication
-    "mulhi",
+    // High integer multiplication
+    "mul_hi",
 
-    // Fused multiply-add
+    // Wide integer multiplication
+    "mul_wide",
+
+    // Fused multiply-add (integers & floats)
     "fma",
 
     // Minimum, maximum

--- a/tests/basics.cpp
+++ b/tests/basics.cpp
@@ -131,7 +131,7 @@ const char *op_name[(int) JitOp::Count] {
     "add", "sub", "mul", "div", "mod",
 
     // High multiplication
-    "mulhi",
+    "mul_hi",
 
     // Fused multiply-add
     "fma",
@@ -283,14 +283,14 @@ template <typename T> bool test_const_prop() {
          { JitOp::Add, JitOp::Sub, JitOp::Mul, JitOp::Div,
            JitOp::Mod, JitOp::Min, JitOp::Max, JitOp::And, JitOp::Or,
            JitOp::Xor, JitOp::Shl, JitOp::Shr, JitOp::Eq, JitOp::Neq,
-           JitOp::Lt, JitOp::Le, JitOp::Gt, JitOp::Ge, JitOp::Mulhi }) {
+           JitOp::Lt, JitOp::Le, JitOp::Gt, JitOp::Ge, JitOp::MulHi }) {
         if (op == JitOp::Mod && IsFloat)
             continue;
         if ((IsFloat || IsMask) && (op == JitOp::Shl || op == JitOp::Shr))
             continue;
         if (IsMask && !(op == JitOp::Or || op == JitOp::And || op == JitOp::Xor))
             continue;
-        if (!IsInt && op == JitOp::Mulhi)
+        if (!IsInt && op == JitOp::MulHi)
             continue;
 
         for (uint32_t i = 0; i < Size2; ++i)


### PR DESCRIPTION
This PR adds a wide (e.g. i32xi32 -> i64) integer multiplication node, which is the central operation underlying the Philox pseudorandom number generator.

Test coverage is added separately at the Dr.Jit level.