### PR TITLE
New JIT nodes for `dr.scatter_cas()` and `dr.scatter_exch()`

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1053,6 +1053,31 @@ extern JIT_EXPORT uint32_t jit_var_scatter_inc(uint32_t *target,
                                                uint32_t mask);
 
 /**
+ * \brief Perform an atomic compare-and-swap
+ *
+ * This operation is similar to ``jit_var_scatter`` but with an extra comparison
+ * before writing the new value. More specifically, it will compare the current
+ * value in the target buffer against ``compare``, and will only write the new
+ * value if these two match. This operation is atomic on each lane, collisions
+ * in the ``index`` variable can therefore produce non-deterministic results.
+ *
+ * It returns two new variables ``old`` and ``success`, the former holds the
+ * original value of the target buffer at the looked up index and the latter is
+ * a boolean array which is only set to true for indices where the new value
+ * was written.
+ *
+ * The ``target`` argument will be updated if it is unsafe to directly write to
+ * it.
+ */
+extern JIT_EXPORT void jit_var_scatter_cas(uint32_t *target,
+                                           uint32_t compare,
+                                           uint32_t value,
+                                           uint32_t index,
+                                           uint32_t mask,
+                                           uint32_t *old,
+                                           uint32_t *success);
+
+/**
  * \brief Create an identical copy of the given variable
  *
  * This function creates an exact copy of the variable \c index and returns the

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -1053,6 +1053,22 @@ extern JIT_EXPORT uint32_t jit_var_scatter_inc(uint32_t *target,
                                                uint32_t mask);
 
 /**
+ * \brief Atomically exchange values
+ *
+ * This operation is almost exactly like ``jit_var_scatter``, it differs in the
+ * fact that it also returns the previous value of the ``target`` (before
+ * writing the new ``value``). This operation is atomic on each lane, collisions
+ * in the ``index`` variable can therefore produce non-deterministic results.
+ *
+ * The ``target`` argument will be updated if it is unsafe to directly write to
+ * it.
+ */
+extern JIT_EXPORT uint32_t jit_var_scatter_exch(uint32_t *target,
+                                                uint32_t value,
+                                                uint32_t index,
+                                                uint32_t mask);
+
+/**
  * \brief Perform an atomic compare-and-swap
  *
  * This operation is similar to ``jit_var_scatter`` but with an extra comparison
@@ -1084,7 +1100,6 @@ extern JIT_EXPORT void jit_var_scatter_cas(uint32_t *target,
  * index of the copy, whose reference count is initialized to 1.
  */
 extern JIT_EXPORT uint32_t jit_var_copy(uint32_t index);
