### PR TITLE
Add vcall func name to error msg

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -614,7 +614,7 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
         call->use_optix |= call2->use_optix;
         call->use_index |= call2->use_index;
         call->use_thread_id |= call2->use_thread_id;
-        for (uint32_t index_2 : call2->outer_in)
+        for (uint32_t index_2: call2->outer_in)
             jitc_var_call_analyze(call, inst_id, index_2, data_offset);
     } else if (kind == VarKind::LoopCond) {
         LoopData *loop = (LoopData *) jitc_var(v->dep[0])->data;

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -319,7 +319,7 @@ void jitc_cuda_assemble_func(const CallData *call, uint32_t inst,
 
             if (unlikely(it == call->data_map.end())) {
                 jitc_fail("jitc_cuda_assemble_func(): could not find entry for "
-                          "variable r%u in 'data_map'", sv.index);
+                          "variable r%u in 'data_map' for function %s", sv.index, call->name.c_str());
                 continue;
             }
 

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -345,7 +345,7 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
             auto it = call->data_map.find(key);
             if (unlikely(it == call->data_map.end())) {
                 jitc_fail("jitc_llvm_assemble_func(): could not find entry for "
-                          "variable r%u in 'data_map'", sv.index);
+                          "variable r%u in 'data_map' for function %s", sv.index, call->name.c_str());
                 continue;
             }
 


### PR DESCRIPTION
This simple patch adds vcall function names to the error message for easier debugging.