### PR TITLE
Add missing checks for jit_leak_warnings

### DIFF
--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -511,15 +511,17 @@ void jitc_malloc_shutdown() {
     for (int i = 0; i < (int) AllocType::Count; ++i)
         total += leak_count[i];
 
-    if (total > 0) {
-        jitc_log(Warn, "jit_malloc_shutdown(): leaked");
-        for (int i = 0; i < (int) AllocType::Count; ++i) {
-            if (leak_count[i] == 0)
-                continue;
+    if (jit_leak_warnings()) {
+        if (total > 0) {
+            jitc_log(Warn, "jit_malloc_shutdown(): leaked");
+            for (int i = 0; i < (int) AllocType::Count; ++i) {
+                if (leak_count[i] == 0)
+                    continue;
 
-            jitc_log(Warn, " - %s memory: %s in %zu allocation%s",
-                    alloc_type_name[i], jitc_mem_string(leak_size[i]),
-                    leak_count[i], leak_count[i] > 1 ? "s" : "");
+                jitc_log(Warn, " - %s memory: %s in %zu allocation%s",
+                        alloc_type_name[i], jitc_mem_string(leak_size[i]),
+                        leak_count[i], leak_count[i] > 1 ? "s" : "");
+            }
         }
     }
 }

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -250,17 +250,19 @@ void jitc_registry_clear() {
 void jitc_registry_shutdown() {
     Registry &r = registry;
 
-    if (!r.rev_map.empty()) {
-        std::vector<size_t> leak_counts(r.domains.size(), 0);
+    if (jit_leak_warnings()) {
+        if (!r.rev_map.empty()) {
+            std::vector<size_t> leak_counts(r.domains.size(), 0);
 
-        for (const auto &entry : r.rev_map)
-            leak_counts.at(entry.second.domain_id)++;
+            for (const auto &entry : r.rev_map)
+                leak_counts.at(entry.second.domain_id)++;
 
-        for (size_t i = 0; i < r.domains.size(); i++) {
-            if (leak_counts[i] > 0)
-                jitc_log(Warn,
-                         "jit_registry_shutdown(): leaking %zu instances of type \"%s\".",
-                         leak_counts[i], r.domains[i].name);
+            for (size_t i = 0; i < r.domains.size(); i++) {
+                if (leak_counts[i] > 0)
+                    jitc_log(Warn,
+                            "jit_registry_shutdown(): leaking %zu instances of type \"%s\".",
+                            leak_counts[i], r.domains[i].name);
+            }
         }
     }
 


### PR DESCRIPTION
This patch adds missing checks for `jit_leak_warnings`.