-
 
 /**
  * Register an existing memory region as a variable in the JIT compiler, and

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -602,6 +602,12 @@ uint32_t jit_var_scatter_inc(uint32_t *target, uint32_t index, uint32_t mask) {
     return jitc_var_scatter_inc(target, index, mask);
 }
 
+uint32_t jit_var_scatter_exch(uint32_t *target, uint32_t value, uint32_t index,
+                              uint32_t mask) {
+    lock_guard guard(state.lock);
+    return jitc_var_scatter_exch(target, value, index, mask);
+}
+
 void jit_var_scatter_cas(uint32_t *target, uint32_t compare, uint32_t value,
                          uint32_t index, uint32_t mask, uint32_t *old,
                          uint32_t *success) {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -602,6 +602,13 @@ uint32_t jit_var_scatter_inc(uint32_t *target, uint32_t index, uint32_t mask) {
     return jitc_var_scatter_inc(target, index, mask);
 }
 
+void jit_var_scatter_cas(uint32_t *target, uint32_t compare, uint32_t value,
+                         uint32_t index, uint32_t mask, uint32_t *old,
+                         uint32_t *success) {
+    lock_guard guard(state.lock);
+    jitc_var_scatter_cas(target, compare, value, index, mask, old, success);
+}
+
 uint32_t jit_var_pointer(JitBackend backend, const void *value,
                          uint32_t dep, int write) {
     lock_guard guard(state.lock);

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -954,6 +954,10 @@ static void jitc_cuda_render(Variable *v) {
             jitc_cuda_render_scatter_add_kahan(v, a0, a1, a2, a3);
             break;
 
+        case VarKind::ScatterCAS:
+            jitc_cuda_render_scatter_cas(v, a0, a1, a2, a3);
+            break;
+
         case VarKind::BoundsCheck:
             fmt("    setp.ge.and.u32 $v, $v, $u, $v;\n"
                 "    @$v st.global.u32 [$v], $v;\n"

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -954,6 +954,10 @@ static void jitc_cuda_render(Variable *v) {
             jitc_cuda_render_scatter_add_kahan(v, a0, a1, a2, a3);
             break;
 
+        case VarKind::ScatterExch:
+            jitc_cuda_render_scatter_exch(v, a0, a1, a2, a3);
+            break;
+
         case VarKind::ScatterCAS:
             jitc_cuda_render_scatter_cas(v, a0, a1, a2, a3);
             break;

--- a/src/cuda_scatter.cpp
+++ b/src/cuda_scatter.cpp
@@ -481,6 +481,26 @@ void jitc_cuda_render_scatter_add_kahan(const Variable *v,
     fmt("\nl_$u_done:\n", v->reg_index);
 }
 
+void jitc_cuda_render_scatter_exch(Variable *v,
+                                   const Variable *ptr,
+                                   const Variable *value,
+                                   const Variable *index,
+                                   const Variable *mask) {
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+
+    jitc_cuda_prepare_index(ptr, index, index);
+
+    fmt("    mov.$b $v, 0;\n"
+        "    ",
+        v, v);
+    if (!is_unmasked)
+        fmt("@$v ", mask);
+    fmt("atom.global.exch.$b $v, [%rd3], $v;\n",
+        value, v, value);
+
+    v->consumed = 1;
+}
+
 void jitc_cuda_render_scatter_cas(Variable *v,
                                   const Variable *ptr,
                                   const Variable *compare,

--- a/src/cuda_scatter.h
+++ b/src/cuda_scatter.h
@@ -33,6 +33,12 @@ extern void jitc_cuda_render_scatter_add_kahan(const Variable *v,
                                                const Variable *index,
                                                const Variable *value);
 
+extern void jitc_cuda_render_scatter_exch(Variable *v,
+                                          const Variable *ptr,
+                                          const Variable *value,
+                                          const Variable *index,
+                                          const Variable *mask);
+
 extern void jitc_cuda_render_scatter_cas(Variable *v,
                                          const Variable *ptr,
                                          const Variable *compare,

--- a/src/cuda_scatter.h
+++ b/src/cuda_scatter.h
@@ -32,3 +32,9 @@ extern void jitc_cuda_render_scatter_add_kahan(const Variable *v,
                                                const Variable *ptr_2,
                                                const Variable *index,
                                                const Variable *value);
+
+extern void jitc_cuda_render_scatter_cas(Variable *v,
+                                         const Variable *ptr,
+                                         const Variable *compare,
+                                         const Variable *value,
+                                         const Variable *index);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -253,7 +253,8 @@ static void jitc_var_traverse(uint32_t size, uint32_t index, uint32_t depth = 0)
             "evalute the consumed variables if they are required by operations "
             "in an other kernel."
             "\nThis can happen when trying to re-use the outputs of the "
-            "dr.scatter_inc() or dr.sactter_cas() operations.", index);
+            "dr.scatter_inc(), dr.scatter_exch() or dr.sactter_cas() "
+            "operations.", index);
 
     if (depth == 0) {
         // If we're visiting this variable the first time regardless of size

--- a/src/internal.h
+++ b/src/internal.h
@@ -86,7 +86,7 @@ enum class VarKind : uint32_t {
     BoundsCheck,
 
     // Memory-related operations
-    Gather, Scatter, ScatterInc, ScatterKahan, ScatterCAS,
+    Gather, Scatter, ScatterInc, ScatterKahan, ScatterCAS, ScatterExch,
 
     // Gather multiple contiguous values at once
     PacketGather,

--- a/src/internal.h
+++ b/src/internal.h
@@ -86,7 +86,7 @@ enum class VarKind : uint32_t {
     BoundsCheck,
 
     // Memory-related operations
-    Gather, Scatter, ScatterInc, ScatterKahan,
+    Gather, Scatter, ScatterInc, ScatterKahan, ScatterCAS,
 
     // Gather multiple contiguous values at once
     PacketGather,

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -986,6 +986,10 @@ static void jitc_llvm_render(Variable *v) {
             jitc_llvm_render_scatter_add_kahan(v, a0, a1, a2, a3);
             break;
 
+        case VarKind::ScatterExch:
+            jitc_llvm_render_scatter_exch(v, a0, a1, a2, a3);
+            break;
+
         case VarKind::ScatterCAS:
             jitc_llvm_render_scatter_cas(v, a0, a1, a2, a3);
             break;

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -986,6 +986,10 @@ static void jitc_llvm_render(Variable *v) {
             jitc_llvm_render_scatter_add_kahan(v, a0, a1, a2, a3);
             break;
 
+        case VarKind::ScatterCAS:
+            jitc_llvm_render_scatter_cas(v, a0, a1, a2, a3);
+            break;
+
         case VarKind::PacketGather:
             jitc_llvm_render_gather_packet(v, a0, a1, a2);
             break;

--- a/src/llvm_scatter.h
+++ b/src/llvm_scatter.h
@@ -33,5 +33,11 @@ extern void jitc_llvm_render_scatter_inc(Variable *v, const Variable *ptr,
                                          const Variable *index,
                                          const Variable *mask);
 
+extern void jitc_llvm_render_scatter_cas(Variable *v,
+                                         const Variable *ptr,
+                                         const Variable *compare,
+                                         const Variable *value,
+                                         const Variable *index);
+
 extern const char *jitc_llvm_append_reduce_op_local(VarType vt, ReduceOp op,
                                                     const Variable *v);

--- a/src/llvm_scatter.h
+++ b/src/llvm_scatter.h
@@ -33,6 +33,12 @@ extern void jitc_llvm_render_scatter_inc(Variable *v, const Variable *ptr,
                                          const Variable *index,
                                          const Variable *mask);
 
+extern void jitc_llvm_render_scatter_exch(Variable *v,
+                                          const Variable *ptr,
+                                          const Variable *value,
+                                          const Variable *index,
+                                          const Variable *mask);
+
 extern void jitc_llvm_render_scatter_cas(Variable *v,
                                          const Variable *ptr,
                                          const Variable *compare,

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -1749,6 +1749,10 @@ uint32_t jitc_var_check_bounds(BoundsCheckType bct, uint32_t index,
                         msg = "drjit.scatter_add_kahan(): out-of-bounds write to position";
                         break;
 
+                    case BoundsCheckType::ScatterCAS:
+                        msg = "drjit.scatter_cas(): out-of-bounds write to position";
+                        break;
+
                     case BoundsCheckType::ArrayRead:
                         msg = "drjit.Local.read(): out-of-bounds read from position";
                         break;
@@ -2252,6 +2256,150 @@ uint32_t jitc_var_scatter_inc(uint32_t *target_p, uint32_t index, uint32_t mask)
     jitc_var_mark_side_effect(se.release());
 
     return result;
+}
+
+void jitc_var_scatter_cas(uint32_t *target_p, uint32_t compare, uint32_t value,
+                          uint32_t index, uint32_t mask, uint32_t *old,
+                          uint32_t *success) {
+    auto print_log = [&](const char *msg) {
+        int type_id = 0;
+        if (value)
+            type_id = jitc_var(value)->type;
+
+        jitc_log(Debug,
+                 "jit_var_scatter_cas(): (r%u, r%u) = (r%u[r%u] == r%u) ? r%u : r%u[r%u] "
+                 "(type=%s, mask=r%u) [%s]",
+                 *old, *success, *target_p, index, compare, value, *target_p, index,
+                 type_name[type_id], mask, msg);
+    };
+
+    if (*target_p == 0)
+        jitc_raise("jit_var_scatter_cas(): attempted to scatter to an empty array!");
+
+    auto [var_info, compare_v, value_v, index_v, mask_v] =
+        jitc_var_check("jit_var_scatter_cas", compare, value, index, mask);
+
+    Ref target = borrow(*target_p);
+    auto [target_info, target_v] =
+        jitc_var_check("jit_var_scatter_cas", (uint32_t) target);
+
+    // Go to the original if 'target' is wrapped into a loop state variable
+    unwrap(target, target_v);
+
+    if (target_v->symbolic)
+        jitc_raise(
+            "jit_var_scatter_cas(): cannot scatter to a symbolic variable (r%u)!",
+            (uint32_t) target);
+    if (target_v->type != compare_v->type || compare_v->type != value_v->type)
+        jitc_raise("jit_var_scatter_cas(): 'target', 'old_value' and "
+                   "'new_value' must have the same type.");
+    if ((VarType) index_v->type != VarType::UInt32)
+        jitc_raise(
+            "jit_var_scatter_cas(): 'index' must be an unsigned 32-bit array.");
+
+    uint32_t flags = jitc_flags();
+    bool symbolic = flags & (uint32_t) JitFlag::SymbolicScope;
+
+    if (var_info.symbolic && !symbolic)
+        jitc_raise(
+            "jit_var_scatter_cas(): input arrays are symbolic, but the "
+            "operation was issued outside of a symbolic recording session.");
+
+    if (target_v->is_literal() && new_v->is_literal() &&
+        target_v->literal == new_v->literal) {
+        print_log("skipped, target/source are value variables with the "
+                  "same value");
+        target.release();
+        return;
+    }
+
+    if (mask_v->is_literal() && mask_v->literal == 0) {
+        print_log("skipped, always masked");
+        target.release();
+        return;
+    }
+
+    // Copy-on-Write logic. See the same line in jitc_var_scatter() for details
+    if (target_v->ref_count != 2 && target_v->ref_count_stashed != 1) {
+        target = steal(jitc_var_copy(target));
+        target_v = jitc_var(target);
+    }
+
+    // Get a pointer to the array data (non-writable).
+    void *target_addr = nullptr;
+    target = steal(jitc_var_data(target, false, &target_addr));
+    Ref ptr = steal(jitc_var_pointer(var_info.backend, target_addr, target, 0));
+
+    // Update target argument
+    bool updated_target = false;
+    if (target != *target_p) {
+        updated_target = true;
+        jitc_var_inc_ref(target);
+        jitc_var_dec_ref(*target_p);
+        *target_p = target;
+        target_v = jitc_var(target);
+    }
+
+    // Apply default masks
+    Ref mask_2  = steal(jitc_var_mask_apply(mask, var_info.size)),
+        index_2 = steal(jitc_scatter_gather_index(target, index));
+
+    if (flags & (uint32_t) JitFlag::Debug)
+        mask_2 = steal(jitc_var_check_bounds(BoundsCheckType::ScatterCAS, index,
+                                             mask_2, target_info.size));
+
+    uint32_t op_size = std::max(var_info.size, jitc_var(mask_2)->size);
+
+    /// This function produces 4 new variables:
+    /// - ScatterCAS node: This is the main node which when assembled produces
+    ///   the compare-and-swap instruction. When assembled, it is consumed.
+    /// - Extract 0 node: This node extracts the `old` value of the operation.
+    /// - Extract 1 node: This node extracts the `success` value of the operation.
+    /// - Nop node: This is a dummy node that's sole purpose is to track this
+    ///   entire function as a side-effect.
+    ///
+    /// The relations between these are very intricate. The last three nodes
+    /// depend on the ScatterCAS node, therefore guaranteeing that the operation
+    /// is only assembled & consumed once. The last Nop node, as it is a
+    /// side-effect, ensures that the operation takes place on the next kernel
+    /// launch. It is necessary to have the side-effect on a separate leaf node,
+    /// that depends on a writable pointer to the target, to correctly trigger
+    /// and flush the writes to the target.
+
+    ScatterCASDData *cas_data = new ScatterCASDData();
+    cas_data->mask = mask_2;
+    Ref scatter_cas_op = steal(jitc_var_new_node_4(
+        target_info.backend, VarKind::ScatterCAS, VarType::Void,
+        op_size, symbolic, ptr, jitc_var(ptr),
+        compare, jitc_var(compare), value, jitc_var(value),
+        index_2, jitc_var(index_2), (uintptr_t) cas_data));
+
+    jitc_var_inc_ref(mask_2);
+    auto callback = [](uint32_t /*index*/, int free, void *ptr) {
+        if (free)
+            delete (ScatterCASDData *) ptr;
+    };
+    jitc_var_set_callback(scatter_cas_op, callback, cas_data, true);
+
+    // Extract first return value: the old content of the target
+    *old = jitc_var_new_node_1(
+        target_info.backend, VarKind::Extract, target_info.type, op_size, symbolic,
+        scatter_cas_op, jitc_var(scatter_cas_op), (uint64_t) 0);
+
+    // Extract second return value: whether or not the swap took place
+    *success = jitc_var_new_node_1(
+        target_info.backend, VarKind::Extract, VarType::Bool, op_size, symbolic,
+        scatter_cas_op, jitc_var(scatter_cas_op), (uint64_t) 1);
+
+    print_log(updated_target ? "direct" : "copied target");
+
+    // Dummy node that represents the side-effect
+    uint32_t write_ptr = jitc_var_pointer(var_info.backend, target_addr, target, 1);
+    uint32_t se = jitc_var_new_node_1(var_info.backend, VarKind::Nop,
+                                      VarType::Void, var_info.size, symbolic,
+                                      scatter_cas_op, jitc_var(scatter_cas_op));
+    jitc_var(se)->dep[3] = write_ptr;
+    jitc_var_mark_side_effect(se);
 }
 
 extern size_t llvm_expand_threshold;

