### PR TITLE
scatter packet reduce: Fix missing mask predicate in cuda packet scatter_reduce path

### DIFF
--- a/src/cuda_packet.cpp
+++ b/src/cuda_packet.cpp
@@ -304,9 +304,14 @@ void jitc_cuda_render_scatter_reduce_packet(const Variable *v,
 
         fmt("    mad.wide.$t %rd3, $v, $u, $v;\n",
             index, index, tsize, ptr);
-        for (uint32_t i = 0; i < count; i++)
-            fmt("    red.global.$s.$s$s [%rd3+$u], $v;\n",
+        for (uint32_t i = 0; i < count; i++){
+            if (is_masked)
+                fmt("    @$v ", mask);
+            else
+                put("        ");
+            fmt("red.global.$s.$s$s [%rd3+$u], $v;\n",
                 tp, op_name, qualifier, i * tsize, jitc_var(values[i]));
+        }
     }
 }
 


### PR DESCRIPTION
Fixes the bug with the mask predicate operation of the scatter_packet_reduce.

Reproducer:
```python
import drjit as dr
from drjit.cuda import UInt32, Bool, ArrayXu

dr.set_flag(dr.JitFlag.PacketOps, True)
dr.set_flag(dr.JitFlag.ScatterReduceLocal, False)

target = dr.zeros(UInt32, 8)
dr.scatter_reduce(dr.ReduceOp.Add, target,
                  dr.ones(ArrayXu, (2, 2)),
                  UInt32(0, 0xFFFFFFF0),
                  active=Bool(True, False))
dr.eval(target) # CUDA_ERROR_ILLEGAL_ADDRESS
```