### PR TITLE
Event API

### DIFF
--- a/src/cuda.h
+++ b/src/cuda.h
@@ -94,3 +94,12 @@ extern CUfunction *jitc_cuda_block_prefix_reduce[(int) ReduceOp::Count]
                                                 [(int) VarType::Count][10];
 extern CUfunction *jitc_cuda_reduce_dot[(int) VarType::Count];
 extern CUfunction *jitc_cuda_aggregate;
+
+/// Event API functions for CUDA backend
+typedef struct JitEvent_* JitEvent;
+extern JitEvent jitc_cuda_event_create(bool enable_timing);
+extern void jitc_cuda_event_destroy(JitEvent event);
+extern void jitc_cuda_event_record(JitEvent event);
+extern int jitc_cuda_event_query(JitEvent event);
+extern void jitc_cuda_event_wait(JitEvent event);
+extern float jitc_cuda_event_elapsed_time(JitEvent start, JitEvent end);

--- a/src/cuda_api.cpp
+++ b/src/cuda_api.cpp
@@ -95,6 +95,7 @@ bool jitc_cuda_api_init() {
         LOAD(cuEventRecord);
         LOAD(cuEventSynchronize);
         LOAD(cuEventElapsedTime);
+        LOAD(cuEventQuery);
         LOAD(cuFuncSetAttribute);
         LOAD(cuGetErrorName);
         LOAD(cuGetErrorString);

--- a/src/cuda_api.h
+++ b/src/cuda_api.h
@@ -78,6 +78,7 @@ extern CUresult (*cuStreamWaitEvent_ptsz)(CUstream, CUevent, unsigned int);
 #  define CUDA_ERROR_OUT_OF_MEMORY 2
 #  define CUDA_ERROR_INVALID_GRAPHICS_CONTEXT 219
 #  define CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED 704
+#  define CUDA_ERROR_NOT_READY 600
 #  define CUDA_SUCCESS 0
 
 #define CU_RESOURCE_TYPE_ARRAY 0
@@ -229,6 +230,7 @@ DR_CUDA_SYM(CUresult (*cuDriverGetVersion)(int *));
 DR_CUDA_SYM(CUresult (*cuEventCreate)(CUevent *, unsigned int));
 DR_CUDA_SYM(CUresult (*cuEventDestroy)(CUevent));
 DR_CUDA_SYM(CUresult (*cuEventRecord)(CUevent, CUstream));
+DR_CUDA_SYM(CUresult (*cuEventQuery)(CUevent));
 DR_CUDA_SYM(CUresult (*cuEventSynchronize)(CUevent));
 DR_CUDA_SYM(CUresult (*cuEventElapsedTime)(float *, CUevent, CUevent));
 DR_CUDA_SYM(CUresult (*cuFuncSetAttribute)(CUfunction, int, int));

--- a/src/internal.h
+++ b/src/internal.h
@@ -1143,4 +1143,28 @@ extern bool jitc_is_max(Variable *v);
 extern bool jitc_is_min(Variable *v);
 inline void jitc_var_set_data(Variable &v, void *data) { v.data = data; }
 
+// ====================================================================
+//                         Event data structure
+// ====================================================================
+
+struct EventData {
+    JitBackend backend;
+    bool enable_timing;
+    ThreadState* ts;
+    union {
+        CUevent cuda_event;
+        Task* llvm_task;
+    };
+
+    EventData(JitBackend backend, bool enable_timing)
+        : backend(backend), enable_timing(enable_timing), ts(nullptr) {
+        if (backend == JitBackend::CUDA)
+            cuda_event = nullptr;
+        else
+            llvm_task = nullptr;
+    }
+
+    ~EventData() = default;
+};
+
 extern const char *var_kind_name[(int) VarKind::Count];

--- a/src/llvm.h
+++ b/src/llvm.h
@@ -122,3 +122,12 @@ extern void jitc_llvm_ray_trace(uint32_t func, uint32_t scene, int shadow_ray,
 /// atomic scatter.
 extern std::pair<uint32_t, uint32_t>
 jitc_llvm_expand_replication_factor(uint32_t size, uint32_t tsize);
+
+/// Event API functions for LLVM backend
+typedef struct JitEvent_* JitEvent;
+extern JitEvent jitc_llvm_event_create(bool enable_timing);
+extern void jitc_llvm_event_destroy(JitEvent event);
+extern void jitc_llvm_event_record(JitEvent event);
+extern int jitc_llvm_event_query(JitEvent event);
+extern void jitc_llvm_event_wait(JitEvent event);
+extern float jitc_llvm_event_elapsed_time(JitEvent start, JitEvent end);


### PR DESCRIPTION
This PR adds a new event API to Dr.Jit-core.

This functionality directly maps to standard CUDA events on the CUDA backend. The LLVM backend provides the same interface via the nanothread thread pool.

This feature makes it possible to:

1. Record an event (recording multiple times invalidates the old event)

2. Query the event for completion without blocking

3. Blocking to wait for event completion. This is especially useful to wait for an event scheduled some time ago, which can be much more efficient than ``jit_sync_thread/device()`` when other work was scheduled in the meantime.

4. Measuring the relative time between two events. This provides a cheaper alternative to the kernel history for simple benchmarking tasks.

5. Extracting the native event pointer for advanced use cases


Discussion:

- The event API does not do anything clever with regards to kernel freezing at the moment. It was not clear to me if this even makes sense. Events cannot be fused into kernels, and they don't produce outputs or consume array inputs. How would one replay events, and where would they be stored? So I am assuming this is a feature that will be used outside of frozen functions.