--- a/src/op.h
+++ b/src/op.h
@@ -41,6 +41,11 @@ extern void jitc_var_scatter_add_kahan(uint32_t *target_1, uint32_t *target_2,
 /// Atomic scatter-increment
 extern uint32_t jitc_var_scatter_inc(uint32_t *target, uint32_t index, uint32_t mask);
 
+/// Atomic compare-and-swap
+extern void jitc_var_scatter_cas(uint32_t *target, uint32_t compare,
+                                 uint32_t value, uint32_t index, uint32_t mask,
+                                 uint32_t *old, uint32_t *success);
+
 /// Perform an ordinary or reinterpreting cast of the variable 'index'
 extern uint32_t jitc_var_cast(uint32_t index, VarType target_type,
                               int reinterpret);
@@ -126,5 +131,14 @@ struct PacketScatterData {
     ~PacketScatterData() {
         for (uint32_t index: values)
             jitc_var_dec_ref(index);
+    }
+};
+
+/// Extra data describing a scatter CAS operation
+struct ScatterCASDData {
+    uint32_t mask;
+
+    ~ScatterCASDData() {
+        jitc_var_dec_ref(mask);
     }
 };

--- a/src/op.h
+++ b/src/op.h
@@ -41,6 +41,10 @@ extern void jitc_var_scatter_add_kahan(uint32_t *target_1, uint32_t *target_2,
 /// Atomic scatter-increment
 extern uint32_t jitc_var_scatter_inc(uint32_t *target, uint32_t index, uint32_t mask);
 
+/// Atomic exchange
+extern uint32_t jitc_var_scatter_exch(uint32_t *target, uint32_t value,
+                                      uint32_t index, uint32_t mask);
+
 /// Atomic compare-and-swap
 extern void jitc_var_scatter_cas(uint32_t *target, uint32_t compare,
                                  uint32_t value, uint32_t index, uint32_t mask,

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -191,7 +191,7 @@ const char *var_kind_name[(int) VarKind::Count] {
     "bounds_check",
 
     // Memory-related operations
-    "gather", "scatter", "scatter_inc", "scatter_kahan",
+    "gather", "scatter", "scatter_inc", "scatter_kahan", "scatter_cas",
 
     // Gather multiple contiguous values at once
     "packet_gather",

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -191,7 +191,7 @@ const char *var_kind_name[(int) VarKind::Count] {
     "bounds_check",
 
     // Memory-related operations
-    "gather", "scatter", "scatter_inc", "scatter_kahan", "scatter_cas",
+    "gather", "scatter", "scatter_inc", "scatter_kahan", "scatter_cas", "scatter_xchg",
 
     // Gather multiple contiguous values at once
     "packet_gather",

--- a/src/var.h
+++ b/src/var.h
@@ -300,6 +300,7 @@ enum class BoundsCheckType {
     ScatterReduce,
     ScatterAddKahan,
     ScatterInc,
+    ScatterExch,
     ScatterCAS,
     Gather,
     PacketGather,

--- a/src/var.h
+++ b/src/var.h
@@ -300,6 +300,7 @@ enum class BoundsCheckType {
     ScatterReduce,
     ScatterAddKahan,
     ScatterInc,
+    ScatterCAS,
     Gather,
     PacketGather,
     PacketScatter,


### PR DESCRIPTION
This PR lays the groundwork for implementing `dr.scatter_cas()` and `dr.scatter_exch()`.

The implementation shares a lot of similarities with `scatter_inc`, as the outputs are only valid when used in the same kernel as where the memory write takes place. To do so, it also relies on the `consumed` field of `Variables`.

PTX has instructions to peform both of these operations trivially, where as the LLVM implementation must rely on a loop over the vectorization width; there currently is no `cmpxchg` or ` atomicrmw` for vectorized types in the LLVM IR spec.

As always, tests are contained in the Dr.Jit PR: https://github.com/mitsuba-renderer/drjit/pull/450