### PR TITLE
Fixed literal target for jitc_coop_vec_outer_product_accum

### DIFF
--- a/src/coop_vec.cpp
+++ b/src/coop_vec.cpp
@@ -678,8 +678,8 @@ uint32_t jitc_coop_vec_outer_product_accum(uint32_t target_,
     }
 
     void *p = nullptr;
-    Ref tmp = steal(jitc_var_data(target, false, &p));
-    Ref target_ptr = steal(jitc_var_pointer(backend, p, tmp, 1));
+    target = steal(jitc_var_data(target, false, &p));
+    Ref target_ptr = steal(jitc_var_pointer(backend, p, target, 1));
 
     Ref mask = steal(jitc_var_bool(backend, true));
     mask = steal(jitc_var_mask_apply(mask, size));


### PR DESCRIPTION
This PR fixes the case where the target buffer of `jitc_coop_vec_outer_product_accum` is a literal instead of a buffer or nothing, by returning the opaque version of the target, in which the operation accumulates. The fix is inspired by the `jitc_var_scatter` function. This fixes a bug where gradients of neural networks would not be calculated correctly, if the previous gradient was a non zero sized literal, for example wen setting it in beforehand.