### PR TITLE
Dr.Jit core performance improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ext/robin_map"]
     path = ext/robin_map
-    url = https://github.com/Tessil/robin-map
+    url = https://github.com/mitsuba-renderer/robin-map
 
 [submodule "ext/nanothread"]
     path = ext/nanothread

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,18 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
   endif()
 endif()
 
+# The stack protector (on by default on some distributions) has a noticeable
+# runtime cost in Dr.Jit's hot tracing functions, with little benefit given its
+# threat model (nonexistent). Disable it in optimized builds only.
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-fno-stack-protector DRJIT_HAVE_NO_STACK_PROTECTOR)
+  if (DRJIT_HAVE_NO_STACK_PROTECTOR)
+    target_compile_options(drjit-core PRIVATE
+      $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-fno-stack-protector>)
+  endif()
+endif()
+
 # The following compiler flags are needed for Clang/GCC to autovectorize the
 # batched GEMM
 if (NOT MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,16 +264,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   target_link_options(drjit-core PRIVATE -Wno-free-nonheap-object)
 endif()
 
-# Opt into faster TLS ABI (TLSDESC) on Linux
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-    (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-  include(CheckCXXCompilerFlag)
-  check_cxx_compiler_flag(-mtls-dialect=gnu2 DRJIT_HAVE_MTLS_GNU2)
-  if (DRJIT_HAVE_MTLS_GNU2)
-    target_compile_options(drjit-core PRIVATE -mtls-dialect=gnu2)
-  endif()
-endif()
-
 # The stack protector (on by default on some distributions) has a noticeable
 # runtime cost in Dr.Jit's hot tracing functions, with little benefit given its
 # threat model (nonexistent). Disable it in optimized builds only.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,16 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   target_link_options(drjit-core PRIVATE -Wno-free-nonheap-object)
 endif()
 
+# Opt into faster TLS ABI (TLSDESC) on Linux
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+    (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag(-mtls-dialect=gnu2 DRJIT_HAVE_MTLS_GNU2)
+  if (DRJIT_HAVE_MTLS_GNU2)
+    target_compile_options(drjit-core PRIVATE -mtls-dialect=gnu2)
+  endif()
+endif()
+
 # The following compiler flags are needed for Clang/GCC to autovectorize the
 # batched GEMM
 if (NOT MSVC)

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1162,12 +1162,16 @@ uint32_t jit_var_write(uint32_t index, size_t offset, const void *src) {
 
 void jit_eval() {
     lock_guard guard(state.lock);
+    ThreadLocal &tl = jitc_thread_local();
 #if defined(DRJIT_ENABLE_CUDA)
-    jitc_eval(thread_state_cuda);
+    if (tl.ts_cuda)
+        jitc_eval(tl.ts_cuda);
 #endif
-    jitc_eval(thread_state_llvm);
+    if (tl.ts_llvm)
+        jitc_eval(tl.ts_llvm);
 #if defined(DRJIT_ENABLE_METAL)
-    jitc_eval(thread_state_metal);
+    if (tl.ts_metal)
+        jitc_eval(tl.ts_metal);
 #endif
 }
 

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -80,7 +80,7 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
     }
 
     for (uint32_t i = 0; i < n_in; ++i) {
-        const Variable *v = jitc_var(in[i]);
+        Variable *v = jitc_var(in[i]);
         if ((VarKind) v->kind == VarKind::CallInput) {
             if (!v->dep[0])
                 jitc_raise("jit_var_call(): symbolic variable r%u does not "
@@ -95,6 +95,8 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
             // Literal field, read temporarily stashed size (see
             // jitc_var_call_input in var.cpp)
             size = std::max(size, v->scratch);
+            // Reset 'scratch' to not interfere with visited tracking in jit_eval()
+            v->scratch = 0;
         }
 
         if (v->size != 1)

--- a/src/common.h
+++ b/src/common.h
@@ -134,6 +134,17 @@ inline uint32_t log2i_ceil(uint32_t x) {
 #endif
 }
 
+/// Portable trailing zero count
+inline uint32_t tzcnt_u64(uint64_t x) {
+#if defined(_MSC_VER)
+    unsigned long y;
+    _BitScanForward64(&y, x);
+    return (uint32_t) y;
+#else
+    return (uint32_t) __builtin_ctzll(x);
+#endif
+}
+
 // Precomputed integer division helper
 // Based on libidivide (https://github.com/ridiculousfish/libdivide)
 struct divisor {

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -1077,7 +1077,7 @@ static void jitc_cuda_render(Variable *v) {
                     v, v, v, v, v, a0, a1);
             break;
 
-        case VarKind::TexFetchBilerp:
+        case VarKind::TexFetchBilerp: {
             fmt("    .reg.f32 %f$u_out_<4>;\n",
                 v->reg_index);
             if (!(a1->is_literal() && a1->literal == 1)) {
@@ -1102,6 +1102,7 @@ static void jitc_cuda_render(Variable *v) {
                     v->reg_index, v->reg_index, v->reg_index, v->reg_index);
             }
             break;
+        }
 
         case VarKind::TexWrite: {
             TexData *td = (TexData *) v->data;

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -10,14 +10,10 @@
  *  Format  Input          Example result    Description
  * --------------------------------------------------------------------------
  *  $u      uint32_t      `1234`             Decimal number (32 bit)
- *  $U      uint64_t      `1234`             Decimal number (64 bit)
  * --------------------------------------------------------------------------
- *  $x      uint32_t      `4d2`              Hexadecimal number (32 bit)
- *  $X      uint64_t      `4d2`              Hexadecimal number (64 bit)
  *  $Q      uint64_t      `00000000000004d2` Hex. number, 0-filled (64 bit)
  * --------------------------------------------------------------------------
  *  $s      const char *  `foo`              Zero-terminated string
- *  $c      char          `f`                A single ASCII character
  * --------------------------------------------------------------------------
  *  $t      Variable      `f32`              Variable type
  * --------------------------------------------------------------------------
@@ -1092,8 +1088,9 @@ static void jitc_cuda_render(Variable *v) {
             } else {
                 put("    ");
             }
-            fmt("tld4.$c.2d.v4.f32.f32 {%f$u_out_0, %f$u_out_1, %f$u_out_2, %f$u_out_3}, [$v, {$v, $v}];\n",
-                "rgba"[v->literal], v->reg_index, v->reg_index, v->reg_index, v->reg_index, a0, a2, a3);
+            char comp[2] = { "rgba"[v->literal], '\0' };
+            fmt("tld4.$s.2d.v4.f32.f32 {%f$u_out_0, %f$u_out_1, %f$u_out_2, %f$u_out_3}, [$v, {$v, $v}];\n",
+                comp, v->reg_index, v->reg_index, v->reg_index, v->reg_index, a0, a2, a3);
             if (jitc_is_half(v)) {
                 fmt("    .reg.f16 %h$u_out_<4>;\n"
                     "    cvt.rn.f16.f32 %h$u_out_0, %f$u_out_0;\n"

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -460,6 +460,12 @@ void jitc_cuda_render_loop_end(Variable *a0) {
             fmt("    mov.$b $v, $v;\n", in, in, out);
     }
 
+    // Reset 'scratch' to not interfere with visited tracking in jit_eval()
+    for (uint32_t i = 0; i < size; ++i) {
+        jitc_var(ld->inner_in[i])->scratch = 0;
+        jitc_var(ld->inner_out[i])->scratch = 0;
+    }
+
     fmt("    bra l_$u_cond;\n\n"
         "l_$u_done:\n",
         a0->reg_index, a0->reg_index);

--- a/src/cuda_eval.h
+++ b/src/cuda_eval.h
@@ -1,9 +1,12 @@
-#define fmt(fmt, ...) buffer.fmt_cuda(count_args(__VA_ARGS__), fmt, ##__VA_ARGS__)
-#define put(...)      buffer.put(__VA_ARGS__)
+#define fmt(fmt, ...)                                                          \
+    buffer.fmt_cuda(count_args(__VA_ARGS__), fmt_strlen(fmt), fmt,             \
+                    ##__VA_ARGS__)
+#define put(...) buffer.put(__VA_ARGS__)
 #define fmt_intrinsic(fmt, ...)                                                \
     do {                                                                       \
         size_t tmpoff = buffer.size();                                         \
-        buffer.fmt_cuda(count_args(__VA_ARGS__), fmt, ##__VA_ARGS__);          \
+        buffer.fmt_cuda(count_args(__VA_ARGS__), fmt_strlen(fmt), fmt,         \
+                        ##__VA_ARGS__);                                        \
         jitc_register_global(buffer.get() + tmpoff);                           \
         buffer.rewind_to(tmpoff);                                              \
     } while (0);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -22,7 +22,6 @@
 #include "tex.h"
 #include "op.h"
 #include "array.h"
-#include <tsl/robin_set.h>
 
 #if defined(DRJIT_ENABLE_METAL)
 #  include "metal.h"
@@ -47,38 +46,47 @@ struct VisitedKey {
     uint32_t depth;
     VisitedKey(uint32_t size, uint32_t index, uint32_t depth)
         : size(size), index(index), depth(depth) { }
-
-    bool operator==(VisitedKey k) const {
-        return k.size == size && k.index == index && k.depth == depth;
-    }
 };
 
-struct VisitedKeyHash {
-    size_t operator()(VisitedKey k) const {
-        return (size_t) fmix64((uint64_t(k.size ^ k.depth) << 32) |  k.index);
-    }
+/// A traversal "task": a root or side effect to be visited at a given size
+struct EvalTask {
+    uint32_t size;
+    uint32_t index;
+    bool side_effect;
 };
 
-/// Auxiliary data structure needed to compute 'schedule' and 'schedule_groups'
-static tsl::robin_set<VisitedKey, VisitedKeyHash> visited;
-static std::vector<VisitedKey> visited_keys;
+/// Roots & side effects collected at the start of jit_eval(), grouped by size
+static std::vector<EvalTask> eval_tasks;
 
-static bool jitc_visited_insert(uint32_t size, uint32_t index, uint32_t depth) {
-    VisitedKey key(size, index, depth);
-    auto [it, inserted] = visited.emplace(key);
-    (void) it;
-    if (inserted)
-        visited_keys.push_back(key);
-    return inserted;
-}
+/// Indices of the explicitly scheduled variables (to be marked as outputs)
+static std::vector<uint32_t> eval_roots;
 
-static void jitc_visited_clear() {
-    for (const VisitedKey &key : visited_keys) {
-        auto it = visited.find(key);
-        if (likely(it != visited.end()))
-            visited.erase_fast(it);
+/* Generation counter used by jitc_var_traverse() to detect already-visited
+   variables. The traversal stamps the current generation into 'Variable::scratch'
+   and treats a variable as visited iff its stamp equals 'visit_gen'. Starting a
+   new traversal then takes only a single increment of 'visit_gen', which makes
+   every existing stamp stale and so marks all variables unvisited.
+
+   jitc_eval_impl() starts a fresh generation for each group of equally-sized
+   variables, so the traversal visits (and schedules) a shared sub-expression
+   exactly once for each distinct kernel size it feeds into. The generation only
+   needs to encode size. The traversal size stays constant within a group, and a
+   variable's call/loop nesting depth never changes, so the traversal always
+   reaches it at the same depth.
+
+   Generation 0 serves as the "never visited" sentinel. A freshly constructed
+   variable has scratch == 0, and 'visit_gen' is never 0, so the traversal
+   correctly treats such a variable as unvisited. On the rare 32-bit wraparound,
+   reset all stamps to 0 and restart. */
+static uint32_t visit_gen = 0;
+
+static void jitc_visit_new_gen() {
+    if (unlikely(visit_gen == 0xFFFFFFFFu)) {
+        for (Variable &v : state.variables)
+            v.scratch = 0;
+        visit_gen = 0;
     }
-    visited_keys.clear();
+    ++visit_gen;
 }
 
 /// Kernel parameter buffer and variable ids
@@ -145,10 +153,10 @@ bool jitc_elide_scatter(uint32_t index, const Variable *v) {
 
 /// Recursively traverse the computation graph to find variables needed by a computation
 static void jitc_var_traverse(uint32_t size, uint32_t index, uint32_t depth = 0) {
-    if (!jitc_visited_insert(size, index, depth))
-        return;
-
     Variable *v = jitc_var(index);
+    if (v->scratch == visit_gen)
+        return;
+    v->scratch = visit_gen;
     switch ((VarKind) v->kind) {
         case VarKind::Scatter:
             if (jitc_elide_scatter(index, v))
@@ -305,9 +313,10 @@ static void jitc_var_traverse(uint32_t size, uint32_t index, uint32_t depth = 0)
             "operations.", index);
 
     if (depth == 0) {
-        // If we're visiting this variable the first time regardless of size
-        if (jitc_visited_insert(0, index, depth))
-            v->output_flag = false;
+        // A scheduled variable is an output only if it was explicitly requested;
+        // clear the flag here and let jitc_eval_impl() set it on the roots once
+        // all traversal is done.
+        v->output_flag = false;
         schedule.emplace_back(size, v->scope, index);
         jitc_var_inc_ref(index, v);
     }
@@ -825,42 +834,82 @@ void jitc_eval(ThreadState *ts) {
 }
 
 void jitc_eval_impl(ThreadState *ts) {
-    jitc_visited_clear();
     visit_later.clear();
     schedule.clear();
+    eval_tasks.clear();
+    eval_roots.clear();
 
 #if defined(DRJIT_ENABLE_OPTIX)
     jitc_optix_max_coopvec_size = 0;
 #endif
 
+    // Collect the roots (explicitly scheduled variables). 'ts->scheduled' only
+    // holds weak references, so take a temporary strong reference on each root.
     for (WeakRef wr: ts->scheduled) {
         // Skip variables that expired, or which we already evaluated
         Variable *v = jitc_var(wr);
         if (!v || v->is_evaluated())
             continue;
-        jitc_var_traverse(v->size, wr.index);
-        v->output_flag = true;
+        jitc_var_inc_ref(wr.index, v);
+        eval_tasks.push_back({ v->size, wr.index, false });
+        eval_roots.push_back(wr.index);
     }
 
     ts->scheduled.clear();
 
+    // ... and the side effects. A scatter whose target buffer has become
+    // unreferenced writes a result that nobody reads and can be elided.
     for (uint32_t index: ts->side_effects) {
         Variable *v = jitc_var(index);
 
         if (jitc_elide_scatter(index, v))
             jitc_var_dec_ref(index);
         else
-            jitc_var_traverse(v->size, index);
+            eval_tasks.push_back({ v->size, index, true });
     }
 
     ts->side_effects.clear();
 
-    // Should not be replaced by a range-based for loop,
-    // as the traversal may append further items
-    for (size_t i = 0; i < visit_later.size(); ++i) {
-        VisitedKey vk = visit_later[i];
-        jitc_var_traverse(vk.size, vk.index, vk.depth);
+    if (eval_tasks.empty())
+        return;
+
+    /* Traverse same-size tasks consecutively, each size under its own
+       generation. */
+    std::stable_sort(eval_tasks.begin(), eval_tasks.end(),
+                     [](const EvalTask &a, const EvalTask &b) {
+                         if (a.size != b.size)
+                             return a.size > b.size;
+                         return a.side_effect < b.side_effect;
+                     });
+
+    for (size_t i = 0, n = eval_tasks.size(); i < n; ) {
+        uint32_t group_size = eval_tasks[i].size;
+
+        // Advance generation counter per distinct size
+        jitc_visit_new_gen();
+
+        size_t j = i;
+        for (; j < n && eval_tasks[j].size == group_size; ++j)
+            jitc_var_traverse(group_size, eval_tasks[j].index);
+
+        // Process deferred nodes. Do not use a range-based for loop, as
+        // traversal adds items.
+        for (size_t k = 0; k < visit_later.size(); ++k) {
+            VisitedKey vk = visit_later[k];
+            jitc_var_traverse(vk.size, vk.index, vk.depth);
+        }
+        visit_later.clear();
+
+        i = j;
     }
+
+    // Mark roots as outputs
+    for (uint32_t index: eval_roots)
+        jitc_var(index)->output_flag = true;
+
+    // Release the temporary references taken during root collection.
+    for (uint32_t index: eval_roots)
+        jitc_var_dec_ref(index);
 
     if (schedule.empty())
         return;
@@ -980,7 +1029,7 @@ XXH128_hash_t jitc_assemble_func(const CallData *call, uint32_t inst,
                                  uint32_t out_size, uint32_t out_align) {
     ProfilerPhase profiler(profiler_region_assemble_func);
 
-    jitc_visited_clear();
+    jitc_visit_new_gen();
     visit_later.clear();
     schedule.clear();
     callable_depth++;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -38,7 +38,10 @@
 std::vector<ScheduledVariable> schedule;
 
 /// Groups of variables with the same size
-std::vector<ScheduledGroup> schedule_groups;
+static std::vector<ScheduledGroup> schedule_groups;
+
+/// Scratch buffer reused by the schedule sort
+static std::vector<ScheduledVariable> schedule_scratch;
 
 struct VisitedKey {
     uint32_t size;
@@ -788,6 +791,72 @@ static ProfilerRegion profiler_region_eval("jit_eval");
 // Forward declaration
 void jitc_eval_impl(ThreadState *ts);
 
+/// Implementation detail of jitc_schedule_sort()
+struct Bucket { uint32_t size, scope, count, offset; };
+static std::vector<Bucket> buckets;
+
+/// Stable count sort of ``schedule`` by size (descending) and scope (ascending).
+static void jitc_schedule_sort() {
+    auto less = [](const auto &a, const auto &b) {
+        return a.size != b.size ? a.size > b.size : a.scope < b.scope;
+    };
+
+    // A distinct (size, scope) key and the entries that map to it
+    buckets.clear();
+
+    // Locate the bucket for a key. Entries sharing a key are contiguous in the
+    // schedule, so the most recent match is the likeliest hit.
+    uint32_t hint = 0;
+    auto find = [&](const ScheduledVariable &sv) -> Bucket * {
+        if (hint < buckets.size() && buckets[hint].size == sv.size &&
+            buckets[hint].scope == sv.scope)
+            return &buckets[hint];
+        for (hint = 0; hint < buckets.size(); ++hint)
+            if (buckets[hint].size == sv.size && buckets[hint].scope == sv.scope)
+                return &buckets[hint];
+        return nullptr;
+    };
+
+    // Pass 1: tally the distinct keys
+    const uint32_t max_buckets = 32;
+    bool fallback = false;
+    for (const ScheduledVariable &sv : schedule) {
+        if (Bucket *b = find(sv)) {
+            b->count++;
+        } else if (likely(buckets.size() < max_buckets)) {
+            hint = (uint32_t) buckets.size();
+            buckets.push_back({ sv.size, sv.scope, 1, 0 });
+        } else {
+            fallback = true; // Pathological key count; use a comparison sort
+            break;
+        }
+    }
+
+    if (fallback) {
+        std::stable_sort(schedule.begin(), schedule.end(), less);
+        return;
+    }
+
+    // A single key means the schedule is already in the desired order
+    if (buckets.size() <= 1)
+        return;
+
+    // Order the (few) keys and turn their counts into output offsets
+    std::sort(buckets.begin(), buckets.end(), less);
+    uint32_t offset = 0;
+    for (Bucket &b : buckets) {
+        b.offset = offset;
+        offset += b.count;
+    }
+
+    // Pass 2: stably scatter each entry into its group, then swap into place
+    schedule_scratch.resize(schedule.size());
+    hint = 0;
+    for (const ScheduledVariable &sv : schedule)
+        schedule_scratch[find(sv)->offset++] = sv;
+    schedule.swap(schedule_scratch);
+}
+
 /// Evaluate all computation that is queued on the given ThreadState
 void jitc_eval(ThreadState *ts) {
     if (!ts || (ts->scheduled.empty() && ts->side_effects.empty()))
@@ -914,21 +983,8 @@ void jitc_eval_impl(ThreadState *ts) {
     if (schedule.empty())
         return;
 
-    // Order variables into groups of matching size
-    std::stable_sort(
-        schedule.begin(), schedule.end(),
-        [](const ScheduledVariable &a, const ScheduledVariable &b) {
-            if (a.size > b.size)
-                return true;
-            else if (a.size < b.size)
-                return false;
-            else if (a.scope > b.scope)
-                return false;
-            else if (a.scope < b.scope)
-                return true;
-            else
-                return false;
-        });
+    // Order variables into kernel groups (by size, then scope)
+    jitc_schedule_sort();
 
     // Partition into groups of matching size
     schedule_groups.clear();

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -571,11 +571,12 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
         // buffer has a different size. We work around the issue by inserting a
         // unique callable that prevents this optimization.
 
-        buffer.fmt_cuda(2,
+        const char *id_fmt =
             "\n.visible .func (.param .align 8 .b8 result[16]) __direct_callable__id() {\n"
             "    st.param.u64 [result+0], 0x$Q;\n"
             "    st.param.u64 [result+8], 0x$Q;\n"
-            "}",
+            "}";
+        buffer.fmt_cuda(2, fmt_strlen(id_fmt), id_fmt,
             kernel_hash.low64,
             kernel_hash.high64
         );
@@ -713,8 +714,9 @@ Task *jitc_run(ThreadState *ts, ScheduledGroup group) {
         if (jitc_is_cuda(ts->backend) && !uses_optix) {
             // Locate the kernel entry point
             size_t offset = buffer.size();
-            buffer.fmt_cuda(2, "drjit_$Q$Q", kernel_hash.high64,
-                            kernel_hash.low64);
+            const char *name_fmt = "drjit_$Q$Q";
+            buffer.fmt_cuda(2, fmt_strlen(name_fmt), name_fmt,
+                            kernel_hash.high64, kernel_hash.low64);
             cuda_check(cuModuleGetFunction(&kernel.cuda.func, kernel.cuda.mod,
                                            buffer.get() + offset));
             buffer.rewind_to(offset);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -552,7 +552,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
     // Search for the kernel-name marker rather than the first '^', because
     // injected preamble code may contain '^' in comments that must not be
     // overwritten.
-    kernel_hash = hash_kernel(buffer.get());
+    kernel_hash = hash_kernel(buffer.get(), buffer.size(), backend);
 
     const char *needle =
         (uses_optix && jitc_is_cuda(backend)) ? "__raygen__^"

--- a/src/eval.h
+++ b/src/eval.h
@@ -21,6 +21,8 @@ struct ScheduledVariable {
     uint32_t scope;
     void *data;
 
+    ScheduledVariable() = default;
+
     ScheduledVariable(uint32_t size, uint32_t scope, uint32_t index)
         : size(size), index(index), scope(scope), data(nullptr) { }
 };
@@ -101,9 +103,6 @@ extern uint32_t callable_depth;
 
 /// Ordered list of variables that should be computed
 extern std::vector<ScheduledVariable> schedule;
-
-/// Groups of variables with the same size
-extern std::vector<ScheduledGroup> schedule_groups;
 
 /// Track kernel parameter metadata (writability, GPU resource kind)
 extern std::vector<KernelParamInfo> kernel_param_info;

--- a/src/hash.h
+++ b/src/hash.h
@@ -15,6 +15,7 @@
 #endif
 
 #include <tsl/robin_map.h>
+#include <drjit-core/jit.h>
 #include <drjit-core/hash.h>
 #include <xxh3.h>
 
@@ -74,13 +75,17 @@ inline size_t hash_str(const char *str) {
     return hash(str, strlen(str));
 }
 
-inline XXH128_hash_t hash_kernel(const char *str) {
-    const char *offset = strstr(str, "body:");
-    if (unlikely(!offset)) {
-        offset = strchr(str, '{');
-        if (unlikely(!offset))
-            jitc_fail("hash_kernel(): invalid input!");
-    }
+/// Hash the IR of a just-generated kernel, starting at its body. CUDA and LLVM
+/// unconditionally emit a "body:" label; Metal has no such label, and hashing
+/// starts at the first '{' (of its ``struct Params`` declaration) instead.
+inline XXH128_hash_t hash_kernel(const char *str, size_t size,
+                                 JitBackend backend) {
+    const char *offset = backend == JitBackend::Metal
+                             ? strchr(str, '{')
+                             : strstr(str, "body:");
 
-    return XXH128(offset, strlen(offset), 0);
+    if (unlikely(!offset))
+        jitc_fail("hash_kernel(): could not locate the start of the kernel body!");
+
+    return XXH128(offset, size - (size_t) (offset - str), 0);
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -294,7 +294,8 @@ void jitc_shutdown(int light) {
                 jitc_log(Warn,
                         " - id=%u: size=%u, type=%s, dep=[%u, "
                         "%u, %u, %u]",
-                        kv.second, kv.first.size, type_name[kv.first.type],
+                        kv.second, kv.first.size,
+                        type_name[(kv.first.packed >> 9) & 0x1f],
                         kv.first.dep[0], kv.first.dep[1], kv.first.dep[2],
                         kv.first.dep[3]);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -54,25 +54,9 @@ State state;
 #endif
 
 #if defined(_MSC_VER)
-#if defined(DRJIT_ENABLE_CUDA)
-  __declspec(thread) ThreadState* thread_state_cuda = nullptr;
-#endif
-  __declspec(thread) ThreadState* thread_state_llvm = nullptr;
-#if defined(DRJIT_ENABLE_METAL)
-  __declspec(thread) ThreadState* thread_state_metal = nullptr;
-#endif
-  __declspec(thread) uint32_t jitc_flags_v = (uint32_t) JitFlag::Default;
-  __declspec(thread) JitBackend default_backend = JitBackend::None;
+  __declspec(thread) ThreadLocal tls;
 #else
-#if defined(DRJIT_ENABLE_CUDA)
-  __thread ThreadState* thread_state_cuda = nullptr;
-#endif
-  __thread ThreadState* thread_state_llvm = nullptr;
-#if defined(DRJIT_ENABLE_METAL)
-  __thread ThreadState* thread_state_metal = nullptr;
-#endif
-  __thread uint32_t jitc_flags_v = (uint32_t) JitFlag::Default;
-  __thread JitBackend default_backend = JitBackend::None;
+  __thread ThreadLocal tls;
 #endif
 
 #if defined(DRJIT_ENABLE_ITTNOTIFY)
@@ -308,12 +292,13 @@ void jitc_shutdown(int light) {
         state.tss.clear();
     }
 
-    thread_state_llvm = nullptr;
+    ThreadLocal &tl = jitc_thread_local();
+    tl.ts_llvm = nullptr;
 #if defined(DRJIT_ENABLE_CUDA)
-    thread_state_cuda = nullptr;
+    tl.ts_cuda = nullptr;
 #endif
 #if defined(DRJIT_ENABLE_METAL)
-    thread_state_metal = nullptr;
+    tl.ts_metal = nullptr;
 #endif
 
     if (std::max(state.log_level_stderr, state.log_level_callback) >= LogLevel::Warn &&
@@ -611,19 +596,21 @@ void jitc_sync_thread(ThreadState *ts, bool hold_lock) {
 
 /// Wait for all computation on the current stream to finish
 void jitc_sync_thread(bool hold_lock) {
+    ThreadLocal &tl = jitc_thread_local();
 #if defined(DRJIT_ENABLE_CUDA)
-    jitc_sync_thread(thread_state_cuda, hold_lock);
+    jitc_sync_thread(tl.ts_cuda, hold_lock);
 #endif
-    jitc_sync_thread(thread_state_llvm, hold_lock);
+    jitc_sync_thread(tl.ts_llvm, hold_lock);
 #if defined(DRJIT_ENABLE_METAL)
-    jitc_sync_thread(thread_state_metal, hold_lock);
+    jitc_sync_thread(tl.ts_metal, hold_lock);
 #endif
 }
 
 /// Wait for all computation on the current device to finish
 void jitc_sync_device() {
+    ThreadLocal &tl = jitc_thread_local();
 #if defined(DRJIT_ENABLE_CUDA)
-    ThreadState *ts = thread_state_cuda;
+    ThreadState *ts = tl.ts_cuda;
     if (ts) {
         /* Release lock while synchronizing */ {
             unlock_guard guard(state.lock);
@@ -633,7 +620,7 @@ void jitc_sync_device() {
     }
 #endif
 
-    if (thread_state_llvm) {
+    if (tl.ts_llvm) {
         std::vector<ThreadState *> tss = state.tss;
         // Release lock while synchronizing */
         for (ThreadState *ts_2 : tss) {

--- a/src/internal.h
+++ b/src/internal.h
@@ -383,31 +383,24 @@ struct VariableExtra {
 
 /// Abbreviated version of the Variable data structure for Local Value Numbering (LVN)
 struct VariableKey {
-    uint32_t size;
-    uint32_t dep[4];
-    uint32_t kind         : 8;
-    uint32_t backend      : 2;
-    uint32_t type         : 4;
-    uint32_t write_ptr    : 1;
-    uint32_t unused       : 1;
-    uint32_t array_length : 16;
+    // The first four members are laid out in *exactly* the same order as the
+    // corresponding fields of 'Variable'. Copy with a single vmovdqu 32-byte copy.
     uint32_t scope;
+    uint32_t dep[4];
     uint64_t literal;
+    uint32_t size;
 
-    // The LVN data structure is significantly more efficient when
-    // a single key fits into exactly 32 bytes. Hence the elaborate
-    // bit packing below.
+    /// Bits 0..14 hold (kind|backend|type|write_ptr), bit 15 is unused (zero),
+    /// and bits 16..31 hold the array length for array/coop-vec variables.
+    uint32_t packed;
+
     VariableKey(const Variable &v) {
-        size = v.size;
-        memcpy(dep, v.dep, sizeof(uint32_t)*4);
-        kind = v.kind;
-        backend = v.backend;
-        type = v.type;
-        write_ptr = v.write_ptr;
-        unused = 0;
-        scope = v.scope;
-        array_length = (v.is_array() || v.coop_vec) ? v.array_length : 0;
-        literal = v.literal;
+        memcpy((void *) this, (const void *) &v.scope, 32);
+        uint32_t array_length =
+            (v.is_array() || v.coop_vec) ? (uint32_t) v.array_length : 0u;
+        packed = (uint32_t) v.kind | ((uint32_t) v.backend << 7) |
+                 ((uint32_t) v.type << 9) | ((uint32_t) v.write_ptr << 14) |
+                 (array_length << 16);
     }
 
     bool operator==(const VariableKey &v) const {
@@ -416,12 +409,40 @@ struct VariableKey {
     }
 };
 
+/// Check condition required for fast VariableKey construction
+static_assert(
+    offsetof(VariableKey, scope)   == offsetof(Variable, scope)   - offsetof(Variable, scope) &&
+    offsetof(VariableKey, dep)     == offsetof(Variable, dep)     - offsetof(Variable, scope) &&
+    offsetof(VariableKey, literal) == offsetof(Variable, literal) - offsetof(Variable, scope) &&
+    offsetof(VariableKey, size)    == offsetof(Variable, size)    - offsetof(Variable, scope),
+    "The layout of Variable and VariableKey are incompatible (compiler aligment/packing issue)!");
+
+
 #pragma pack(pop)
 
 /// Helper class to hash VariableKey instances
 struct VariableKeyHasher {
     size_t operator()(const VariableKey &k) const {
-        return hash((const void *) &k, 9 * sizeof(uint32_t), 0);
+        // The VariableKey hasher is performance-critical and uses a custom
+        // implementation.
+        //
+        // 'mix' is based on wyhash: a full 64x64->128 bit multiply with the
+        // halves folded together. XOR-ing each input with a constant first
+        // avoids the degenerate all-zero multiply. We reuse xxHash's five
+        // 64-bit primes.
+        auto mix = [](uint64_t a, uint64_t b) -> uint64_t {
+            XXH128_hash_t r = XXH_mult64to128(a, b);
+            return r.low64 ^ r.high64;
+        };
+
+        uint64_t w[4];
+        memcpy(w, &k, sizeof(w));
+
+        // Three independent 128-bit multiplies, then fold + finalize.
+        uint64_t a = mix(w[0] ^ PRIME64_1, w[1] ^ PRIME64_2);
+        uint64_t b = mix(w[2] ^ PRIME64_3, w[3] ^ PRIME64_4);
+        uint64_t c = mix((uint64_t) k.packed ^ PRIME64_5, PRIME64_1);
+        return (size_t) mix(a ^ b ^ c, PRIME64_2);
     }
 };
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -18,7 +18,6 @@
 #include "llvm.h"
 #include "alloc.h"
 #include "io.h"
-#include <queue>
 #include <string.h>
 #include <nanothread/nanothread.h>
 
@@ -973,9 +972,38 @@ private:
     size_t m_capacity;
 };
 
-using UnusedPQ = std::priority_queue<uint32_t, std::vector<uint32_t>, std::greater<uint32_t>>;
-
 using PointerMap = tsl::robin_map<const void *, uint32_t, PointerHasher>;
+
+/// Free-slot allocator based on a packed bit representation. Allocation returns
+/// the lowest set bit, which improves the overall cache and branch prediction
+/// behavior of Dr.Jit. A cursor marks the lowest word that may hold a free
+/// bit so that the scan can resume from there instead of from the start.
+struct FreeSlots {
+    std::vector<uint64_t> words; //< A set bit marks a free slot
+    uint32_t cursor = 0;         //< Lowest word that may contain a free bit
+    size_t count = 0;            //< Number of free slots
+
+    bool empty() const { return count == 0; }
+    size_t size() const { return count; }
+
+    void push(uint32_t i) {
+        uint32_t w = i / 64;
+        if (w >= words.size())
+            words.resize(w + 1, 0);
+        words[w] |= (uint64_t) 1 << (i % 64);
+        cursor = std::min(cursor, w);
+        count++;
+    }
+
+    uint32_t pop() {
+        while (words[cursor] == 0)
+            cursor++;
+        uint64_t bits = words[cursor];
+        words[cursor] = bits & (bits - 1); // clear lowest set bit
+        count--;
+        return cursor * 64 + tzcnt_u64(bits);
+    }
+};
 
 /// Records the full JIT compiler state (most frequently two used entries at top)
 struct State {
@@ -988,8 +1016,8 @@ struct State {
     /// A flat list of variable data structures, including unused one
     std::vector<Variable> variables;
 
-    /// A priority queue of indices into 'variables' that are currently unused
-    UnusedPQ unused_variables;
+    /// Bit-packed free list of indices into 'variables' that are currently unused
+    FreeSlots unused_variables;
 
     /// Maps from a key characterizing a variable to its index
     LVNMap lvn_map;
@@ -998,8 +1026,8 @@ struct State {
     /// definition for documentation). Includes unused ones.
     std::vector<VariableExtra> extra;
 
-    // A priority queu of indices into 'extra' that are currently unused
-    UnusedPQ unused_extra;
+    /// LIFO free list of indices into 'extra' that are currently unused
+    std::vector<uint32_t> unused_extra;
 
     /// Counter to create variable scopes that enforce a variable ordering
     uint32_t scope_ctr = 2;

--- a/src/internal.h
+++ b/src/internal.h
@@ -398,9 +398,13 @@ struct VariableKey {
         memcpy((void *) this, (const void *) &v.scope, 32);
         uint32_t array_length =
             (v.is_array() || v.coop_vec) ? (uint32_t) v.array_length : 0u;
-        packed = (uint32_t) v.kind | ((uint32_t) v.backend << 7) |
-                 ((uint32_t) v.type << 9) | ((uint32_t) v.write_ptr << 14) |
-                 (array_length << 16);
+        // The bitfields kind:7|backend:2|type:5|write_ptr:1 occupy bits 0..14 of
+        // the 32-bit word immediately after 'scratch' (LSB-first packing), which
+        // is exactly the layout 'packed' wants. Reading the raw word and masking
+        // avoids extracting and re-assembling each field (~14 dependent insns).
+        uint32_t flag_word;
+        memcpy(&flag_word, &v.scratch + 1, sizeof(flag_word));
+        packed = (flag_word & 0x7FFFu) | (array_length << 16);
     }
 
     bool operator==(const VariableKey &v) const {

--- a/src/internal.h
+++ b/src/internal.h
@@ -443,11 +443,17 @@ struct VariableKeyHasher {
         uint64_t w[4];
         memcpy(w, &k, sizeof(w));
 
-        // Three independent 128-bit multiplies, then fold + finalize.
+        // Three independent 128-bit multiplies, XOR-combined. Each 'mix'
+        // already avalanches its inputs (every output bit depends on the whole
+        // 128-bit product via the high/low fold), so the XOR of three of them
+        // is well-distributed in every bit position -- including the low bits
+        // that select the hash table bucket. A separate finalizer would only
+        // add a serial multiply on this hot path without improving the
+        // distribution, so we return the combined value directly.
         uint64_t a = mix(w[0] ^ PRIME64_1, w[1] ^ PRIME64_2);
         uint64_t b = mix(w[2] ^ PRIME64_3, w[3] ^ PRIME64_4);
         uint64_t c = mix((uint64_t) k.packed ^ PRIME64_5, PRIME64_1);
-        return (size_t) mix(a ^ b ^ c, PRIME64_2);
+        return (size_t) (a ^ b ^ c);
     }
 };
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -19,6 +19,7 @@
 #include "alloc.h"
 #include "io.h"
 #include <string.h>
+#include <new>
 #include <nanothread/nanothread.h>
 
 /// List of operations in Dr.Jit-Core's intermediate representation (see ``Variable::kind``)
@@ -1148,26 +1149,43 @@ struct State {
 
 enum ParamType { Register, Input, Output };
 
-/// State specific to threads
+/// Thread-local Dr.Jit state
+struct ThreadLocal {
+    ThreadState *ts_llvm = nullptr;
+#if defined(DRJIT_ENABLE_CUDA)
+    ThreadState *ts_cuda = nullptr;
+#endif
+#if defined(DRJIT_ENABLE_METAL)
+    ThreadState *ts_metal = nullptr;
+#endif
+
+    // Compilation flags
+    uint32_t flags = (uint32_t) JitFlag::Default;
+
+    // Default backend
+    JitBackend def_backend = JitBackend::None;
+};
+
 #if defined(_MSC_VER)
-  extern __declspec(thread) ThreadState* thread_state_llvm;
-#if defined(DRJIT_ENABLE_CUDA)
-  extern __declspec(thread) ThreadState* thread_state_cuda;
-#endif
-#if defined(DRJIT_ENABLE_METAL)
-  extern __declspec(thread) ThreadState* thread_state_metal;
-#endif
-  extern __declspec(thread) JitBackend default_backend;
+  extern __declspec(thread) ThreadLocal tls;
 #else
-  extern __thread ThreadState* thread_state_llvm;
+  extern __thread ThreadLocal tls;
+#endif
+
+// Compatibility aliases that access fields in 'tls' using the previous naming convention
+#define thread_state_llvm (tls.ts_llvm)
 #if defined(DRJIT_ENABLE_CUDA)
-  extern __thread ThreadState* thread_state_cuda;
+#  define thread_state_cuda (tls.ts_cuda)
 #endif
 #if defined(DRJIT_ENABLE_METAL)
-  extern __thread ThreadState* thread_state_metal;
+#  define thread_state_metal (tls.ts_metal)
 #endif
-  extern __thread JitBackend default_backend;
-#endif
+#define jitc_flags_v      (tls.flags)
+#define default_backend   (tls.def_backend)
+
+// Map TLS accesses through std::launder() (optimization boundary) to force the compiler
+// to materialize the lookup once instead of potentially replicating it across branches.
+JIT_INLINE ThreadLocal &jitc_thread_local() { return *std::launder(&tls); }
 
 extern ThreadState *jitc_init_thread_state(JitBackend backend);
 

--- a/src/llvm.h
+++ b/src/llvm.h
@@ -52,9 +52,6 @@ extern uint32_t jitc_llvm_vector_width;
 /// Maximum alignment needed for vector loads
 extern uint32_t jitc_llvm_max_align;
 
-/// Should the LLVM IR use typed (e.g., "i8*") or untyped ("ptr") pointers?
-extern bool jitc_llvm_opaque_pointers;
-
 /// LLVM version (parts can equal -1, which means: not sure)
 extern int jitc_llvm_version_major;
 extern int jitc_llvm_version_minor;

--- a/src/llvm_api.cpp
+++ b/src/llvm_api.cpp
@@ -227,12 +227,6 @@ bool jitc_llvm_api_init() {
         }
     }
 
-    if (jitc_llvm_version_major < 11) {
-        jitc_log(Warn, "jit_llvm_init(): the detected LLVM version was too "
-                       "old, at least 11.0.0 is needed.");
-        return false;
-    }
-
     return true;
 }
 

--- a/src/llvm_array.cpp
+++ b/src/llvm_array.cpp
@@ -46,9 +46,9 @@ static bool mask_safe_to_ignore (const Variable *mask) {
 extern void jitc_llvm_render_array_init(Variable *v, Variable *pred, Variable *value) {
     v->reg_index = pred->reg_index;
 
-    if (value->is_literal() && value->literal == 0 && jitc_llvm_opaque_pointers) {
-        fmt_intrinsic("declare void @llvm.memset.inline.p0.p0i8.i32({i8*}, i8, i32, i1)");
-        fmt("    call void @llvm.memset.inline.p0.p0i8.i32(ptr %arr_$u, i8 0, i32 $u, i1 0)\n",
+    if (value->is_literal() && value->literal == 0) {
+        fmt_intrinsic("declare void @llvm.memset.inline.p0.i32(ptr, i8, i32, i1)");
+        fmt("    call void @llvm.memset.inline.p0.i32(ptr %arr_$u, i8 0, i32 $u, i1 0)\n",
             v->reg_index,
             v->array_length * type_size[v->type] * jitc_llvm_vector_width);
     } else {
@@ -59,19 +59,17 @@ extern void jitc_llvm_render_array_init(Variable *v, Variable *pred, Variable *v
             ext = "_e";
             src = v;
         }
-        fmt("    $v_base = bitcast $m* %arr_$u to {$M*}\n"
-            "    br label %l_$u_pre\n\n"
+        fmt("    br label %l_$u_pre\n\n"
             "l_$u_pre:\n"
             "    br label %l_$u_loop\n\n"
             "l_$u_loop:\n"
             "    $v_cur = phi i64 [ 0, %l_$u_pre ], [ $v_next, %l_$u_loop ]\n"
-            "    $v_ptr = getelementptr inbounds $M, {$M*} $v_base, i64 $v_cur\n"
-            "    store $M $v$s, {$M*} $v_ptr, align $A\n"
+            "    $v_ptr = getelementptr inbounds $M, ptr %arr_$u, i64 $v_cur\n"
+            "    store $M $v$s, ptr $v_ptr, align $A\n"
             "    $v_next = add i64 $v_cur, 1\n"
             "    $v_cont = icmp ult i64 $v_next, $u\n"
             "    br i1 $v_cont, label %l_$u_loop, label %l_$u_done\n\n"
             "l_$u_done:\n",
-            v, v, v->reg_index, v,
             v->reg_index,
             v->reg_index,
             v->reg_index,
@@ -79,9 +77,9 @@ extern void jitc_llvm_render_array_init(Variable *v, Variable *pred, Variable *v
             // phi
             v, v->reg_index, v, v->reg_index,
             // gep
-            v, v, v, v, v,
+            v, v, v->reg_index, v,
             // store
-            value, src, ext, v, v, v,
+            value, src, ext, v, v,
             v, v,
             v, v, v->array_length,
             v, v->reg_index, v->reg_index,
@@ -100,50 +98,47 @@ void jitc_llvm_render_array_read(Variable *v, Variable *source, Variable *mask,
     if (!offset || offset->size == 1) {
         // Scalar/literal offset case: we can avoid a gather operation
         if (offset) {
-            fmt_intrinsic("declare i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32>)");
+            fmt_intrinsic("declare i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32>)");
 
             // Scalar offset, extract the value (danger: can't use
             // extractelement because masked index entries can be invalid)
             fmt("    $v_0 = select $V, $V, $T $z\n"
-                "    $v_1 = call i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32> $v_0)\n"
+                "    $v_1 = call i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32> $v_0)\n"
                 "    $v_2 = mul i32 $v_1, $u\n"
-                "    $v_3 = getelementptr inbounds $m, {$m*} %arr_$u, i32 $v_2\n",
+                "    $v_3 = getelementptr inbounds $m, ptr %arr_$u, i32 $v_2\n",
                 v, mask, offset, offset,
                 v, v,
                 v, v, jitc_llvm_vector_width,
-                v, v, v, source->reg_index, v);
+                v, v, source->reg_index, v);
         } else {
-            fmt("    $v_3 = getelementptr inbounds $m, {$m*} %arr_$u, i32 $u\n",
-                v, v, v, source->reg_index, v->literal * jitc_llvm_vector_width);
+            fmt("    $v_3 = getelementptr inbounds $m, ptr %arr_$u, i32 $u\n",
+                v, v, source->reg_index, v->literal * jitc_llvm_vector_width);
         }
 
-        fmt("{    $v_4 = bitcast $m* $v_3 to $M*\n|}",
-            v, v, v, v);
-
         if (mask_safe_to_ignore(mask)) {
-            fmt("    $v$s = load $M, $M* $v_{4|3}, align $A\n",
-                v, ext, v, v, v, v);
+            fmt("    $v$s = load $M, ptr $v_3, align $A\n",
+                v, ext, v, v, v);
         } else {
-            fmt("    $v_5 = load $M, $M* $v_{4|3}, align $A\n"
+            fmt("    $v_5 = load $M, ptr $v_3, align $A\n"
                 "    $v$s = select $V, $M $v_5, $M $z\n",
-                v, v, v, v, v,
+                v, v, v, v,
                 v, ext, mask, v, v, v);
         }
     } else if (jitc_llvm_vector_width >= 8 && DRJIT_LLVM_OPTIMIZE_ARRAY_ACCESSES) {
         // Check if the gather can be reduced to a packet load
 
-        fmt_intrinsic("declare i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32>)");
-        fmt_intrinsic("declare i32 @llvm$e.vector.reduce.umin.v$wi32(<$w x i32>)");
-        fmt_intrinsic("declare $M @llvm.masked.gather.v$w$H(<$w x {$m*}>, i32, <$w x i1>, $M)",
-                      v, v, v, v);
+        fmt_intrinsic("declare i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32>)");
+        fmt_intrinsic("declare i32 @llvm.vector.reduce.umin.v$wi32(<$w x i32>)");
+        fmt_intrinsic("declare $M @llvm.masked.gather.v$w$H(<$w x ptr>, i32, <$w x i1>, $M)",
+                      v, v, v);
 
         // Check if the wread is coherent
         fmt("    $v_0 = insertelement <$w x i32> undef, i32 -1, i32 0\n"
             "    $v_1 = shufflevector <$w x i32> $v_0, <$w x i32> undef, <$w x i32> $z\n"
             "    $v_2 = select $V, $V, <$w x i32> $z\n"
             "    $v_3 = select $V, $V, <$w x i32> $v_1\n"
-            "    $v_4 = call i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32> $v_2)\n"
-            "    $v_5 = call i32 @llvm$e.vector.reduce.umin.v$wi32(<$w x i32> $v_3)\n"
+            "    $v_4 = call i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32> $v_2)\n"
+            "    $v_5 = call i32 @llvm.vector.reduce.umin.v$wi32(<$w x i32> $v_3)\n"
             "    $v_6 = icmp eq i32 $v_4, $v_5\n"
             "    br i1 $v_6, label %l_$u_u, label %l_$u_n\n\n",
             v,
@@ -158,21 +153,18 @@ void jitc_llvm_render_array_read(Variable *v, Variable *source, Variable *mask,
         // Uniform case
         fmt( "l_$u_u:\n"
              "    $v_7 = mul i32 $v_4, $u\n"
-             "    $v_8 = getelementptr inbounds $m, {$m*} %arr_$u, i32 $v_7\n"
-            "{    $v_9 = bitcast $m* $v_8 to $M*\n|}",
+             "    $v_8 = getelementptr inbounds $m, ptr %arr_$u, i32 $v_7\n",
             v->reg_index,
             v, v, jitc_llvm_vector_width,
-            v, v, v, source->reg_index, v,
-            v, v, v, v
-        );
+            v, v, source->reg_index, v);
 
         if (mask_safe_to_ignore(mask)) {
-            fmt("    $v_u = load $M, $M* $v_{9|8}, align $A\n",
-                v, v, v, v, v);
+            fmt("    $v_u = load $M, ptr $v_8, align $A\n",
+                v, v, v, v);
         } else {
-            fmt("    $v_10 = load $M, $M* $v_{9|8}, align $A\n"
+            fmt("    $v_10 = load $M, ptr $v_8, align $A\n"
                 "    $v_u = select $V, $M $v_10, $M $z\n",
-                v, v, v, v, v,
+                v, v, v, v,
                 v, mask, v, v, v);
         }
         fmt("    br label %l_$u_done\n\n", v->reg_index);
@@ -181,14 +173,14 @@ void jitc_llvm_render_array_read(Variable *v, Variable *source, Variable *mask,
         fmt("l_$u_n:\n"
             "    $v_12 = mul $V, $s\n"
             "    $v_13 = add <$w x i32> $v_12, $s\n"
-            "    $v_14 = getelementptr inbounds $m, {$m*} %arr_$u, <$w x i32> $v_13\n"
-            "    $v_n = call $M @llvm.masked.gather.v$w$H(<$w x {$m*}> $v_14, i32 $a, $V, $M $z)\n"
+            "    $v_14 = getelementptr inbounds $m, ptr %arr_$u, <$w x i32> $v_13\n"
+            "    $v_n = call $M @llvm.masked.gather.v$w$H(<$w x ptr> $v_14, i32 $a, $V, $M $z)\n"
             "    br label %l_$u_done\n\n",
             v->reg_index,
             v, offset, jitc_llvm_u32_width_str,
             v, v, jitc_llvm_u32_arange_str,
-            v, v, v, source->reg_index, v,
-            v, v, v, v, v, v, mask, v,
+            v, v, source->reg_index, v,
+            v, v, v, v, v, mask, v,
             v->reg_index);
 
         // Trailer
@@ -197,17 +189,17 @@ void jitc_llvm_render_array_read(Variable *v, Variable *source, Variable *mask,
             v->reg_index,
             v, ext, v, v, v->reg_index, v, v->reg_index);
     } else {
-        fmt_intrinsic("declare $M @llvm.masked.gather.v$w$H(<$w x {$m*}>, i32, <$w x i1>, $M)",
-                      v, v, v, v);
+        fmt_intrinsic("declare $M @llvm.masked.gather.v$w$H(<$w x ptr>, i32, <$w x i1>, $M)",
+                      v, v, v);
 
         fmt("    $v_0 = mul $V, $s\n"
             "    $v_1 = add <$w x i32> $v_0, $s\n"
-            "    $v_2 = getelementptr inbounds $m, {$m*} %arr_$u, <$w x i32> $v_1\n"
-            "    $v$s = call $M @llvm.masked.gather.v$w$H(<$w x {$m*}> $v_2, i32 $a, $V, $M $z)\n",
+            "    $v_2 = getelementptr inbounds $m, ptr %arr_$u, <$w x i32> $v_1\n"
+            "    $v$s = call $M @llvm.masked.gather.v$w$H(<$w x ptr> $v_2, i32 $a, $V, $M $z)\n",
             v, offset, jitc_llvm_u32_width_str,
             v, v, jitc_llvm_u32_arange_str,
-            v, v, v, source->reg_index, v,
-            v, ext, v, v, v, v, v, mask, v);
+            v, v, source->reg_index, v,
+            v, ext, v, v, v, v, mask, v);
     }
 
     if (v->type == (uint32_t) VarType::Bool)
@@ -227,13 +219,9 @@ void jitc_llvm_render_array_write(Variable *v, Variable *target,
     if (copy) {
         target_buffer = jitc_array_buffer(v)->reg_index;
 
-        fmt_intrinsic("declare void @llvm.memcpy.inline.p0{i8|}.p0{i8|}.i32({i8*}, {i8*}, i32, i1)");
-        fmt("{    $v_dst = bitcast $m* %arr_$u to i8*\n"
-             "    $v_src = bitcast $m* %arr_$u to i8*\n|}"
-             "    call void @llvm.memcpy.inline.p0{i8|}.p0{i8|}.i32({i8*} align($A) {$v_dst|%arr_$u}, {i8*} align($A) {$v_src|%arr_$u}, i32 $u, i1 0)\n",
-            v, v, target_buffer,
-            v, v, target->reg_index,
-            v, v, target_buffer, v, v, target->reg_index,
+        fmt_intrinsic("declare void @llvm.memcpy.inline.p0.p0.i32(ptr, ptr, i32, i1)");
+        fmt("    call void @llvm.memcpy.inline.p0.p0.i32(ptr align($A) %arr_$u, ptr align($A) %arr_$u, i32 $u, i1 0)\n",
+            v, target_buffer, v, target->reg_index,
             target->array_length * type_size[target->type] * jitc_llvm_vector_width);
     }
 
@@ -247,52 +235,49 @@ void jitc_llvm_render_array_write(Variable *v, Variable *target,
     if (!offset || offset->size == 1) {
         // Scalar/literal offset case: we can avoid a scatter operation
         if (offset) {
-            fmt_intrinsic("declare i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32>)");
+            fmt_intrinsic("declare i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32>)");
 
             // Scalar offset, extract the value (danger: can't use
             // extractelement because masked index entries can be invalid)
             fmt("    $v_0 = select $V, $V, $T $z\n"
-                "    $v_1 = call i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32> $v_0)\n"
+                "    $v_1 = call i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32> $v_0)\n"
                 "    $v_2 = mul i32 $v_1, $u\n"
-                "    $v_3 = getelementptr inbounds $m, {$m*} %arr_$u, i32 $v_2\n",
+                "    $v_3 = getelementptr inbounds $m, ptr %arr_$u, i32 $v_2\n",
                 v, mask, offset, offset,
                 v, v,
                 v, v, jitc_llvm_vector_width,
-                v, v, v, target_buffer, v);
+                v, v, target_buffer, v);
         } else {
-            fmt("    $v_3 = getelementptr inbounds $m, {$m*} %arr_$u, i32 $u\n",
-                v, v, v, target_buffer, v->literal * jitc_llvm_vector_width);
+            fmt("    $v_3 = getelementptr inbounds $m, ptr %arr_$u, i32 $u\n",
+                v, v, target_buffer, v->literal * jitc_llvm_vector_width);
         }
 
-        fmt("{    $v_4 = bitcast $m* $v_3 to $M*\n|}",
-            v, v, v, v);
-
         if (mask_safe_to_ignore(mask)) {
-            fmt("    store $M $v$s, $M* $v_{4|3}, align $A\n",
-                v, value, ext, v, v, v);
+            fmt("    store $M $v$s, ptr $v_3, align $A\n",
+                v, value, ext, v, v);
         } else {
-            fmt("    $v_5 = load $M, $M* $v_{4|3}, align $A\n"
+            fmt("    $v_5 = load $M, ptr $v_3, align $A\n"
                 "    $v_6 = select $V, $M $v$s, $V_5\n"
-                "    store $V_6, $M* $v_{4|3}, align $A\n",
-                v, v, v, v, v,
+                "    store $V_6, ptr $v_3, align $A\n",
+                v, v, v, v,
                 v, mask, v, value, ext, v,
-                v, v, v, v);
+                v, v, v);
         }
     } else if (jitc_llvm_vector_width >= 8 && DRJIT_LLVM_OPTIMIZE_ARRAY_ACCESSES) {
         /// Check if the scatter can be reduced to a packet store
 
-        fmt_intrinsic("declare i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32>)");
-        fmt_intrinsic("declare i32 @llvm$e.vector.reduce.umin.v$wi32(<$w x i32>)");
-        fmt_intrinsic("declare void @llvm.masked.scatter.v$w$H($M, <$w x {$m*}>, i32, <$w x i1>)",
-                      v, v, v);
+        fmt_intrinsic("declare i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32>)");
+        fmt_intrinsic("declare i32 @llvm.vector.reduce.umin.v$wi32(<$w x i32>)");
+        fmt_intrinsic("declare void @llvm.masked.scatter.v$w$H($M, <$w x ptr>, i32, <$w x i1>)",
+                      v, v);
 
         // Check if the write is coherent
         fmt("    $v_0 = insertelement <$w x i32> undef, i32 -1, i32 0\n"
             "    $v_1 = shufflevector <$w x i32> $v_0, <$w x i32> undef, <$w x i32> $z\n"
             "    $v_2 = select $V, $V, <$w x i32> $z\n"
             "    $v_3 = select $V, $V, <$w x i32> $v_1\n"
-            "    $v_4 = call i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32> $v_2)\n"
-            "    $v_5 = call i32 @llvm$e.vector.reduce.umin.v$wi32(<$w x i32> $v_3)\n"
+            "    $v_4 = call i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32> $v_2)\n"
+            "    $v_5 = call i32 @llvm.vector.reduce.umin.v$wi32(<$w x i32> $v_3)\n"
             "    $v_6 = icmp eq i32 $v_4, $v_5\n"
             "    br i1 $v_6, label %l_$u_u, label %l_$u_n\n\n",
             v,
@@ -307,23 +292,21 @@ void jitc_llvm_render_array_write(Variable *v, Variable *target,
         // Uniform case
         fmt( "l_$u_u:\n"
              "    $v_7 = mul i32 $v_4, $u\n"
-             "    $v_8 = getelementptr inbounds $m, {$m*} %arr_$u, i32 $v_7\n"
-            "{    $v_9 = bitcast $m* $v_8 to $M*\n|}",
+             "    $v_8 = getelementptr inbounds $m, ptr %arr_$u, i32 $v_7\n",
             v->reg_index,
             v, v, jitc_llvm_vector_width,
-            v, v, v, target_buffer, v,
-            v, v, v, v);
+            v, v, target_buffer, v);
 
         if (mask_safe_to_ignore(mask)) {
-            fmt("    store $M $v$s, $M* $v_{9|8}, align $A\n",
-                v, value, ext, v, v, v);
+            fmt("    store $M $v$s, ptr $v_8, align $A\n",
+                v, value, ext, v, v);
         } else {
-            fmt("    $v_10 = load $M, $M* $v_{9|8}, align $A\n"
+            fmt("    $v_10 = load $M, ptr $v_8, align $A\n"
                 "    $v_11 = select $V, $M $v$s, $V_10\n"
-                "    store $V_11, $M* $v_{9|8}, align $A\n",
-                v, v, v, v, v,
+                "    store $V_11, ptr $v_8, align $A\n",
+                v, v, v, v,
                 v, mask, v, value, ext, v,
-                v, v, v, v);
+                v, v, v);
         }
 
         fmt("    br label %l_$u_done\n\n", v->reg_index);
@@ -332,74 +315,62 @@ void jitc_llvm_render_array_write(Variable *v, Variable *target,
         fmt("l_$u_n:\n"
             "    $v_12 = mul $V, $s\n"
             "    $v_13 = add <$w x i32> $v_12, $s\n"
-            "    $v_14 = getelementptr inbounds $m, {$m*} %arr_$u, <$w x i32> $v_13\n"
-            "    call void @llvm.masked.scatter.v$w$H($M $v$s, <$w x {$m*}> $v_14, i32 $a, $V)\n"
+            "    $v_14 = getelementptr inbounds $m, ptr %arr_$u, <$w x i32> $v_13\n"
+            "    call void @llvm.masked.scatter.v$w$H($M $v$s, <$w x ptr> $v_14, i32 $a, $V)\n"
             "    br label %l_$u_done\n\n",
             v->reg_index,
             v, offset, jitc_llvm_u32_width_str,
             v, v, jitc_llvm_u32_arange_str,
-            v, v, v, target_buffer, v,
-            v, v, value, ext, v, v, v, mask,
+            v, v, target_buffer, v,
+            v, v, value, ext, v, v, mask,
             v->reg_index);
 
         // Trailer
         fmt("l_$u_done:\n", v->reg_index);
     } else {
-        fmt_intrinsic("declare void @llvm.masked.scatter.v$w$H($M, <$w x {$m*}>, i32, <$w x i1>)",
-                      v, v, v);
+        fmt_intrinsic("declare void @llvm.masked.scatter.v$w$H($M, <$w x ptr>, i32, <$w x i1>)",
+                      v, v);
 
         fmt("    $v_0 = mul $V, $s\n"
             "    $v_1 = add <$w x i32> $v_0, $s\n"
-            "    $v_2 = getelementptr inbounds $m, {$m*} %arr_$u, <$w x i32> $v_1\n"
-            "    call void @llvm.masked.scatter.v$w$H($M $v$s, <$w x {$m*}> $v_2, i32 $a, $V)\n",
+            "    $v_2 = getelementptr inbounds $m, ptr %arr_$u, <$w x i32> $v_1\n"
+            "    call void @llvm.masked.scatter.v$w$H($M $v$s, <$w x ptr> $v_2, i32 $a, $V)\n",
             v, offset, jitc_llvm_u32_width_str,
             v, v, jitc_llvm_u32_arange_str,
-            v, v, v, target_buffer, v,
-            v, v, value, ext, v, v, v, mask);
+            v, v, target_buffer, v,
+            v, v, value, ext, v, v, mask);
     }
 
     v->reg_index = target_buffer;
 }
 
 void jitc_llvm_render_array_memcpy_in(const Variable *v) {
-    fmt_intrinsic("declare void @llvm.memcpy.inline.p0{i8}.p0{i8}.i32({i8*}, {i8*}, i32, i1)");
-    fmt( "    $v_p1 = getelementptr inbounds {i8*}, {i8**} %params, i32 $o\n"
-         "    $v_p2 = load {i8*}, {i8**} $v_p1, align 8, !alias.scope !2\n"
-         "    $v_p3 = bitcast i8* $v_p2 to $m*\n"
-         "    $v_p4 = mul i64 %index, $u\n"
-         "    $v_p5 = getelementptr inbounds $m, $m* $v_p3, i64 $v_p4\n"
-         "    $v_p6 = bitcast $m* $v_p5 to i8*\n"
-         "    $v_p7 = bitcast $m* %arr_$u to i8*\n"
-         "    call void @llvm.memcpy.inline.p0{i8}.p0{i8}.i32({i8*} align($A) $v_p7, {i8*} align($A) $v_p6, i32 $u, i1 0)\n",
+    fmt_intrinsic("declare void @llvm.memcpy.inline.p0.p0.i32(ptr, ptr, i32, i1)");
+    fmt( "    $v_p1 = getelementptr inbounds ptr, ptr %params, i32 $o\n"
+         "    $v_p2 = load ptr, ptr $v_p1, align 8, !alias.scope !2\n"
+         "    $v_p3 = mul i64 %index, $u\n"
+         "    $v_p4 = getelementptr inbounds $m, ptr $v_p2, i64 $v_p3\n"
+         "    call void @llvm.memcpy.inline.p0.p0.i32(ptr align($A) %arr_$u, ptr align($A) $v_p4, i32 $u, i1 0)\n",
         v, v,
         v, v,
-        v, v, v,
         v, v->size == 1 ? 0 : v->array_length,
-        v, v, v, v, v,
-        v, v, v,
-        v, v, v->reg_index,
-        v, v, v, v, v->array_length * type_size[v->type] * jitc_llvm_vector_width
+        v, v, v, v,
+        v, v->reg_index, v, v, v->array_length * type_size[v->type] * jitc_llvm_vector_width
     );
 }
 
 void jitc_llvm_render_array_memcpy_out(const Variable *v) {
-    fmt_intrinsic("declare void @llvm.memcpy.inline.p0{i8|}.p0{i8|}.i32({i8*}, {i8*}, i32, i1)");
-    fmt( "    $v_p1 = getelementptr inbounds {i8*}, {i8**} %params, i32 $o\n"
-         "    $v_p2 = load {i8*}, {i8**} $v_p1, align 8, !alias.scope !2\n"
-         "    $v_p3 = bitcast i8* $v_p2 to $m*\n"
-         "    $v_p4 = mul i64 %index, $u\n"
-         "    $v_p5 = getelementptr inbounds $m, $m* $v_p3, i64 $v_p4\n"
-         "    $v_p6 = bitcast $m* $v_p5 to i8*\n"
-         "    $v_p7 = bitcast $m* %arr_$u to i8*\n"
-         "    call void @llvm.memcpy.inline.p0{i8|}.p0{i8|}.i32({i8*} align($A) $v_p6, {i8*} align($A) $v_p7, i32 $u, i1 0)\n",
+    fmt_intrinsic("declare void @llvm.memcpy.inline.p0.p0.i32(ptr, ptr, i32, i1)");
+    fmt( "    $v_p1 = getelementptr inbounds ptr, ptr %params, i32 $o\n"
+         "    $v_p2 = load ptr, ptr $v_p1, align 8, !alias.scope !2\n"
+         "    $v_p3 = mul i64 %index, $u\n"
+         "    $v_p4 = getelementptr inbounds $m, ptr $v_p2, i64 $v_p3\n"
+         "    call void @llvm.memcpy.inline.p0.p0.i32(ptr align($A) $v_p4, ptr align($A) %arr_$u, i32 $u, i1 0)\n",
         v, v,
         v, v,
-        v, v, v,
         v, v->array_length,
-        v, v, v, v, v,
-        v, v, v,
-        v, v, v->reg_index,
-        v, v, v, v, v->array_length * type_size[v->type] * jitc_llvm_vector_width
+        v, v, v, v,
+        v, v, v, v->reg_index, v->array_length * type_size[v->type] * jitc_llvm_vector_width
     );
 }
 
@@ -407,40 +378,34 @@ void jitc_llvm_render_array_select(Variable *v, Variable *mask, Variable *t, Var
     uint32_t reg_index = jitc_array_buffer(v)->reg_index;
     v->reg_index = reg_index;
 
-    fmt("    $v_tp = bitcast $m* %arr_$u to {$M*}\n"
-        "    $v_fp = bitcast $m* %arr_$u to {$M*}\n"
-        "    $v_vp = bitcast $m* %arr_$u to {$M*}\n"
-        "    br label %l_$u_pre\n\n"
+    fmt("    br label %l_$u_pre\n\n"
         "l_$u_pre:\n"
         "    br label %l_$u_loop\n\n"
         "l_$u_loop:\n"
         "    $v_cur = phi i64 [ 0, %l_$u_pre ], [ $v_next, %l_$u_loop ]\n"
-        "    $v_ti = getelementptr inbounds $M, {$M*} $v_tp, i64 $v_cur\n"
-        "    $v_fi = getelementptr inbounds $M, {$M*} $v_fp, i64 $v_cur\n"
-        "    $v_vi = getelementptr inbounds $M, {$M*} $v_vp, i64 $v_cur\n"
-        "    $v_t = load $M, {$M*} $v_ti, align $A\n"
-        "    $v_f = load $M, {$M*} $v_fi, align $A\n"
+        "    $v_ti = getelementptr inbounds $M, ptr %arr_$u, i64 $v_cur\n"
+        "    $v_fi = getelementptr inbounds $M, ptr %arr_$u, i64 $v_cur\n"
+        "    $v_vi = getelementptr inbounds $M, ptr %arr_$u, i64 $v_cur\n"
+        "    $v_t = load $M, ptr $v_ti, align $A\n"
+        "    $v_f = load $M, ptr $v_fi, align $A\n"
         "    $v_v = select $V, $M $v_t, $M $v_f\n"
-        "    store $M $v_v, {$M*} $v_vi, align $A\n"
+        "    store $M $v_v, ptr $v_vi, align $A\n"
         "    $v_next = add i64 $v_cur, 1\n"
         "    $v_cont = icmp ult i64 $v_next, $u\n"
         "    br i1 $v_cont, label %l_$u_loop, label %l_$u_done\n\n"
         "l_$u_done:\n",
-        v, v, t->reg_index, v,
-        v, v, f->reg_index, v,
-        v, v, v->reg_index, v,
         reg_index,
         reg_index,
         reg_index,
         reg_index,
         v, reg_index, v, reg_index,
-        v, v, v, v, v,
-        v, v, v, v, v,
-        v, v, v, v, v,
-        v, v, v, v, v,
-        v, v, v, v, v,
+        v, v, t->reg_index, v,
+        v, v, f->reg_index, v,
+        v, v, reg_index, v,
+        v, v, v, v,
+        v, v, v, v,
         v, mask, v, v, v, v,
-        v, v, v, v, v,
+        v, v, v, v,
         v, v,
         v, v, v->array_length,
         v, reg_index, reg_index,

--- a/src/llvm_coop_vec.cpp
+++ b/src/llvm_coop_vec.cpp
@@ -24,10 +24,10 @@ void jitc_llvm_render_coop_vec_accum(const Variable *v, const Variable *target,
                                      const Variable *value, const Variable *mask) {
     put("    ; coop_vec_accum\n");
 
-    fmt("    $v_p = bitcast $<{i8*}$> $v to $<{$t*}$>\n", v, target, value);
+    fmt("    $v_p = bitcast $<ptr$> $v to $<ptr$>\n", v, target);
 
     if (callable_depth == 0) {
-        fmt_intrinsic("declare $t @llvm$e.vector.reduce.fadd.v$w$h($t, $T)",
+        fmt_intrinsic("declare $t @llvm.vector.reduce.fadd.v$w$h($t, $T)",
                       value, value, value, value);
     } else {
         jitc_llvm_append_reduce_op_local((VarType) value->type, ReduceOp::Add, value);
@@ -36,19 +36,18 @@ void jitc_llvm_render_coop_vec_accum(const Variable *v, const Variable *target,
     }
 
     for (uint32_t i = 0; i < value->array_length; ++i) {
-            fmt("    $v_p_$u = getelementptr inbounds $t, $<{$t*}$> $v_p, i32 $u\n",
-                v, i, value, value, v, (uint32_t) v->literal + i);
+            fmt("    $v_p_$u = getelementptr inbounds $t, $<ptr$> $v_p, i32 $u\n",
+                v, i, value, v, (uint32_t) v->literal + i);
 
         if (callable_depth == 0) {
-            fmt("    $v_valid_$u = select $V, $V_$u, $T zeroinitializer\n"
-                "    $v_red_$u = call $t @llvm$e.vector.reduce.fadd.v$w$h($t zeroinitializer, $T $v_valid_$u)\n"
-                "    atomicrmw fadd {$t*} $v_p_$u, $t $v_red_$u monotonic\n",
+            fmt("    $v_valid_$u = select $V, $V_$u, $T $z\n"
+                "    $v_red_$u = call $t @llvm.vector.reduce.fadd.v$w$h($t $z, $T $v_valid_$u)\n"
+                "    atomicrmw fadd ptr $v_p_$u, $t $v_red_$u monotonic\n",
                 v, i, mask, value, i, value,
-                v, i, value, value, value, value, v, i,
-                value, v, i, value, v, i);
+                v, i, value, value, value, value, v, i, v, i, value, v, i);
         } else {
-            fmt("    call fastcc void @reduce_add_$h_atomic_local(<$w x $p> $v_p_$u, $V_$u, i$w $v_mask)\n",
-                value, value, v, i, value, i, v);
+            fmt("    call fastcc void @reduce_add_$h_atomic_local(<$w x ptr> $v_p_$u, $V_$u, i$w $v_mask)\n",
+                value, v, i, value, i, v);
         }
     }
 }
@@ -68,29 +67,29 @@ void jitc_llvm_render_coop_vec_outer_product_accum(const Variable *v, const Vari
     alloca_size  = std::max(alloca_size, (int32_t) (vec_size * (n + m)));
     alloca_align = std::max(alloca_align, (int32_t) (vec_size));
 
-    fmt("    $v_po_0 = getelementptr inbounds i8, $<{i8*}$> $v, i32 $u\n"
-        "    $v_po = bitcast $<{i8*}$> $v_po_0 to $<{[$u x $t]*}$>\n"
-        "    $v_p0 = bitcast {i8*} %buffer to {$T*}\n"
-        "    $v_p1 = getelementptr inbounds $T, {$T*} $v_p0, i32 $u\n"
+    fmt("    $v_po_0 = getelementptr inbounds i8, $<ptr$> $v, i32 $u\n"
+        "    $v_po = bitcast $<ptr$> $v_po_0 to $<ptr$>\n"
+        "    $v_p0 = bitcast ptr %buffer to ptr\n"
+        "    $v_p1 = getelementptr inbounds $T, ptr $v_p0, i32 $u\n"
         "    $v_mask = bitcast $V to i$w\n",
         v, target, d->offset * tsize,
-        v, v, d->stride, v0,
-        v, v0,
-        v, v0, v0, v, m,
+        v, v,
+        v,
+        v, v0, v, m,
         v, mask);
 
     put("\n    ; Prepare inputs\n");
     for (uint32_t i = 0; i < m; ++i) {
-        fmt("    $v_p0_$u = getelementptr inbounds $T, {$T*} $v_p0, i32 $u\n"
-            "    store $V_$u, {$T*} $v_p0_$u, align $A\n",
-            v, i, v0, v0, v, i,
-            v0, i, v0, v, i, v0);
+        fmt("    $v_p0_$u = getelementptr inbounds $T, ptr $v_p0, i32 $u\n"
+            "    store $V_$u, ptr $v_p0_$u, align $A\n",
+            v, i, v0, v, i,
+            v0, i, v, i, v0);
     }
     for (uint32_t i = 0; i < n; ++i) {
-        fmt("    $v_p1_$u = getelementptr inbounds $T, {$T*} $v_p1, i32 $u\n"
-            "    store $V_$u, {$T*} $v_p1_$u, align $A\n",
-            v, i, v1, v1, v, i,
-            v1, i, v1, v, i, v1);
+        fmt("    $v_p1_$u = getelementptr inbounds $T, ptr $v_p1, i32 $u\n"
+            "    store $V_$u, ptr $v_p1_$u, align $A\n",
+            v, i, v1, v, i,
+            v1, i, v, i, v1);
     }
     fmt("    br label %l$u_before\n"
         "\n"
@@ -105,8 +104,8 @@ void jitc_llvm_render_coop_vec_outer_product_accum(const Variable *v, const Vari
         "    br i1 $v_i_cont, label %l$u_load, label %l$u_done\n"
         "\n"
         "l$u_load:\n"
-        "    $v_p0i = getelementptr inbounds $T, {$T*} $v_p0, i32 $v_i\n"
-        "    $v_v0i = load $T, {$T*} $v_p0i, align $A\n"
+        "    $v_p0i = getelementptr inbounds $T, ptr $v_p0, i32 $v_i\n"
+        "    $v_v0i = load $T, ptr $v_p0i, align $A\n"
         "    br label %l$u_inner;\n"
         "\n"
         "l$u_inner:\n"
@@ -128,8 +127,8 @@ void jitc_llvm_render_coop_vec_outer_product_accum(const Variable *v, const Vari
 
         // load:
         v->reg_index,
-        v, v0, v0, v, v,
-        v, v0, v0, v, v0,
+        v, v0, v, v,
+        v, v0, v, v0,
         v->reg_index,
 
         // inner:
@@ -141,29 +140,28 @@ void jitc_llvm_render_coop_vec_outer_product_accum(const Variable *v, const Vari
         v->reg_index
     );
 
-    fmt("    $v_p1j = getelementptr inbounds $T, {$T*} $v_p1, i32 $v_j\n"
-        "    $v_v1j = load $T, {$T*} $v_p1j, align $A\n"
+    fmt("    $v_p1j = getelementptr inbounds $T, ptr $v_p1, i32 $v_j\n"
+        "    $v_v1j = load $T, ptr $v_p1j, align $A\n"
         "    $v_ij = fmul $T $v_v0i, $v_v1j\n",
-        v, v1, v1, v, v,
-        v, v1, v1, v, v1,
+        v, v1, v, v,
+        v, v1, v, v1,
         v, v1, v, v);
 
-    fmt("    $v_po_ij = getelementptr inbounds [$u x $t], $<{[$u x $t]*}$> $v_po, i32 $v_i, i32 $v_j\n",
-        v, d->stride, v0, d->stride, v0, v, v, v);
+    fmt("    $v_po_ij = getelementptr inbounds [$u x $t], $<ptr$> $v_po, i32 $v_i, i32 $v_j\n",
+        v, d->stride, v0, v, v, v);
 
     if (callable_depth == 0) {
-        fmt_intrinsic("declare $t @llvm$e.vector.reduce.fadd.v$w$h($t, $T)",
+        fmt_intrinsic("declare $t @llvm.vector.reduce.fadd.v$w$h($t, $T)",
                       v1, v1, v1, v1);
-        fmt("    $v_valid = select $V, $T $v_ij, $T zeroinitializer\n"
-            "    $v_red = call $t @llvm$e.vector.reduce.fadd.v$w$h($t zeroinitializer, $T $v_valid)\n"
-            "    atomicrmw fadd {$t*} $v_po_ij, $t $v_red monotonic\n",
+        fmt("    $v_valid = select $V, $T $v_ij, $T $z\n"
+            "    $v_red = call $t @llvm.vector.reduce.fadd.v$w$h($t $z, $T $v_valid)\n"
+            "    atomicrmw fadd ptr $v_po_ij, $t $v_red monotonic\n",
             v, mask, v1, v, v1,
-            v, v1, v1, v1, v1, v,
-            v1, v, v1, v);
+            v, v1, v1, v1, v1, v, v, v1, v);
     } else {
         jitc_llvm_append_reduce_op_local((VarType) v1->type, ReduceOp::Add, v1);
-        fmt("    call fastcc void @reduce_add_$h_atomic_local(<$w x $p> $v_po_ij, $T $v_ij, i$w $v_mask)\n",
-            v1, v1, v, v1, v, v);
+        fmt("    call fastcc void @reduce_add_$h_atomic_local(<$w x ptr> $v_po_ij, $T $v_ij, i$w $v_mask)\n",
+            v1, v, v1, v, v);
     }
 
     fmt("    br label %l$u_inner\n"
@@ -216,7 +214,7 @@ void jitc_llvm_render_coop_vec(const Variable *v, const Variable *a0,
                 if ((JitOp) v->literal == JitOp::Step) {
                     for (uint32_t i =  0; i < v->array_length; ++i) {
                         fmt("    $v_$u_m = $s $V_$u, $v_$u\n", v, i, op, a0, i, a1, i);
-                        fmt("    $v_$u = select <$w x i1> $v_$u_m, $T zeroinitializer, $T $s\n",
+                        fmt("    $v_$u = select <$w x i1> $v_$u_m, $T $z, $T $s\n",
                             v, i, v, i, v, v, jitc_llvm_ones_str[v->type]);
                     }
                 } else {
@@ -293,24 +291,24 @@ void jitc_llvm_render_coop_vec(const Variable *v, const Variable *a0,
             break;
 
         case VarKind::CoopVecLoad:
-            fmt("    $v_p = bitcast $<{i8*}$> $v to $<{$t*}$>\n", v, a0, v);
+            fmt("    $v_p = bitcast $<ptr$> $v to $<ptr$>\n", v, a0);
 
             for (uint32_t i = 0; i < v->array_length; ++i) {
-                fmt("    $v_p_$u = getelementptr inbounds $t, $<{$t*}$> $v_p, i32 $u\n",
-                    v, i, v, v, v, (uint32_t) v->literal + i);
+                fmt("    $v_p_$u = getelementptr inbounds $t, $<ptr$> $v_p, i32 $u\n",
+                    v, i, v, v, (uint32_t) v->literal + i);
 
                 if (callable_depth == 0) {
-                    fmt("    $v_$u_0 = load $t, {$t *} $v_p_$u, align $a\n"
+                    fmt("    $v_$u_0 = load $t, ptr $v_p_$u, align $a\n"
                         "    $v_$u_1 = insertelement $T undef, $t $v_$u_0, i32 0\n"
                         "    $v_$u = shufflevector $T $v_$u_1, $T undef, <$w x i32> $z\n",
-                        v, i, v, v, v, i, v,
+                        v, i, v, v, i, v,
                         v, i, v, v, v, i,
                         v, i, v, v, i, v);
                 } else {
-                    fmt_intrinsic("declare $T @llvm.masked.gather.v$w$h(<$w x {$t*}>, i32, <$w x i1>, $T)",
-                                  v, v, v, v);
-                    fmt("    $v_$u = call $T @llvm.masked.gather.v$w$h(<$w x {$t*}> $v_p_$u, i32 $a, $V, $T $z)\n",
-                        v, i, v, v, v, v, i, v, a1, v);
+                    fmt_intrinsic("declare $T @llvm.masked.gather.v$w$h(<$w x ptr>, i32, <$w x i1>, $T)",
+                                  v, v, v);
+                    fmt("    $v_$u = call $T @llvm.masked.gather.v$w$h(<$w x ptr> $v_p_$u, i32 $a, $V, $T $z)\n",
+                        v, i, v, v, v, i, v, a1, v);
                 }
             }
             break;
@@ -329,54 +327,52 @@ void jitc_llvm_render_coop_vec(const Variable *v, const Variable *a0,
                 alloca_size  = std::max(alloca_size, (int32_t) (vec_size * (n + m)));
                 alloca_align = std::max(alloca_align, (int32_t) (vec_size));
 
-                fmt( "    $v_pi = bitcast {i8*} %buffer to {$T*}\n"
-                     "    $v_po = getelementptr inbounds $T, {$T*} $v_pi, i32 $u\n"
-                     "    $v_pa_0 = bitcast $<{i8*}$> $v to $<{$t*}$>\n"
-                     "    $v_pa{_1|} = getelementptr inbounds $t, $<{$t*}$> $v_pa_0, i32 $u\n"
-                    "{    $v_pa = bitcast $<$t*$> $v_pa_1 to $<[$u x $t]*$>\n|}",
-                    v, v,
-                    v, v, v, v, n,
-                    v, a0, v,
-                    v, v, v, v, d->A_descr.offset,
-                    v, v, v, transpose ? m : n, v);
+                fmt( "    $v_pi = bitcast ptr %buffer to ptr\n"
+                     "    $v_po = getelementptr inbounds $T, ptr $v_pi, i32 $u\n"
+                     "    $v_pa_0 = bitcast $<ptr$> $v to $<ptr$>\n"
+                     "    $v_pa = getelementptr inbounds $t, $<ptr$> $v_pa_0, i32 $u\n",
+                    v,
+                    v, v, v, n,
+                    v, a0,
+                    v, v, v, d->A_descr.offset);
                 if (bias) {
-                    fmt("    $v_pb_0 = bitcast $<{i8*}$> $v to $<{$t*}$>\n"
-                        "    $v_pb = getelementptr inbounds $t, $<{$t*}$> $v_pb_0, i32 $u\n",
-                        v, bias, v,
-                        v, v, v, v, d->b_descr.offset);
+                    fmt("    $v_pb_0 = bitcast $<ptr$> $v to $<ptr$>\n"
+                        "    $v_pb = getelementptr inbounds $t, $<ptr$> $v_pb_0, i32 $u\n",
+                        v, bias,
+                        v, v, v, d->b_descr.offset);
                 }
 
                 put("\n    ; Prepare input\n");
                 for (uint32_t i = 0; i < n; ++i) {
-                    fmt("    $v_pi_$u = getelementptr inbounds $T, {$T*} $v_pi, i32 $u\n"
-                        "    store $V_$u, {$T*} $v_pi_$u, align $A\n",
-                        v, i, v, v, v, i,
-                        a1, i, v, v, i, v);
+                    fmt("    $v_pi_$u = getelementptr inbounds $T, ptr $v_pi, i32 $u\n"
+                        "    store $V_$u, ptr $v_pi_$u, align $A\n",
+                        v, i, v, v, i,
+                        a1, i, v, i, v);
                 }
 
                 put("\n    ; Prepare output\n");
                 for (uint32_t i = 0; i < m; ++i) {
                     if (bias) {
-                        fmt("    $v_b_$u_1 = getelementptr inbounds $t, $<{$t*}$> $v_pb, i32 $u\n",
-                            v, i, v, v, v, i);
+                        fmt("    $v_b_$u_1 = getelementptr inbounds $t, $<ptr$> $v_pb, i32 $u\n",
+                            v, i, v, v, i);
                         if (callable_depth == 0) {
-                            fmt("    $v_b_$u_2 = load $t, {$t *} $v_b_$u_1, align $a\n"
+                            fmt("    $v_b_$u_2 = load $t, ptr $v_b_$u_1, align $a\n"
                                 "    $v_b_$u_3 = insertelement $T undef, $t $v_b_$u_2, i32 0\n"
                                 "    $v_b_$u = shufflevector $T $v_b_$u_3, $T undef, <$w x i32> $z\n",
-                                v, i, v, v, v, i, v,
+                                v, i, v, v, i, v,
                                 v, i, v, v, v, i,
                                 v, i, v, v, i, v);
                         } else {
-                            fmt("    $v_b_$u = call $T @llvm.masked.gather.v$w$h(<$w x {$t*}> $v_b_$u_1, i32 $a, $V, $T $z)\n",
-                                v, i, v, v, v, v, i, v, mask, v);
+                            fmt("    $v_b_$u = call $T @llvm.masked.gather.v$w$h(<$w x ptr> $v_b_$u_1, i32 $a, $V, $T $z)\n",
+                                v, i, v, v, v, i, v, mask, v);
                         }
                     }
 
-                    fmt("    $v_po_$u = getelementptr inbounds $T, {$T*} $v_po, i32 $u\n", v, i, v, v, v, i);
+                    fmt("    $v_po_$u = getelementptr inbounds $T, ptr $v_po, i32 $u\n", v, i, v, v, i);
                     if (bias)
-                        fmt("    store $V_b_$u, {$T*} $v_po_$u, align $A\n", v, i, v, v, i, v);
+                        fmt("    store $V_b_$u, ptr $v_po_$u, align $A\n", v, i, v, i, v);
                     else
-                        fmt("    store $T zeroinitializer, {$T*} $v_po_$u, align $A\n", v, v, v, i, v);
+                        fmt("    store $T $z, ptr $v_po_$u, align $A\n", v, v, i, v);
                 }
 
                 put("\n    ; Matrix multiplication\n");
@@ -392,8 +388,8 @@ void jitc_llvm_render_coop_vec(const Variable *v, const Variable *a0,
                     "    br i1 $v_j_cont, label %l$u_load, label %l$u_done\n"
                     "\n"
                     "l$u_load:\n"
-                    "    $v_x1 = getelementptr inbounds $T, {$T*} $v_pi, i32 $v_j\n"
-                    "    $v_x = load $T, {$T*} $v_x1, align $A\n"
+                    "    $v_x1 = getelementptr inbounds $T, ptr $v_pi, i32 $v_j\n"
+                    "    $v_x = load $T, ptr $v_x1, align $A\n"
                     "    br label %l$u_inner;\n"
                     "\n"
                     "l$u_inner:\n"
@@ -413,8 +409,8 @@ void jitc_llvm_render_coop_vec(const Variable *v, const Variable *a0,
                     v, v->reg_index, v->reg_index,
 
                     v->reg_index,
-                    v, v, v, v, v,
-                    v, v, v, v, v,
+                    v, v, v, v,
+                    v, v, v, v,
                     v->reg_index,
 
                     v->reg_index,
@@ -425,25 +421,24 @@ void jitc_llvm_render_coop_vec(const Variable *v, const Variable *a0,
                     v->reg_index
                 );
 
-                fmt("    $v_a1 = getelementptr inbounds [$u x $t], $<{[$u x $t]*}$> $v_pa, i32 $v_$s, i32 $v_$s\n",
-                    v, transpose ? m : n,
+                fmt("    $v_a1 = getelementptr inbounds [$u x $t], $<ptr$> $v_pa, i32 $v_$s, i32 $v_$s\n",
                     v, transpose ? m : n,
                     v, v,
                     v, transpose ? "j" : "i",
                     v, transpose ? "i" : "j");
 
                 if (callable_depth == 0) {
-                    fmt("    $v_a2 = load $t, {$t *} $v_a1, align $a\n"
+                    fmt("    $v_a2 = load $t, ptr $v_a1, align $a\n"
                         "    $v_a3 = insertelement $T undef, $t $v_a2, i32 0\n"
                         "    $v_a = shufflevector $T $v_a3, $T undef, <$w x i32> $z\n",
-                        v, v, v, v, v,
+                        v, v, v, v,
                         v, v, v, v,
                         v, v, v, v);
                 } else {
-                    fmt_intrinsic("declare $T @llvm.masked.gather.v$w$h(<$w x {$t*}>, i32, <$w x i1>, $T)",
-                                  v, v, v, v);
-                    fmt("    $v_a = call $T @llvm.masked.gather.v$w$h(<$w x {$t*}> $v_a1, i32 $a, $V, $T $z)\n",
-                        v, v, v, v, v, v, mask, v);
+                    fmt_intrinsic("declare $T @llvm.masked.gather.v$w$h(<$w x ptr>, i32, <$w x i1>, $T)",
+                                  v, v, v);
+                    fmt("    $v_a = call $T @llvm.masked.gather.v$w$h(<$w x ptr> $v_a1, i32 $a, $V, $T $z)\n",
+                        v, v, v, v, v, mask, v);
                 }
 
                 bool custom_intrinsic = false;
@@ -458,14 +453,14 @@ void jitc_llvm_render_coop_vec(const Variable *v, const Variable *a0,
                                   v, v, v, v, v);
 
                 const char *intrinsic_prefix = custom_intrinsic ? "" : "llvm.";
-                fmt("    $v_y1 = getelementptr inbounds $T, {$T*} $v_po, i32 $v_i\n"
-                    "    $v_y = load $T, {$T*} $v_y1, align $A\n"
+                fmt("    $v_y1 = getelementptr inbounds $T, ptr $v_po, i32 $v_i\n"
+                    "    $v_y = load $T, ptr $v_y1, align $A\n"
                     "    $v_r = call $T @$sfma.v$w$h($V_a, $V_x, $V_y)\n"
-                    "    store $V_r, {$T*} $v_y1, align $A\n",
-                    v, v, v, v, v,
-                    v, v, v, v, v,
+                    "    store $V_r, ptr $v_y1, align $A\n",
+                    v, v, v, v,
+                    v, v, v, v,
                     v, v, intrinsic_prefix, v, v, v, v,
-                    v, v, v, v);
+                    v, v, v);
 
                 fmt("    br label %l$u_inner\n"
                     "\n"
@@ -475,7 +470,7 @@ void jitc_llvm_render_coop_vec(const Variable *v, const Variable *a0,
 
                 put("    ; Read back results\n");
                 for (uint32_t i = 0; i < m; ++i)
-                    fmt("    $v_$u = load $T, {$T*} $v_po_$u, align $A\n", v, i, v, v, v, i, v);
+                    fmt("    $v_$u = load $T, ptr $v_po_$u, align $A\n", v, i, v, v, i, v);
             }
             break;
 

--- a/src/llvm_core.cpp
+++ b/src/llvm_core.cpp
@@ -43,9 +43,6 @@ char *jitc_llvm_target_features = nullptr;
 uint32_t jitc_llvm_vector_width = 0;
 uint32_t jitc_llvm_max_align = 0;
 
-/// Should the LLVM IR use typed (e.g., "i8*") or untyped ("ptr") pointers?
-bool jitc_llvm_opaque_pointers = false;
-
 // Strings related to the vector width, used by template engine
 
 /// The literal one, for different variable types
@@ -183,7 +180,15 @@ bool jitc_llvm_init() {
         return false;
     }
 
-    jitc_llvm_opaque_pointers = jitc_llvm_version_major >= 15;
+    if (jitc_llvm_version_major < 15) {
+        jitc_log(Warn,
+                 "jit_llvm_init(): the located LLVM version (%i) is too old. The "
+                 "Dr.Jit LLVM backend requires LLVM 15 or newer for opaque pointer "
+                 "support, shutting down LLVM backend..",
+                 jitc_llvm_version_major);
+        jitc_llvm_shutdown();
+        return false;
+    }
 
     jitc_llvm_update_strings();
 
@@ -197,11 +202,10 @@ bool jitc_llvm_init() {
         snprintf(patch_str, sizeof(patch_str), "%i", jitc_llvm_version_patch);
 
     jitc_log(Info,
-             "jit_llvm_init(): found LLVM %s.%s.%s (%s), target=%s, cpu=%s, %s pointers, width=%u.",
+             "jit_llvm_init(): found LLVM %s.%s.%s (%s), target=%s, cpu=%s, width=%u.",
              major_str, minor_str, patch_str,
              jitc_llvm_use_orcv2 ? "ORCv2" : "MCJIT",
              jitc_llvm_target_triple, jitc_llvm_target_cpu,
-             jitc_llvm_opaque_pointers ? "opaque" : "typed",
              jitc_llvm_vector_width);
 
     return jitc_llvm_init_success;

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -10,17 +10,11 @@
  *  Format  Input          Example result    Description
  * --------------------------------------------------------------------------
  *  $u      uint32_t      `1234`             Decimal number (32 bit)
- *  $U      uint64_t      `1234`             Decimal number (64 bit)
- * --------------------------------------------------------------------------
- *  $x      uint32_t      `4d2`              Hexadecimal number (32 bit)
- *  $X      uint64_t      `4d2`              Hexadecimal number (64 bit)
  * --------------------------------------------------------------------------
  *  $s      const char *  `foo`              Zero-terminated string
  * --------------------------------------------------------------------------
  *  $t      Variable      `float`            Scalar variable type
  *  $T      Variable      `<8 x float>`      Vector variable type
- *  $p      Variable      `float*`           Pointer type
- *  $P      Variable      `<8 x float*>`     Vector variable type
  *  $h      Variable      `f32`              Type abbreviation for intrinsics
  * --------------------------------------------------------------------------
  *  $b      Variable      `i32`              Scalar variable type (as int)
@@ -49,14 +43,7 @@
  * --------------------------------------------------------------------------
  *  $w      (none)        `16`               Vector width of LLVM backend
  *  $z      (none)        `zeroinitializer`  Zero initializer string
- *  $e      (none)        `.experimental`    Ignored on newer LLVM versions
  * --------------------------------------------------------------------------
- *
- * Pointers should be wrapped in braces, as in `{i8*}` or `{$t*}`. This will
- * allow them to be replaced by the opaque `ptr` type on newer versions of LLVM
- * that use this convention. An extended form of this syntax `{a|b}` causes `a`
- * and `b` to be generated for LLVM with non-opaque and opaque pointers,
- * respectively.
  *
  * Another syntax pattern used in a few places is `$<foo$>`. It expands to
  * `foo` at the top level and `<16 x foo>` when the generated code is part
@@ -92,7 +79,7 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
                         (jitc_flags() & (uint32_t) JitFlag::PrintIR);
 
     fmt("define void @drjit_^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^(i64 %start, i64 "
-        "%end, i32 %thread_id, {i8**} noalias %params) #0 ${\n"
+        "%end, i32 %thread_id, ptr noalias %params) #0 {\n"
         "entry:\n");
 
     for (uint32_t gi = group.start; gi != group.end; ++gi) {
@@ -129,8 +116,8 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
         /// Determine source/destination address of input/output parameters
         if (ptype == ParamType::Input && size == 1 && vt == VarType::Pointer) {
             // Case 1: load a pointer address from the parameter array
-            fmt("    $v_p1 = getelementptr inbounds {i8*}, {i8**} %params, i32 $o\n"
-                "    $v = load {i8*}, {i8**} $v_p1, align 8, !alias.scope !2\n",
+            fmt("    $v_p1 = getelementptr inbounds ptr, ptr %params, i32 $o\n"
+                "    $v = load ptr, ptr $v_p1, align 8, !alias.scope !2\n",
                 v, v, v, v);
         } else if (v->is_array()) {
             if (ptype == ParamType::Input)
@@ -138,16 +125,14 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
         } else if (ptype != ParamType::Register) {
             // Case 3: read a regular input/output parameter
 
-            fmt( "    $v_p1 = getelementptr inbounds {i8*}, {i8**} %params, i32 $o\n"
-                 "    $v_p{2|3} = load {i8*}, {i8**} $v_p1, align 8, !alias.scope !2\n"
-                "{    $v_p3 = bitcast i8* $v_p2 to $m*\n|}",
-                v, v, v, v, v, v, v);
+            fmt("    $v_p1 = getelementptr inbounds ptr, ptr %params, i32 $o\n"
+                "    $v_p2 = load ptr, ptr $v_p1, align 8, !alias.scope !2\n",
+                v, v, v, v);
 
             // For output parameters and non-scalar inputs
             if (ptype != ParamType::Input || size != 1)
-                fmt( "    $v_p{4|5} = getelementptr inbounds $m, {$m*} $v_p3, i64 %index\n"
-                    "{    $v_p5 = bitcast $m* $v_p4 to $M*\n|}",
-                    v, v, v, v, v, v, v, v);
+                fmt("    $v_p3 = getelementptr inbounds $m, ptr $v_p2, i64 %index\n",
+                    v, v, v);
         }
 
         if (likely(ptype == ParamType::Input)) {
@@ -161,14 +146,14 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
                 const char *nontemporal =
                     vt == VarType::Float16 ? "" : ", !nontemporal !3";
 
-                fmt("    $v$s = load $M, {$M*} $v_p5, align $A, !alias.scope !2$s\n",
-                    v, vt == VarType::Bool ? "_0" : "", v, v, v, v, nontemporal);
+                fmt("    $v$s = load $M, ptr $v_p3, align $A, !alias.scope !2$s\n",
+                    v, vt == VarType::Bool ? "_0" : "", v, v, v, nontemporal);
                 if (vt == VarType::Bool)
                     fmt("    $v = trunc $M $v_0 to $T\n", v, v, v, v);
             } else {
                 // Load a scalar value and broadcast it
-                fmt("    $v_0 = load $m, {$m*} $v_p3, align $a, !alias.scope !2\n",
-                    v, v, v, v, v);
+                fmt("    $v_0 = load $m, ptr $v_p2, align $a, !alias.scope !2\n",
+                    v, v, v, v);
 
                 if (vt == VarType::Bool)
                     fmt("    $v_1 = trunc i8 $v_0 to i1\n", v, v);
@@ -202,8 +187,8 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
                     fmt("    $v_e = zext $V to $M\n", v, v, v);
                     ext = "_e";
                 }
-                fmt("    store $M $v$s, {$M*} $v_p5, align $A, !noalias !2, !nontemporal !3\n",
-                    v, v, ext, v, v, v);
+                fmt("    store $M $v$s, ptr $v_p3, align $A, !noalias !2, !nontemporal !3\n",
+                    v, v, ext, v, v);
             } else {
                 jitc_llvm_render_array_memcpy_out(v);
             }
@@ -227,7 +212,7 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
                suffix_target = (char *) strchr(buffer.get(), ':') - buffer.get() + 2;
 
         if (indirect_callable_count > 0)
-            fmt("    %callables = load {i8**}, {i8***} @callables, align 8\n");
+            fmt("    %callables = load ptr, ptr @callables, align 8\n");
 
         if (alloca_size >= 0)
             fmt("    %buffer = alloca i8, i32 $u, align $u\n",
@@ -253,7 +238,7 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
         "!3 = !{i32 1}\n"
         "!4 = !{!\"llvm.loop.unroll.disable\", !\"llvm.loop.vectorize.enable\", i1 0}\n\n");
 
-    fmt("attributes #0 = ${ norecurse nounwind \"frame-pointer\"=\"none\" "
+    fmt("attributes #0 = { norecurse nounwind \"frame-pointer\"=\"none\" "
         "\"no-builtins\" \"no-stack-arg-probe\" \"target-cpu\"=\"$s\"", jitc_llvm_target_cpu);
 
     const char *target_features = jitc_llvm_target_features;
@@ -310,16 +295,16 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
     if (call->use_thread_id)
         put(", i32 %thread_id");
 
-    fmt(", {i8*} noalias %params");
+    fmt(", ptr noalias %params");
 
     if (!call->data_map.empty()) {
         if (callable_depth == 1)
-            fmt(", {i8*} noalias %data, <$w x i32> %offsets");
+            fmt(", ptr noalias %data, <$w x i32> %offsets");
         else
-            fmt(", <$w x {i8*}> %data, <$w x i32> %offsets");
+            fmt(", <$w x ptr> %data, <$w x i32> %offsets");
     }
 
-    fmt(") #0 ${\n"
+    fmt(") #0 {\n"
         "entry:\n"
         "    ; Call: $s\n", call->name.c_str());
 
@@ -356,41 +341,37 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
                     "between the recording step and code generation (which is "
                     "happening now). This is not allowed.", sv.index);
 
-            fmt_intrinsic("declare $M @llvm.masked.gather.v$w$h(<$w x {$m*}>, i32, <$w x i1>, $M)",
-                          v, v, v, v);
+            fmt_intrinsic("declare $M @llvm.masked.gather.v$w$h(<$w x ptr>, i32, <$w x i1>, $M)",
+                          v, v, v);
 
             uint32_t offset = it->second - call->data_offset[inst];
             bool is_pointer_or_bool =
                 (vt == VarType::Pointer) || (vt == VarType::Bool);
             // Expand $<..$> only when we are compiling a recursive function call
             callable_depth--;
-            fmt( "    $v_p1 = getelementptr inbounds i8, $<{i8*}$> %data, i32 $u\n"
-                 "    $v_p2 = getelementptr inbounds i8, $<{i8*}$> $v_p1, <$w x i32> %offsets\n"
-                "{    $v_p3 = bitcast <$w x i8*> $v_p2 to <$w x $m*>\n|}"
-                 "    $v$s = call $M @llvm.masked.gather.v$w$h(<$w x {$m*}> $v_p{3|2}, i32 $a, <$w x i1> %mask, $M $z)\n",
+            fmt("    $v_p1 = getelementptr inbounds i8, $<ptr$> %data, i32 $u\n"
+                "    $v_p2 = getelementptr inbounds i8, $<ptr$> $v_p1, <$w x i32> %offsets\n"
+                "    $v$s = call $M @llvm.masked.gather.v$w$h(<$w x ptr> $v_p2, i32 $a, <$w x i1> %mask, $M $z)\n",
                 v, offset,
                 v, v,
-                v, v, v,
-                v, is_pointer_or_bool ? "_p4" : "", v, v, v, v, v, v);
+                v, is_pointer_or_bool ? "_p3" : "", v, v, v, v, v);
             callable_depth++;
 
             if (vt == VarType::Pointer)
-                fmt("    $v = inttoptr <$w x i64> $v_p4 to <$w x {i8*}>\n",
+                fmt("    $v = inttoptr <$w x i64> $v_p3 to <$w x ptr>\n",
                     v, v);
             else if (vt == VarType::Bool)
-                fmt("    $v = trunc <$w x i8> $v_p4 to <$w x i1>\n",
+                fmt("    $v = trunc <$w x i8> $v_p3 to <$w x i1>\n",
                     v, v);
             continue;
         }
 
         switch (kind) {
             case VarKind::CallInput:
-                fmt( "    $v_i{0|1} = getelementptr inbounds i8, {i8*} %params, i64 $u\n"
-                    "{    $v_i1 = bitcast i8* $v_i0 to $M*\n|}"
-                     "    $v$s = load $M, {$M*} $v_i1, align $A\n",
+                fmt("    $v_i1 = getelementptr inbounds i8, ptr %params, i64 $u\n"
+                    "    $v$s = load $M, ptr $v_i1, align $A\n",
                     v, jitc_var(v->dep[0])->param_offset * width,
-                    v, v, v,
-                    v, vt == VarType::Bool ? "_i2" : "", v, v, v, v);
+                    v, vt == VarType::Bool ? "_i2" : "", v, v, v);
 
                 if (vt == VarType::Bool)
                     fmt("    $v = trunc $M $v_i2 to $T\n",
@@ -418,12 +399,10 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
         uint32_t vti = v->type;
         const VarType vt = (VarType) vti;
 
-        fmt( "    %out_$u_{0|1} = getelementptr inbounds i8, {i8*} %params, i64 $u\n"
-            "{    %out_$u_1 = bitcast i8* %out_$u_0 to $M*\n|}"
-             "    %out_$u_2 = load $M, {$M*} %out_$u_1, align $A\n",
+        fmt("    %out_$u_1 = getelementptr inbounds i8, ptr %params, i64 $u\n"
+            "    %out_$u_2 = load $M, ptr %out_$u_1, align $A\n",
             i, offset * width,
-            i, i, v,
-            i, v, v, i, v);
+            i, v, i, v);
 
         if (vt == VarType::Bool)
             fmt("    %out_$u_zext = zext $V to $M\n"
@@ -434,8 +413,8 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
             fmt("    %out_$u_3 = select <$w x i1> %mask, $V, $T %out_$u_2\n",
                 i, v, v, i);
 
-        fmt("    store $M %out_$u_3, {$M*} %out_$u_1, align $A\n",
-            v, i, v, i, v);
+        fmt("    store $M %out_$u_3, ptr %out_$u_1, align $A\n",
+            v, i, i, v);
     }
 
     /* The function requires extra memory or uses callables. Insert
@@ -446,7 +425,7 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
                    (char *) strrchr(buffer.get(), '{') - buffer.get() + 9;
 
         if (callables_local != indirect_callable_count)
-            fmt("    %callables = load {i8**}, {i8***} @callables, align 8\n");
+            fmt("    %callables = load ptr, ptr @callables, align 8\n");
 
         if (alloca_size >= 0)
             fmt("    %buffer = alloca i8, i32 $u, align $u\n",
@@ -686,39 +665,25 @@ static void jitc_llvm_render(Variable *v) {
             break;
 
         case VarKind::Min:
-            if (jitc_llvm_version_major >= 12 || jitc_is_float(v)) {
-                if (jitc_is_float(v))
-                    stmt = "minnum";
-                else if (jitc_is_uint(v))
-                    stmt = "umin";
-                else
-                    stmt = "smin";
-                fmt_intrinsic("declare $T @llvm.$s.v$w$h($T, $T)", v, stmt, v, a0, a1);
-                fmt("    $v = call $T @llvm.$s.v$w$h($V, $V)\n", v, v, stmt, v, a0, a1);
-            } else {
-                fmt("    $v_0 = icmp $s $V, $v\n"
-                    "    $v = select <$w x i1> $v_0, $V, $V\n",
-                    v, jitc_is_uint(v) ? "ult" : "slt", a0, a1,
-                    v, v, a0, a1);
-            }
+            if (jitc_is_float(v))
+                stmt = "minnum";
+            else if (jitc_is_uint(v))
+                stmt = "umin";
+            else
+                stmt = "smin";
+            fmt_intrinsic("declare $T @llvm.$s.v$w$h($T, $T)", v, stmt, v, a0, a1);
+            fmt("    $v = call $T @llvm.$s.v$w$h($V, $V)\n", v, v, stmt, v, a0, a1);
             break;
 
         case VarKind::Max:
-            if (jitc_llvm_version_major >= 12 || jitc_is_float(v)) {
-                if (jitc_is_float(v))
-                    stmt = "maxnum";
-                else if (jitc_is_uint(v))
-                    stmt = "umax";
-                else
-                    stmt = "smax";
-                fmt_intrinsic("declare $T @llvm.$s.v$w$h($T, $T)", v, stmt, v, a0, a1);
-                fmt("    $v = call $T @llvm.$s.v$w$h($V, $V)\n", v, v, stmt, v, a0, a1);
-            } else {
-                fmt("    $v_0 = icmp $s $V, $v\n"
-                    "    $v = select <$w x i1> $v_0, $V, $V\n",
-                    v, jitc_is_uint(v) ? "ugt" : "sgt", a0, a1,
-                    v, v, a0, a1);
-            }
+            if (jitc_is_float(v))
+                stmt = "maxnum";
+            else if (jitc_is_uint(v))
+                stmt = "umax";
+            else
+                stmt = "smax";
+            fmt_intrinsic("declare $T @llvm.$s.v$w$h($T, $T)", v, stmt, v, a0, a1);
+            fmt("    $v = call $T @llvm.$s.v$w$h($V, $V)\n", v, v, stmt, v, a0, a1);
             break;
 
         case VarKind::Ceil:
@@ -923,15 +888,13 @@ static void jitc_llvm_render(Variable *v) {
                     v->type = (uint32_t) VarType::UInt8;
 
                 fmt_intrinsic(
-                    "declare $T @llvm.masked.gather.v$w$h($P, i32, $T, $T)",
-                    v, v, v, a2, v);
+                    "declare $T @llvm.masked.gather.v$w$h(<$w x ptr>, i32, $T, $T)",
+                    v, v, a2, v);
 
-                fmt("{    $v_0 = bitcast $<i8*$> $v to $<$t*$>\n|}"
-                     "    $v_1 = getelementptr inbounds $t, $<$p$> {$v_0|$v}, $V\n"
-                     "    $v$s = call $T @llvm.masked.gather.v$w$h($P $v_1, i32 $a, $V, $T $z)\n",
-                     v, a0, v,
-                     v, v, v, v, a0, a1,
-                     v, is_bool ? "_2" : "", v, v, v, v, v, a2, v);
+                fmt("    $v_1 = getelementptr inbounds $t, $<ptr$> $v, $V\n"
+                     "    $v$s = call $T @llvm.masked.gather.v$w$h(<$w x ptr> $v_1, i32 $a, $V, $T $z)\n",
+                     v, v, a0, a1,
+                     v, is_bool ? "_2" : "", v, v, v, v, a2, v);
 
                 if (is_bool) { // Restore
                     v->type = (uint32_t) VarType::Bool;
@@ -972,14 +935,14 @@ static void jitc_llvm_render(Variable *v) {
             break;
 
         case VarKind::BoundsCheck:
-            fmt_intrinsic("declare i1 @llvm$e.vector.reduce.or.v$wi1(<$w x i1>)");
-            fmt_intrinsic("declare void @llvm.masked.scatter.v$wi32(<$w x i32>, <$w x {i32*}>, i32, <$w x i1>)");
+            fmt_intrinsic("declare i1 @llvm.vector.reduce.or.v$wi1(<$w x i1>)");
+            fmt_intrinsic("declare void @llvm.masked.scatter.v$wi32(<$w x i32>, <$w x ptr>, i32, <$w x i1>)");
 
             fmt("    $v_0 = insertelement <$w x i32> undef, i32 $u, i32 0\n"
                 "    $v_1 = shufflevector <$w x i32> $v_0, <$w x i32> undef, <$w x i32> $z\n"
                 "    $v_2 = icmp uge $V, $v_1\n"
                 "    $v_3 = and $V, $v_2\n"
-                "    $v_4 = call i1 @llvm$e.vector.reduce.or.v$wi1(<$w x i1> $v_3)\n"
+                "    $v_4 = call i1 @llvm.vector.reduce.or.v$wi1(<$w x i1> $v_3)\n"
                 "    br i1 $v_4, label %l_$u_err, label %l_$u_cont\n\n"
                 "l_$u_err:\n",
                 v, (uint32_t) v->literal,
@@ -991,14 +954,12 @@ static void jitc_llvm_render(Variable *v) {
                 v->reg_index);
 
             if (callable_depth == 0)
-                fmt("{    $v_5 = bitcast i8* $v to i32 *\n|}"
-                     "    $v_6 = getelementptr inbounds i32, {i32*} {$v_5|$v}, <$w x i32> $z\n"
-                     "    call void @llvm.masked.scatter.v$wi32($V, <$w x {i32*}> $v_6, i32 4, <$w x i1> $v_3)\n",
+                fmt("    $v_5 = getelementptr inbounds i32, ptr $v, <$w x i32> $z\n"
+                     "    call void @llvm.masked.scatter.v$wi32($V, <$w x ptr> $v_5, i32 4, <$w x i1> $v_3)\n",
                      v, a2,
-                     v, v, a2,
                      a0, v, v);
             else
-                fmt("    call void @llvm.masked.scatter.v$wi32($V, <$w x {i32*}> $v, i32 4, <$w x i1> $v_3)\n",
+                fmt("    call void @llvm.masked.scatter.v$wi32($V, <$w x ptr> $v, i32 4, <$w x i1> $v_3)\n",
                     a0, a2, v);
 
             fmt("    br label %l_$u_cont\n\n"
@@ -1083,8 +1044,8 @@ static void jitc_llvm_render(Variable *v) {
             break;
 
         case VarKind::LoopCond:
-            fmt_intrinsic("declare i1 @llvm$e.vector.reduce.or.v$wi1($T)", a1);
-            fmt("    $v_red = call i1 @llvm$e.vector.reduce.or.v$wi1($V)\n"
+            fmt_intrinsic("declare i1 @llvm.vector.reduce.or.v$wi1($T)", a1);
+            fmt("    $v_red = call i1 @llvm.vector.reduce.or.v$wi1($V)\n"
                 "    br i1 $v_red, label %l_$u_body, label %l_$u_done\n\n"
                 "l_$u_body:\n",
                 a1, a1,
@@ -1128,14 +1089,14 @@ static void jitc_llvm_render(Variable *v) {
 
         case VarKind::CondStart: {
                 const CondData *cd = (CondData *) v->data;
-                fmt_intrinsic("declare i1 @llvm$e.vector.reduce.or.v$wi1($T)", a0);
+                fmt_intrinsic("declare i1 @llvm.vector.reduce.or.v$wi1($T)", a0);
                 fmt("    br label %l_$u_start\n\n"
                     "l_$u_start:\n",
                     v->reg_index,
                     v->reg_index);
                 if (cd->name != "unnamed")
                     fmt("    ; Symbolic conditional: $s\n", cd->name.c_str());
-                fmt("    $v_t = call i1 @llvm$e.vector.reduce.or.v$wi1($V)\n"
+                fmt("    $v_t = call i1 @llvm.vector.reduce.or.v$wi1($V)\n"
                     "    br i1 $v_t, label %l_$u_t, label %l_$u_next\n\n"
                     "l_$u_t:\n",
                     v, a0,
@@ -1164,7 +1125,7 @@ static void jitc_llvm_render(Variable *v) {
                         a0, (uint32_t) i, vt, vt, loop_reg, loop_reg);
                 }
 
-                fmt("    $v_f = call i1 @llvm$e.vector.reduce.or.v$wi1($V)\n"
+                fmt("    $v_f = call i1 @llvm.vector.reduce.or.v$wi1($V)\n"
                     "    br i1 $v_f, label %l_$u_f, label %l_$u_end\n\n"
                     "l_$u_f:\n",
                     a0, jitc_var(a0->dep[1]),
@@ -1370,43 +1331,38 @@ static void jitc_llvm_render_trace(const Variable *v,
             continue; // valid flag not needed for 1-lane versions
 
         const Variable *v2 = jitc_var(indices[i + 1]);
-        fmt( "    $v_in_$u_{0|1} = getelementptr inbounds i8, {i8*} %buffer, i32 $u\n"
-            "{    $v_in_$u_1 = bitcast i8* $v_in_$u_0 to $T*\n|}"
-             "    store $V, {$T*} $v_in_$u_1, align $A\n",
-             v, i, offset,
-             v, i, v, i, v2,
-             v2, v2, v, i, v2);
+        fmt("    $v_in_$u_1 = getelementptr inbounds i8, ptr %buffer, i32 $u\n"
+            "    store $V, ptr $v_in_$u_1, align $A\n",
+            v, i, offset,
+            v2, v, i, v2);
 
         offset += type_size[v2->type] * width;
     }
 
     // Reset geomID field to ones as required
     if (!shadow_ray) {
-        fmt( "    $v_in_geomid_{0|1} = getelementptr inbounds i8, {i8*} %buffer, i32 $u\n"
-            "{    $v_in_geomid_1 = bitcast i8* $v_in_geomid_0 to <$w x i32> *\n|}"
-             "    store <$w x i32> $s, {<$w x i32>*} $v_in_geomid_1, align $u\n",
+        fmt("    $v_in_geomid_1 = getelementptr inbounds i8, ptr %buffer, i32 $u\n"
+            "    store <$w x i32> $s, ptr $v_in_geomid_1, align $u\n",
             v, (14 * float_size + 5 * 4) * width,
-            v, v,
             jitc_llvm_ones_bit_str[(int) VarType::Int32], v, float_size * width);
     }
 
     // Determine whether to mark the rays as coherent or incoherent
     const Variable *coherent = jitc_var(indices[0]);
 
-    fmt( "    $v_in_ctx_{0|1} = getelementptr inbounds i8, {i8*} %buffer, i32 $u\n"
-        "{    $v_in_ctx_1 = bitcast i8* $v_in_ctx_0 to <6 x i32>*\n|}",
-        v, alloca_size_rt, v, v);
+    fmt("    $v_in_ctx_1 = getelementptr inbounds i8, ptr %buffer, i32 $u\n",
+        v, alloca_size_rt);
 
     if (coherent->is_literal()) {
-        fmt("    store <6 x i32> <i32 $u, i32 0, i32 0, i32 0, i32 -1, i32 0>, {<6 x i32>*} $v_in_ctx_1, align 4\n",
+        fmt("    store <6 x i32> <i32 $u, i32 0, i32 0, i32 0, i32 -1, i32 0>, ptr $v_in_ctx_1, align 4\n",
             (uint32_t) coherent->literal, v);
     } else {
-        fmt_intrinsic("declare i1 @llvm$e.vector.reduce.and.v$wi1(<$w x i1>)");
+        fmt_intrinsic("declare i1 @llvm.vector.reduce.and.v$wi1(<$w x i1>)");
 
-        fmt("    $v_coherent_0 = call i1 @llvm$e.vector.reduce.and.v$wi1($V)\n"
+        fmt("    $v_coherent_0 = call i1 @llvm.vector.reduce.and.v$wi1($V)\n"
             "    $v_coherent_1 = zext i1 $v_coherent_0 to i32\n"
             "    $v_ctx = insertelement <6 x i32> <i32 0, i32 0, i32 0, i32 0, i32 -1, i32 0>, i32 $v_coherent_1, i32 0\n"
-            "    store <6 x i32> $v_ctx, {<6 x i32>*} $v_in_ctx_1, align 4\n",
+            "    store <6 x i32> $v_ctx, ptr $v_in_ctx_1, align 4\n",
             v, coherent, v, v, v, v, v, v);
     }
 
@@ -1416,21 +1372,14 @@ static void jitc_llvm_render_trace(const Variable *v,
        which is implemented by the following loop. */
     if (callable_depth == 0) {
         if (jitc_llvm_vector_width > 1) {
-            fmt("{    $v_func = bitcast i8* $v to void (i8*, i8*, i8*, i8*)*\n|}"
-                 "    call void {$v_func|$v}({i8*} $v_in_0_{0|1}, {i8*} $v, {i8*} $v_in_ctx_{0|1}, {i8*} $v_in_1_{0|1})\n",
-                v, func,
-                v, func, v, scene, v, v
+            fmt("    call void $v(ptr $v_in_0_1, ptr $v, ptr $v_in_ctx_1, ptr $v_in_1_1)\n", func, v, scene, v, v
             );
         } else {
-            fmt(
-                "{    $v_func = bitcast i8* $v to void (i8*, i8*, i8*)*\n|}"
-                "     call void {$v_func|$v}({i8*} $v, {i8*} $v_in_ctx_{0|1}, {i8*} $v_in_1_{0|1})\n",
-                v, func,
-                v, func, scene, v, v
+            fmt("     call void $v(ptr $v, ptr $v_in_ctx_1, ptr $v_in_1_1)\n", func, scene, v, v
             );
         }
     } else {
-        fmt_intrinsic("declare i64 @llvm$e.vector.reduce.umax.v$wi64(<$w x i64>)");
+        fmt_intrinsic("declare i64 @llvm.vector.reduce.umax.v$wi64(<$w x i64>)");
 
         // =====================================================
         // 1. Prepare the loop for the ray tracing calls
@@ -1439,27 +1388,25 @@ static void jitc_llvm_render_trace(const Variable *v,
         uint32_t offset_tfar = (8 * float_size + 4) * width;
         const char *tname_tfar = type_name_llvm[(int) float_type];
 
-        fmt( "    br label %l$u_start\n"
-             "\nl$u_start:\n"
-             "    ; Ray tracing\n"
-             "    $v_func_i64 = call i64 @llvm$e.vector.reduce.umax.v$wi64(<$w x i64> %rd$u_p4)\n"
-             "    $v_func_ptr = inttoptr i64 $v_func_i64 to {i8*}\n"
-             "    $v_tfar_{0|1} = getelementptr inbounds i8, {i8*} %buffer, i32 $u\n"
-            "{    $v_tfar_1 = bitcast i8* $v_tfar_0 to <$w x $s> *\n|}",
+        fmt("    br label %l$u_start\n"
+            "\nl$u_start:\n"
+            "    ; Ray tracing\n"
+            "    $v_func_i64 = call i64 @llvm.vector.reduce.umax.v$wi64(<$w x i64> %rd$u_p3)\n"
+            "    $v_func_ptr = inttoptr i64 $v_func_i64 to ptr\n"
+            "    $v_tfar_1 = getelementptr inbounds i8, ptr %buffer, i32 $u\n",
             v->reg_index,
             v->reg_index,
             v, func->reg_index,
             v, v,
-            v, offset_tfar,
-            v, v, tname_tfar);
+            v, offset_tfar);
 
         if (jitc_llvm_vector_width > 1)
-            fmt("    $v_func = bitcast {i8*} $v_func_ptr to {void (i8*, i8*, i8*, i8*)*}\n", v, v);
+            fmt("    $v_func = bitcast ptr $v_func_ptr to ptr\n", v, v);
         else
-            fmt("    $v_func = bitcast {i8*} $v_func_ptr to {void (i8*, i8*, i8*)*}\n", v, v);
+            fmt("    $v_func = bitcast ptr $v_func_ptr to ptr\n", v, v);
 
         // Get original mask, to be overwritten at every iteration
-        fmt("    $v_mask_value = load <$w x i32>, {<$w x i32>*} $v_in_0_1, align 64\n"
+        fmt("    $v_mask_value = load <$w x i32>, ptr $v_in_0_1, align 64\n"
             "    br label %l$u_check\n",
             v, v, v->reg_index);
 
@@ -1468,11 +1415,11 @@ static void jitc_llvm_render_trace(const Variable *v,
         // =====================================================
 
         fmt("\nl$u_check:\n"
-            "    $v_scene = phi <$w x {i8*}> [ %rd$u, %l$u_start ], [ $v_scene_next, %l$u_call ]\n"
-            "    $v_scene_i64 = ptrtoint <$w x {i8*}> $v_scene to <$w x i64>\n"
-            "    $v_next_i64 = call i64 @llvm$e.vector.reduce.umax.v$wi64(<$w x i64> $v_scene_i64)\n"
-            "    $v_next = inttoptr i64 $v_next_i64 to {i8*}\n"
-            "    $v_valid = icmp ne {i8*} $v_next, null\n"
+            "    $v_scene = phi <$w x ptr> [ %rd$u, %l$u_start ], [ $v_scene_next, %l$u_call ]\n"
+            "    $v_scene_i64 = ptrtoint <$w x ptr> $v_scene to <$w x i64>\n"
+            "    $v_next_i64 = call i64 @llvm.vector.reduce.umax.v$wi64(<$w x i64> $v_scene_i64)\n"
+            "    $v_next = inttoptr i64 $v_next_i64 to ptr\n"
+            "    $v_valid = icmp ne ptr $v_next, null\n"
             "    br i1 $v_valid, label %l$u_call, label %l$u_end\n",
             v->reg_index,
             v, scene->reg_index, v->reg_index, v, v->reg_index,
@@ -1487,15 +1434,15 @@ static void jitc_llvm_render_trace(const Variable *v,
         // =====================================================
 
         fmt("\nl$u_call:\n"
-            "    $v_tfar_prev = load <$w x $s>, {<$w x $s>*} $v_tfar_1, align $u\n"
+            "    $v_tfar_prev = load <$w x $s>, ptr $v_tfar_1, align $u\n"
             "    $v_bcast_0 = insertelement <$w x i64> undef, i64 $v_next_i64, i32 0\n"
             "    $v_bcast_1 = shufflevector <$w x i64> $v_bcast_0, <$w x i64> undef, <$w x i32> $z\n"
-            "    $v_bcast_2 = inttoptr <$w x i64> $v_bcast_1 to <$w x {i8*}>\n"
-            "    $v_active = icmp eq <$w x {i8*}> $v_scene, $v_bcast_2\n"
+            "    $v_bcast_2 = inttoptr <$w x i64> $v_bcast_1 to <$w x ptr>\n"
+            "    $v_active = icmp eq <$w x ptr> $v_scene, $v_bcast_2\n"
             "    $v_active_2 = select <$w x i1> $v_active, <$w x i32> $v_mask_value, <$w x i32> $z\n"
-            "    store <$w x i32> $v_active_2, {<$w x i32>*} $v_in_0_1, align 64\n",
+            "    store <$w x i32> $v_active_2, ptr $v_in_0_1, align 64\n",
             v->reg_index,
-            v, tname_tfar, tname_tfar, v, float_size * width,
+            v, tname_tfar, v, float_size * width,
             v, v,
             v, v,
             v, v,
@@ -1504,21 +1451,21 @@ static void jitc_llvm_render_trace(const Variable *v,
             v, v);
 
         if (jitc_llvm_vector_width > 1)
-            fmt("    call void $v_func({i8*} $v_in_0_{0|1}, {i8*} $v_next, {i8*} $v_in_ctx_{0|1}, {i8*} $v_in_1_{0|1})\n",
+            fmt("    call void $v_func(ptr $v_in_0_1, ptr $v_next, ptr $v_in_ctx_1, ptr $v_in_1_1)\n",
                 v, v, v, v, v);
         else
-            fmt("    call void $v_func({i8*} $v_next, {i8*} $v_in_ctx_{0|1}, {i8*} $v_in_1_{0|1})\n",
+            fmt("    call void $v_func(ptr $v_next, ptr $v_in_ctx_1, ptr $v_in_1_1)\n",
                 v, v, v, v);
 
-        fmt("    $v_tfar_new = load <$w x $s>, {<$w x $s>*} $v_tfar_1, align $u\n"
+        fmt("    $v_tfar_new = load <$w x $s>, ptr $v_tfar_1, align $u\n"
             "    $v_tfar_masked = select <$w x i1> $v_active, <$w x $s> $v_tfar_new, <$w x $s> $v_tfar_prev\n"
-            "    store <$w x $s> $v_tfar_masked, {<$w x $s>*} $v_tfar_1, align $u\n"
-            "    $v_scene_next = select <$w x i1> $v_active, <$w x {i8*}> $z, <$w x {i8*}> $v_scene\n"
+            "    store <$w x $s> $v_tfar_masked, ptr $v_tfar_1, align $u\n"
+            "    $v_scene_next = select <$w x i1> $v_active, <$w x ptr> $z, <$w x ptr> $v_scene\n"
             "    br label %l$u_check\n"
             "\nl$u_end:\n",
-            v, tname_tfar, tname_tfar, v, float_size * width,
+            v, tname_tfar, v, float_size * width,
             v, v, tname_tfar, v, tname_tfar, v,
-            tname_tfar, v, tname_tfar, v, float_size * width,
+            tname_tfar, v, v, float_size * width,
             v, v, v,
             v->reg_index, v->reg_index);
     }
@@ -1530,12 +1477,10 @@ static void jitc_llvm_render_trace(const Variable *v,
         const char *tname = type_name_llvm[(int) vt];
         uint32_t tsize = type_size[(int) vt];
 
-        fmt( "    $v_out_$u_{0|1} = getelementptr inbounds i8, {i8*} %buffer, i32 $u\n"
-            "{    $v_out_$u_1 = bitcast i8* $v_out_$u_0 to <$w x $s> *\n|}"
-             "    $v_out_$u = load <$w x $s>, {<$w x $s>*} $v_out_$u_1, align $u\n",
+        fmt("    $v_out_$u_1 = getelementptr inbounds i8, ptr %buffer, i32 $u\n"
+            "    $v_out_$u = load <$w x $s>, ptr $v_out_$u_1, align $u\n",
             v, i, offset,
-            v, i, v, i, tname,
-            v, i, tname, tname, v, i, float_size * width);
+            v, i, tname, v, i, float_size * width);
 
         if (i == 0)
             offset += (4 * float_size + 3 * 4) * width;
@@ -1561,17 +1506,17 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
     // =====================================================
 
     if (call->n_inst != 1) {
-        fmt_intrinsic("@callables = dso_local local_unnamed_addr global {i8**} null, align 8");
+        fmt_intrinsic("@callables = dso_local local_unnamed_addr global ptr null, align 8");
 
         /* How to prevent @callables from being optimized away as a constant, while
            at the same time not turning it an external variable that would require a
            global offset table (GOT)? Let's make a dummy function that writes to it.. */
-        fmt_intrinsic("define void @set_callables({i8**} %ptr) local_unnamed_addr #0 ${\n"
-                      "    store {i8**} %ptr, {i8***} @callables\n"
+        fmt_intrinsic("define void @set_callables(ptr %ptr) local_unnamed_addr #0 {\n"
+                      "    store ptr %ptr, ptr @callables\n"
                       "    ret void\n"
-                      "$}");
+                      "}");
 
-        fmt_intrinsic("declare i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32>)");
+        fmt_intrinsic("declare i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32>)");
     }
 
     fmt("\n    ; Call: $s\n", call->name.c_str());
@@ -1584,13 +1529,11 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
 
     if (call->n_inst != 1 || data_reg) {
         fmt_intrinsic("declare <$w x i64> @llvm.masked.gather.v$wi64(<$w x "
-                      "{i64*}>, i32, <$w x i1>, <$w x i64>)");
+                      "ptr>, i32, <$w x i1>, <$w x i64>)");
 
-        fmt("{    %u$u_self_ptr_0 = bitcast $<i8*$> %rd$u to $<i64*$>\n|}"
-             "    %u$u_self_ptr = getelementptr i64, $<{i64*}$> {%u$u_self_ptr_0|%rd$u}, <$w x i32> %r$u\n"
-             "    %u$u_self_combined = call <$w x i64> @llvm.masked.gather.v$wi64(<$w x {i64*}> %u$u_self_ptr, i32 8, <$w x i1> %p$u, <$w x i64> $z)\n",
-            call_reg, offset_reg,
-            call_reg, call_reg, offset_reg, self_reg,
+        fmt("    %u$u_self_ptr = getelementptr i64, $<ptr$> %rd$u, <$w x i32> %r$u\n"
+             "    %u$u_self_combined = call <$w x i64> @llvm.masked.gather.v$wi64(<$w x ptr> %u$u_self_ptr, i32 8, <$w x i1> %p$u, <$w x i64> $z)\n",
+            call_reg, offset_reg, self_reg,
             call_reg, call_reg, mask_reg);
     }
 
@@ -1625,20 +1568,17 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
         if (unused)
             continue;
 
-        fmt( "    %u$u_in_$u_{0|1} = getelementptr inbounds i8, {i8*} %buffer, i32 $u\n"
-            "{    %u$u_in_$u_1 = bitcast i8* %u$u_in_$u_0 to $M*\n|}",
-            call_reg, i, v->param_offset * width,
-            call_reg, i, call_reg, i, v
-        );
+        fmt("    %u$u_in_$u_1 = getelementptr inbounds i8, ptr %buffer, i32 $u\n",
+            call_reg, i, v->param_offset * width);
 
         if ((VarType) v->type != VarType::Bool) {
-            fmt("    store $V, {$T*} %u$u_in_$u_1, align $A\n",
-                v, v, call_reg, i, v);
+            fmt("    store $V, ptr %u$u_in_$u_1, align $A\n",
+                v, call_reg, i, v);
         } else {
             fmt("    %u$u_$u_zext = zext $V to $M\n"
-                "    store $M %u$u_$u_zext, {$M*} %u$u_in_$u_1, align $A\n",
+                "    store $M %u$u_$u_zext, ptr %u$u_in_$u_1, align $A\n",
                 call_reg, i, v, v,
-                v, call_reg, i, v, call_reg, i, v);
+                v, call_reg, i, call_reg, i, v);
         }
     }
 
@@ -1649,12 +1589,10 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
 
         const Variable *v = jitc_var(call->inner_out[i]);
 
-        fmt( "    %u$u_tmp_$u_{0|1} = getelementptr inbounds i8, {i8*} %buffer, i64 $u\n"
-            "{    %u$u_tmp_$u_1 = bitcast i8* %u$u_tmp_$u_0 to $M*\n|}"
-             "    store $M $z, {$M*} %u$u_tmp_$u_1, align $A\n",
+        fmt("    %u$u_tmp_$u_1 = getelementptr inbounds i8, ptr %buffer, i64 $u\n"
+            "    store $M $z, ptr %u$u_tmp_$u_1, align $A\n",
             call_reg, i, offset * width,
-            call_reg, i, call_reg, i, v,
-            v, v, call_reg, i, v);
+            v, call_reg, i, v);
     }
 
     // =====================================================
@@ -1678,10 +1616,10 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
         if (call->use_thread_id)
             fmt(", i32 %thread_id");
 
-        fmt(", {i8*} %buffer");
+        fmt(", ptr %buffer");
 
         if (data_reg)
-            fmt(", $<{i8*}$> %rd$u, <$w x i32> %u$u_offset", data_reg, call_reg);
+            fmt(", $<ptr$> %rd$u, <$w x i32> %u$u_offset", data_reg, call_reg);
 
         fmt(")\n");
     } else {
@@ -1692,7 +1630,7 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
         call_reg,
         call_reg, call_reg, call_reg, call_reg, call_reg);
 
-    fmt("    %u$u_next = call i32 @llvm$e.vector.reduce.umax.v$wi32(<$w x i32> %u$u_self)\n"
+    fmt("    %u$u_next = call i32 @llvm.vector.reduce.umax.v$wi32(<$w x i32> %u$u_self)\n"
         "    %u$u_valid = icmp ne i32 %u$u_next, 0\n"
         "    br i1 %u$u_valid, label %l$u_call, label %l$u_end\n",
         call_reg, call_reg,
@@ -1703,8 +1641,8 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
         "    %u$u_bcast_0 = insertelement <$w x i32> undef, i32 %u$u_next, i32 0\n"
         "    %u$u_bcast = shufflevector <$w x i32> %u$u_bcast_0, <$w x i32> undef, <$w x i32> $z\n"
         "    %u$u_active = icmp eq <$w x i32> %u$u_self, %u$u_bcast\n"
-        "    %u$u_func_0 = getelementptr inbounds {i8*}, {i8**} %callables, i32 %u$u_next\n"
-        "    %u$u_func{_1|} = load {i8*}, {i8**} %u$u_func_0\n",
+        "    %u$u_func_0 = getelementptr inbounds ptr, ptr %callables, i32 %u$u_next\n"
+        "    %u$u_func = load ptr, ptr %u$u_func_0\n",
         call_reg,
         call_reg, call_reg, // bcast_0
         call_reg, call_reg, // bcast
@@ -1712,27 +1650,6 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
         call_reg, call_reg, // func_0
         call_reg, call_reg // func_1
     );
-
-    // Cast into correctly typed function pointer
-    if (!jitc_llvm_opaque_pointers) {
-        fmt("    %u$u_func = bitcast i8* %u$u_func_1 to void (<$w x i1>",
-                 call_reg, call_reg);
-
-        if (call->use_self)
-            fmt(", <$w x i32>");
-
-        if (call->use_index)
-            fmt(", i64");
-
-        if (call->use_thread_id)
-            fmt(", i32");
-
-        fmt(", i8*");
-        if (data_reg)
-            fmt(", $<i8*$>, <$w x i32>");
-
-        fmt(")*\n");
-    }
 
     // Perform the actual function call
     fmt("    call fastcc void %u$u_func(<$w x i1> %u$u_active",
@@ -1747,10 +1664,10 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
     if (call->use_thread_id)
         fmt(", i32 %thread_id");
 
-    fmt(", {i8*} %buffer");
+    fmt(", ptr %buffer");
 
     if (data_reg)
-        fmt(", $<{i8*}$> %rd$u, <$w x i32> %u$u_offset", data_reg, call_reg);
+        fmt(", $<ptr$> %rd$u, <$w x i32> %u$u_offset", data_reg, call_reg);
 
     fmt(")\n"
         "    %u$u_self_next = select <$w x i1> %u$u_active, <$w x i32> $z, <$w x i32> %u$u_self\n"
@@ -1771,12 +1688,10 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
 
         bool is_bool = (VarType) v->type == VarType::Bool;
 
-        fmt( "    %u$u_out_$u_{0|1} = getelementptr inbounds i8, {i8*} %buffer, i64 $u\n"
-            "{    %u$u_out_$u_1 = bitcast i8* %u$u_out_$u_0 to $M*\n|}"
-             "    $v$s = load $M, {$M*} %u$u_out_$u_1, align $A\n",
+        fmt("    %u$u_out_$u_1 = getelementptr inbounds i8, ptr %buffer, i64 $u\n"
+            "    $v$s = load $M, ptr %u$u_out_$u_1, align $A\n",
             call_reg, i, call->out_offset[i] * width,
-            call_reg, i, call_reg, i, v,
-            v, is_bool ? "_0" : "", v, v, call_reg, i, v);
+            v, is_bool ? "_0" : "", v, call_reg, i, v);
 
             if (is_bool)
                 fmt("    $v = trunc $M $v_0 to $T\n", v, v, v, v);

--- a/src/llvm_eval.h
+++ b/src/llvm_eval.h
@@ -2,12 +2,14 @@
     buffer.put(__VA_ARGS__)
 
 #define fmt(fmt, ...)                                                          \
-    buffer.fmt_llvm(count_args(__VA_ARGS__), fmt, ##__VA_ARGS__)
+    buffer.fmt_llvm(count_args(__VA_ARGS__), fmt_strlen(fmt), fmt,             \
+                    ##__VA_ARGS__)
 
 #define fmt_intrinsic(fmt, ...)                                                \
     do {                                                                       \
         size_t tmpoff = buffer.size();                                         \
-        buffer.fmt_llvm(count_args(__VA_ARGS__), fmt, ##__VA_ARGS__);          \
+        buffer.fmt_llvm(count_args(__VA_ARGS__), fmt_strlen(fmt), fmt,         \
+                        ##__VA_ARGS__);                                        \
         jitc_register_global(buffer.get() + tmpoff);                           \
         buffer.rewind_to(tmpoff);                                              \
     } while (0)

--- a/src/llvm_packet.cpp
+++ b/src/llvm_packet.cpp
@@ -99,12 +99,10 @@ void gather_packet_recursive(uint32_t l, uint32_t i, uint32_t n, const Variable 
             uint32_t k = i*n+j,
                      align = type_size[v->type]*n;
 
-            fmt( "    %p$u = extractelement <$w x {$m*}> %p, i32 $u\n"
-                "{    %p$u_0 = bitcast $m* %p$u to <$u x $m>*\n|}"
-                 "    %v$u_$u_$u = load <$u x $m>, {<$u x $m>*} %p$u{_0|}, align $u, !alias.scope !2\n",
-                k, v, k,
-                k, v, k, n, v,
-                l, i, j, n, v, n, v, k, align);
+            fmt( "    %p$u = extractelement <$w x ptr> %p, i32 $u\n"
+                 "    %v$u_$u_$u = load <$u x $m>, ptr %p$u, align $u, !alias.scope !2\n",
+                k, k,
+                l, i, j, n, v, k, align);
         }
     } else {
         uint32_t hs = s / 2;
@@ -129,8 +127,8 @@ void jitc_llvm_render_gather_packet(const Variable *v, const Variable *ptr,
 
     fmt_intrinsic("@zero_$m_$u = private constant [$u x $m] $z, align $A", v, n, n, v, v);
 
-    fmt("define internal fastcc [$u x <$w x $m>] @gather_$ux$H(<$w x {$m*}> %p) local_unnamed_addr #0 ${\n",
-        n, v, n, v, v);
+    fmt("define internal fastcc [$u x <$w x $m>] @gather_$ux$H(<$w x ptr> %p) local_unnamed_addr #0 {\n",
+        n, v, n, v);
 
     gather_packet_recursive(0, 0, n, v);
 
@@ -145,7 +143,7 @@ void jitc_llvm_render_gather_packet(const Variable *v, const Variable *ptr,
             i, n, v, i - 1, v, i, i);
 
     fmt("    ret [$u x <$w x $m>] %q$u\n"
-        "$}",
+        "}",
         n, v, n - 1);
 
     jitc_register_global(buffer.get() + offset);
@@ -155,22 +153,18 @@ void jitc_llvm_render_gather_packet(const Variable *v, const Variable *ptr,
     if (v->type == (uint32_t) VarType::Bool)
         ext = "_e";
 
-    fmt("{    $v_0 = bitcast $<i8*$> $v to $<[$u x $m]*$>\n"
-         "    $v_2 = getelementptr [$u x $m], $<{[$u x $m]*}$> {$v_0|$v}, $T $v\n"
-         "    $v_3 = getelementptr [$u x $m], [$u x $m]* @zero_$m_$u, $T $z\n"
-         "    $v_4 = select $V, <$w x {[$u x $m]*}> $v_2, <$w x {[$u x $m]*}> $v_3\n"
-        "{    $v_5 = bitcast <$w x [$u x $m]*> $v_4 to <$w x $m*>\n|}"
-         "    $v_6 = call fastcc [$u x <$w x $m>] @gather_$ux$H(<$w x {$m*}> $v_{5|4})\n",
-        v, ptr, n, v,
-        v, n, v, n, v, v, ptr, index, index,
-        v, n, v, n, v, v, n, index,
-        v, mask, n, v, v, n, v, v,
-        v, n, v, v,  v,
-        v, n, v, n, v, v, v
+    fmt("    $v_2 = getelementptr [$u x $m], $<ptr$> $v, $T $v\n"
+        "    $v_3 = getelementptr [$u x $m], ptr @zero_$m_$u, $T $z\n"
+        "    $v_4 = select $V, <$w x ptr> $v_2, <$w x ptr> $v_3\n"
+        "    $v_5 = call fastcc [$u x <$w x $m>] @gather_$ux$H(<$w x ptr> $v_4)\n",
+        v, n, v, ptr, index, index,
+        v, n, v, v, n, index,
+        v, mask, v, v,
+        v, n, v, n, v, v
     );
 
     for (uint32_t i = 0; i < n; ++i)
-        fmt("    $v_out_$u$s = extractvalue [$u x <$w x $m>] $v_6, $u\n",
+        fmt("    $v_out_$u$s = extractvalue [$u x <$w x $m>] $v_5, $u\n",
             v, i, ext, n, v, v, i);
 
     if (v->type == (uint32_t) VarType::Bool) {
@@ -187,10 +181,8 @@ void scatter_packet_recursive(ReduceOp op, uint32_t l, uint32_t i, uint32_t n, c
         for (uint32_t j = 0; j < n; ++j) {
             uint32_t k = i*n+j, align = type_size[v->type]*n;
 
-            fmt( "    %p$u = extractelement <$w x {$m*}> %p, i32 $u\n"
-                "{    %p$u_0 = bitcast $m* %p$u to <$u x $m>*\n|}",
-                k, v, k,
-                k, v, k, n, v);
+            fmt( "    %p$u = extractelement <$w x ptr> %p, i32 $u\n",
+                k, k);
 
             if (false) {
                 /* Compile via Masked loads/store */
@@ -198,15 +190,15 @@ void scatter_packet_recursive(ReduceOp op, uint32_t l, uint32_t i, uint32_t n, c
                 for (uint32_t m = 0; m < n; ++m)
                     fmt("i32 $u$s", k, m + 1 < n ? ", " : ">\n");
                 if (op == ReduceOp::Identity) {
-                    fmt("    call void @llvm.masked.store.v$u$H.p0{v$u$H|}(<$u x $m> %v$u_$u_$u, {<$u x $m> *} %p$u{_0|}, i32 $u, <$u x i1> %m$u)\n",
-                        n, v, n, v, n, v, l, i, j, n, v, k, align, n, k);
+                    fmt("    call void @llvm.masked.store.v$u$H.p0(<$u x $m> %v$u_$u_$u, ptr %p$u, i32 $u, <$u x i1> %m$u)\n",
+                        n, v, n, v, l, i, j, k, align, n, k);
                 } else if (op == ReduceOp::Add) {
-                    fmt("    %v$u_0 = call <$u x $m> @llvm.masked.load.v$u$H.p0{v$u$H|}({<$u x $m> *} %p$u{_0|}, i32 $u, <$u x i1> %m$u, <$u x $m> undef)\n"
+                    fmt("    %v$u_0 = call <$u x $m> @llvm.masked.load.v$u$H.p0(ptr %p$u, i32 $u, <$u x i1> %m$u, <$u x $m> undef)\n"
                         "    %v$u_1 = $s <$u x $m> %v$u_0, %v$u_$u_$u\n"
-                        "    call void @llvm.masked.store.v$u$H.p0{v$u$H|}(<$u x $m> %v$u_1, {<$u x $m> *} %p$u{_0|}, i32 $u, <$u x i1> %m$u)\n",
-                        k, n, v, n, v, n, v, n, v, k, align, n, k, n, v,
+                        "    call void @llvm.masked.store.v$u$H.p0(<$u x $m> %v$u_1, ptr %p$u, i32 $u, <$u x i1> %m$u)\n",
+                        k, n, v, n, v, k, align, n, k, n, v,
                         k, jitc_is_float(v) ? "fadd" : "add", n, v, k, l, i, j,
-                        n, v, n, v, n, v, k, n, v, k, align, n, k);
+                        n, v, n, v, k, k, align, n, k);
                 }
             } else {
                 fmt("    br label %l$u_pre\n\n"
@@ -217,16 +209,16 @@ void scatter_packet_recursive(ReduceOp op, uint32_t l, uint32_t i, uint32_t n, c
                     k, k, k, k, k, k, k, k);
 
                 if (op == ReduceOp::Identity) {
-                    fmt("    store <$u x $m> %v$u_$u_$u, {<$u x $m>*} "
-                        "%p$u{_0|}, align $u, !noalias !2\n",
-                        n, v, l, i, j, n, v, k, align);
+                    fmt("    store <$u x $m> %v$u_$u_$u, ptr "
+                        "%p$u, align $u, !noalias !2\n",
+                        n, v, l, i, j, k, align);
                 } else if (op == ReduceOp::Add) {
-                    fmt("    %v$u_0 = load <$u x $m>, {<$u x $m>*} %p$u{_0|}, align $u\n"
+                    fmt("    %v$u_0 = load <$u x $m>, ptr %p$u, align $u\n"
                         "    %v$u_1 = $s <$u x $m> %v$u_0, %v$u_$u_$u\n"
-                        "    store <$u x $m> %v$u_1, {<$u x $m>*} %p$u{_0|}, align $u, !noalias !2\n",
-                        k, n, v, n, v, k, align,
+                        "    store <$u x $m> %v$u_1, ptr %p$u, align $u, !noalias !2\n",
+                        k, n, v, k, align,
                         k, jitc_is_float(v) ? "fadd" : "add", n, v, k, l, i, j,
-                        n, v, k, n, v, k, align);
+                        n, v, k, k, align);
                 }
 
                 fmt("    br label %l$u_post\n\n"
@@ -258,14 +250,14 @@ void jitc_llvm_scatter_packet_render_function(const Variable *v0, uint32_t n,
     const char *op_name = "";
     if (op == ReduceOp::Add) {
         op_name = "add_";
-        fmt_intrinsic("declare <$u x $m> @llvm.masked.load.v$u$H.p0{v$u$H|}({<$u x $m> *}, i32, <$u x i1>, <$u x $m>)",
-                      n, v0, n, v0, n, v0, n, v0, n, n, v0);
+        fmt_intrinsic("declare <$u x $m> @llvm.masked.load.v$u$H.p0(ptr, i32, <$u x i1>, <$u x $m>)",
+                      n, v0, n, v0, n, n, v0);
     }
-    fmt_intrinsic("declare void @llvm.masked.store.v$u$H.p0{v$u$H|}(<$u x $m>, {<$u x $m> *}, i32, <$u x i1>)",
-                  n, v0, n, v0, n, v0, n, v0, n);
+    fmt_intrinsic("declare void @llvm.masked.store.v$u$H.p0(<$u x $m>, ptr, i32, <$u x i1>)",
+                  n, v0, n, v0, n);
 
-    fmt("define internal fastcc void @scatter_$s$ux$H(<$w x {$m*}> %p, <$w x i1> %m, [$u x <$w x $m>] %v) local_unnamed_addr #0 ${\n",
-        op_name, n, v0, v0, n, v0);
+    fmt("define internal fastcc void @scatter_$s$ux$H(<$w x ptr> %p, <$w x i1> %m, [$u x <$w x $m>] %v) local_unnamed_addr #0 {\n",
+        op_name, n, v0, n, v0);
 
     for (uint32_t i = 0; i < n; ++i)
         fmt("    %v$u = extractvalue [$u x <$w x $m>] %v, $u\n",
@@ -279,7 +271,7 @@ void jitc_llvm_scatter_packet_render_function(const Variable *v0, uint32_t n,
     scatter_packet_recursive(op, 0, 0, n, v0);
 
     fmt("    ret void\n"
-        "$}");
+        "}");
 
     jitc_register_global(buffer.get() + offset);
     buffer.rewind_to(offset);
@@ -328,14 +320,12 @@ void jitc_llvm_render_scatter_packet(const Variable *v, const Variable *ptr,
         }
 
         // First offset the base pointer by the packet offset.
-        fmt("{    $v_$u_p0 = bitcast $<i8*$> $v to $<$m*$>\n|}"
-            "    $v_$u_p1 = getelementptr $m, $<$m*$> {$v_$u_p0|$v}, i32 $u\n"
-            "    $v_$u_p2 = getelementptr $m, $<$m*$> $v_$u_p1, $V\n",
-            v, offset, ptr, v0,
-            v, offset, v0, v0, v, offset, ptr, offset,
-            v, offset, v0, v0, v, offset, index);
+        fmt("    $v_$u_p1 = getelementptr $m, $<ptr$> $v, i32 $u\n"
+            "    $v_$u_p2 = getelementptr $m, $<ptr$> $v_$u_p1, $V\n",
+            v, offset, v0, ptr, offset,
+            v, offset, v0, v, offset, index);
 
-        fmt("    call fastcc void @scatter_$s$ux$H(<$w x {$m*}> $v_$u_p2, $V, [$u x <$w x $m>] $v_$u)\n",
-            op_name, packet_size, v0, v0, v, offset, mask, packet_size, v0, v, offset + packet_size-1);
+        fmt("    call fastcc void @scatter_$s$ux$H(<$w x ptr> $v_$u_p2, $V, [$u x <$w x $m>] $v_$u)\n",
+            op_name, packet_size, v0, v, offset, mask, packet_size, v0, v, offset + packet_size-1);
     }
 }

--- a/src/llvm_scatter.cpp
+++ b/src/llvm_scatter.cpp
@@ -20,15 +20,13 @@
 void jitc_llvm_render_scatter(const Variable *v, const Variable *ptr,
                               const Variable *value, const Variable *index,
                               const Variable *mask) {
-    fmt_intrinsic("declare void @llvm.masked.scatter.v$w$h($T, <$w x $p>, i32, $T)",
-         value, value, value, mask);
+    fmt_intrinsic("declare void @llvm.masked.scatter.v$w$h($T, <$w x ptr>, i32, $T)",
+         value, value, mask);
 
-    fmt("{    $v_0 = bitcast $<i8*$> $v to $<$t*$>\n|}"
-         "    $v_1 = getelementptr inbounds $t, $<$p$> {$v_0|$v}, $V\n"
-         "    call void @llvm.masked.scatter.v$w$h($V, <$w x $p> $v_1, i32 $a, $V)\n",
-         v, ptr, value,
-         v, value, value, v, ptr, index,
-         value, value, value, v, value, mask);
+    fmt("    $v_1 = getelementptr inbounds $t, $<ptr$> $v, $V\n"
+        "    call void @llvm.masked.scatter.v$w$h($V, <$w x ptr> $v_1, i32 $a, $V)\n",
+        v, value, ptr, index,
+        value, value, v, value, mask);
 }
 
 static const char *jitc_llvm_atomicrmw_name(VarType vt, ReduceOp op) {
@@ -56,13 +54,12 @@ static const char *jitc_llvm_atomicrmw_name(VarType vt, ReduceOp op) {
               (int) op, (int) vt);
 }
 
-static drjit::tuple<const char *, const char *, const char *, const char *, const char*>
+static drjit::tuple<const char *, const char *, const char *, const char *>
 jitc_llvm_vector_reduce_config(VarType vt, ReduceOp op) {
     const char *name = nullptr,
                *modifier = "",
                *identity = "",
-               *identity_type = "",
-               *version ="";
+               *identity_type = "";
 
     if (jitc_is_float(vt)) {
 
@@ -70,9 +67,6 @@ jitc_llvm_vector_reduce_config(VarType vt, ReduceOp op) {
             case ReduceOp::Add:
                 name = "fadd";
                 modifier = "reassoc ";
-
-                if (jitc_llvm_version_major < 12)
-                    version = ".v2";
 
                 switch (vt) {
                     case VarType::Float16:
@@ -142,7 +136,7 @@ jitc_llvm_vector_reduce_config(VarType vt, ReduceOp op) {
                   "supported by the LLVM backend (op %i, vt %i)",
                   (int) op, (int) vt);
 
-    return {name, modifier, identity, identity_type ,version};
+    return {name, modifier, identity, identity_type};
 }
 
 static const char *reduce_op_name[(int) ReduceOp::Count] = {
@@ -161,60 +155,42 @@ static const char *jitc_llvm_append_reduce_op_direct(VarType vt, ReduceOp op, co
                *atomicrmw_name = jitc_llvm_atomicrmw_name(vt, op);
 
     fmt_intrinsic(
-        "define internal fastcc void @reduce_$s_$h_atomic($P %ptr, $T %val, i$w %active) local_unnamed_addr #0 ${\n"
+        "define internal fastcc void @reduce_$s_$h_atomic(<$w x ptr> %ptr, $T %val, i$w %active) local_unnamed_addr #0 {\n"
         "prelude:\n"
-        "    %ptr_a = alloca [$w x $p], align $u\n"
+        "    %ptr_a = alloca [$w x ptr], align $u\n"
         "    %val_a = alloca [$w x $t], align $A\n"
         "    %valid = zext i$w %active to i32\n"
-       "{    %ptr_a2 = bitcast [$w x $p]* %ptr_a to $P*\n|}"
-       "{    %val_a2 = bitcast [$w x $t]* %val_a to $T*\n|}"
-        "    store $P %ptr, {$P*} {%ptr_a2|%ptr_a}, align $u\n"
-        "    store $T %val, {$T*} {%val_a2|%val_a}, align $A\n"
+        "    store <$w x ptr> %ptr, ptr %ptr_a, align $u\n"
+        "    store $T %val, ptr %val_a, align $A\n"
         "    br label %loop_prefix\n\n"
-        ""
         "loop_prefix:\n"
         "    %index = phi i32 [ 0, %prelude ], [ %index_next, %loop_suffix ]\n"
         "    %bit_i = shl nuw i32 1, %index\n"
         "    %valid_i = and i32 %bit_i, %valid\n"
         "    %do_scatter_i = icmp ne i32 %valid_i, 0\n"
         "    br i1 %do_scatter_i, label %do_scatter, label %loop_suffix\n\n"
-        ""
         "do_scatter:\n"
-        "    %ptr_p = getelementptr inbounds [$w x $p], {[$w x $p]*} %ptr_a, i32 0, i32 %index\n"
-        "    %val_p = getelementptr inbounds [$w x $t], {[$w x $t]*} %val_a, i32 0, i32 %index\n"
-        "    %ptr_i = load $p, {$p*} %ptr_p, align $u\n"
-        "    %val_i = load $t, $p %val_p, align $a\n"
-        "    atomicrmw $s $p %ptr_i, $t %val_i monotonic\n"
+        "    %ptr_p = getelementptr inbounds [$w x ptr], ptr %ptr_a, i32 0, i32 %index\n"
+        "    %val_p = getelementptr inbounds [$w x $t], ptr %val_a, i32 0, i32 %index\n"
+        "    %ptr_i = load ptr, ptr %ptr_p, align $u\n"
+        "    %val_i = load $t, ptr %val_p, align $a\n"
+        "    atomicrmw $s ptr %ptr_i, $t %val_i monotonic\n"
         "    br label %loop_suffix\n\n"
-        ""
         "loop_suffix:\n"
         "    %index_next = add nuw nsw i32 %index, 1\n"
         "    %is_done = icmp eq i32 %index_next, $w\n"
         "    br i1 %is_done, label %loop_end, label %loop_prefix\n\n"
-        ""
         "loop_end:\n"
         "    ret void\n"
-        "$}",
+        "}",
 
         // definition
-        op_name, v, v, v,
-
-        // prelude
-        v, ptr_align_vec,
-        v, v,
-
-        v, v,
-        v, v,
-
+        op_name, v, v, ptr_align_vec,
         v, v, ptr_align_vec,
-        v, v, v,
-
-        // do_scatter
         v, v,
+        v, ptr_align,
         v, v,
-        v, v, ptr_align,
-        v, v, v,
-        atomicrmw_name, v, v
+        atomicrmw_name, v
     );
 
     return "atomic"; // variant name
@@ -230,11 +206,11 @@ const char *jitc_llvm_append_reduce_op_local(VarType vt, ReduceOp op, const Vari
                *cmp_op = jitc_is_float(v) ? "fcmp one" : "icmp ne";
 
     auto [vector_reduce_name, vector_reduce_modifier, vector_reduce_identity,
-          vector_reduce_identity_type, vector_reduce_version]
+          vector_reduce_identity_type]
             = jitc_llvm_vector_reduce_config(vt, op);
 
-    fmt_intrinsic("declare $t @llvm$e.vector.reduce$s.$s.v$w$h($s$T)",
-                  v, vector_reduce_version, vector_reduce_name, v, vector_reduce_identity_type, v);
+    fmt_intrinsic("declare $t @llvm.vector.reduce.$s.v$w$h($s$T)",
+                  v, vector_reduce_name, v, vector_reduce_identity_type, v);
 
     Variable id_v{};
     id_v.type = (uint32_t) vt;
@@ -243,11 +219,10 @@ const char *jitc_llvm_append_reduce_op_local(VarType vt, ReduceOp op, const Vari
     // Failed experiment: skipping to the next element via ctz() wasn't
     // faster because of the resulting inter-instruction dependency
     fmt_intrinsic(
-        "define internal fastcc void @reduce_$s_$h_atomic_local($P %ptr, $T %value, i$w %active_in) local_unnamed_addr #0 ${\n"
+        "define internal fastcc void @reduce_$s_$h_atomic_local(<$w x ptr> %ptr, $T %value, i$w %active_in) local_unnamed_addr #0 {\n"
         "prelude:\n"
-        "    %ptr_a = alloca [$w x $p], align $u\n"
-       "{    %ptr_a2 = bitcast [$w x $p]* %ptr_a to $P*\n|}"
-        "    store $P %ptr, {$P*} {%ptr_a2|%ptr_a}, align $u\n"
+        "    %ptr_a = alloca [$w x ptr], align $u\n"
+        "    store <$w x ptr> %ptr, ptr %ptr_a, align $u\n"
         "    %identity_0 = insertelement $T undef, $t $l, i32 0\n"
         "    %identity_1 = shufflevector $T %identity_0, $T undef, <$w x i32> $z\n"
         "    %valid_0 = $s $T %identity_1, %value\n"
@@ -256,12 +231,11 @@ const char *jitc_llvm_append_reduce_op_local(VarType vt, ReduceOp op, const Vari
         "    %bit_0 = bitcast i$w 1 to <$w x i1>\n"
         "    %shiftamt_0 = insertelement <$w x i64> undef, i64 $u, i64 0\n"
         "    %shiftamt_1 = shufflevector <$w x i64> %shiftamt_0, <$w x i64> undef, <$w x i32> $z\n"
-        "    %ptrlo_0 = ptrtoint $P %ptr to <$w x i64>\n"
+        "    %ptrlo_0 = ptrtoint <$w x ptr> %ptr to <$w x i64>\n"
         "    %ptrlo_1 = lshr <$w x i64> %ptrlo_0, %shiftamt_1\n"
         "    %ptrlo_2 = trunc <$w x i64> %ptrlo_1 to <$w x i32>\n"
         "    %ptrlo_3 = select <$w x i1> %valid_1, <$w x i32> %ptrlo_2, <$w x i32> $z\n"
         "    br label %loop_prefix\n\n"
-        ""
         "loop_prefix:\n"
         "    %active = phi <$w x i1> [ %valid_2, %prelude ], [ %active_final, %loop_suffix ]\n"
         "    %bit = phi <$w x i1> [ %bit_0, %prelude ], [ %bit_next, %loop_suffix ]\n"
@@ -269,28 +243,25 @@ const char *jitc_llvm_append_reduce_op_local(VarType vt, ReduceOp op, const Vari
         "    %active_0 = bitcast <$w x i1> %active to i$w\n"
         "    %active_1 = icmp ne i$w %active_0, 0\n"
         "    br i1 %active_1, label %loop_body, label %loop_end\n\n"
-        ""
         "loop_body:\n"
         "    %active_2 = and <$w x i1> %bit, %active\n"
         "    %active_3 = bitcast <$w x i1> %active_2 to i$w\n"
         "    %active_4 = icmp ne i$w %active_3, 0\n"
         "    br i1 %active_4, label %do_scatter, label %loop_suffix\n\n"
-        ""
         "do_scatter:\n"
-        "    %ptr_p = getelementptr inbounds [$w x $p], {[$w x $p]*} %ptr_a, i32 0, i32 %index\n"
-        "    %ptr_i = load $p, {$p*} %ptr_p, align $u\n"
-        "    %ptrlo_4 = ptrtoint $p %ptr_i to i64\n"
+        "    %ptr_p = getelementptr inbounds [$w x ptr], ptr %ptr_a, i32 0, i32 %index\n"
+        "    %ptr_i = load ptr, ptr %ptr_p, align $u\n"
+        "    %ptrlo_4 = ptrtoint ptr %ptr_i to i64\n"
         "    %ptrlo_5 = lshr i64 %ptrlo_4, $u\n"
         "    %ptrlo_6 = trunc i64 %ptrlo_5 to i32\n"
         "    %ptrlo_7 = insertelement <$w x i32> undef, i32 %ptrlo_6, i32 0\n"
         "    %ptrlo_8 = shufflevector <$w x i32> %ptrlo_7, <$w x i32> undef, <$w x i32> $z\n"
         "    %ptr_diff = icmp ne <$w x i32> %ptrlo_8, %ptrlo_3\n"
         "    %red_in = select <$w x i1> %ptr_diff, $T %identity_1, $T %value\n"
-        "    %red_out = call $s$t @llvm$e.vector.reduce$s.$s.v$w$h($s$T %red_in)\n"
-        "    atomicrmw $s $p %ptr_i, $t %red_out monotonic\n"
+        "    %red_out = call $s$t @llvm.vector.reduce.$s.v$w$h($s$T %red_in)\n"
+        "    atomicrmw $s ptr %ptr_i, $t %red_out monotonic\n"
         "    %active_next = and <$w x i1> %active, %ptr_diff\n"
         "    br label %loop_suffix\n\n"
-        ""
         "loop_suffix:\n"
         "    %active_final = phi <$w x i1> [ %active, %loop_body ], [ %active_next, %do_scatter ]\n"
         "    %bit_1 = bitcast <$w x i1> %bit to i$w\n"
@@ -298,32 +269,20 @@ const char *jitc_llvm_append_reduce_op_local(VarType vt, ReduceOp op, const Vari
         "    %bit_next = bitcast i$w %bit_2 to <$w x i1>\n"
         "    %index_next = add nsw nuw i32 %index, 1\n"
         "    br label %loop_prefix\n\n"
-        ""
         "loop_end:\n"
         "    ret void\n"
-        "$}",
+        "}",
 
         // definition
-        op_name, v, v, v,
-
-        // prelude
-        v, ptr_align_vec,
-        v, v,
-        v, v, ptr_align_vec,
+        op_name, v, v, ptr_align_vec, ptr_align_vec,
         v, v, &id_v,
         v, v,
         cmp_op, v,
-        shiftamt,
-        v,
-
-        // do_scatter
-        v, v,
-        v, v, ptr_align,
-        v,
+        shiftamt, ptr_align,
         shiftamt,
         v, v,
-        vector_reduce_modifier, v, vector_reduce_version, vector_reduce_name, v, vector_reduce_identity, v,
-        atomicrmw_name, v, v
+        vector_reduce_modifier, v, vector_reduce_name, v, vector_reduce_identity, v,
+        atomicrmw_name, v
     );
 
     return "atomic_local"; // variant name
@@ -339,11 +298,11 @@ static const char *jitc_llvm_append_reduce_op_noconflict(VarType vt, ReduceOp op
 
 
     auto [vector_reduce_name, vector_reduce_modifier, vector_reduce_identity,
-          vector_reduce_identity_type, vector_reduce_version]
+          vector_reduce_identity_type]
             = jitc_llvm_vector_reduce_config(vt, op);
 
-    fmt_intrinsic("declare $t @llvm$e.vector.reduce$s.$s.v$w$h($s$T)",
-                  v, vector_reduce_version, vector_reduce_name, v, vector_reduce_identity_type, v);
+    fmt_intrinsic("declare $t @llvm.vector.reduce.$s.v$w$h($s$T)",
+                  v, vector_reduce_name, v, vector_reduce_identity_type, v);
 
     bool is_float = jitc_is_float(v),
          is_sint = jitc_is_sint(v);
@@ -385,11 +344,11 @@ static const char *jitc_llvm_append_reduce_op_noconflict(VarType vt, ReduceOp op
 #if !defined(__aarch64__)
     if ((op == ReduceOp::Min || op == ReduceOp::Max) && vt == VarType::Float16) {
         fmt_intrinsic(
-            "define internal fastcc half @$s.f16(half %arg0, half %arg1) #0 ${\n"
+            "define internal fastcc half @$s.f16(half %arg0, half %arg1) #0 {\n"
             "    %p = fcmp $s half %arg0, %arg1\n"
             "    %f = select i1 %p, half %arg0, half %arg1\n"
             "    ret half %f\n"
-            "$}",
+            "}",
             scalar_op_name,
             op == ReduceOp::Max ? "ogt" : "olt"
         );
@@ -414,11 +373,10 @@ static const char *jitc_llvm_append_reduce_op_noconflict(VarType vt, ReduceOp op
     id_v.literal = jitc_reduce_identity(vt, op);
 
     fmt_intrinsic(
-        "define internal fastcc void @reduce_$s_$h_noconflict($P %ptr, $T %value, i$w %active_in) local_unnamed_addr #0 ${\n"
+        "define internal fastcc void @reduce_$s_$h_noconflict(<$w x ptr> %ptr, $T %value, i$w %active_in) local_unnamed_addr #0 {\n"
         "prelude:\n"
-        "    %ptr_a = alloca [$w x $p], align $u\n"
-       "{    %ptr_a2 = bitcast [$w x $p]* %ptr_a to $P*\n|}"
-        "    store $P %ptr, {$P*} {%ptr_a2|%ptr_a}, align $u\n"
+        "    %ptr_a = alloca [$w x ptr], align $u\n"
+        "    store <$w x ptr> %ptr, ptr %ptr_a, align $u\n"
         "    %identity_0 = insertelement $T undef, $t $l, i32 0\n"
         "    %identity_1 = shufflevector $T %identity_0, $T undef, <$w x i32> $z\n"
         "    %valid_0 = $s $T %identity_1, %value\n"
@@ -427,12 +385,11 @@ static const char *jitc_llvm_append_reduce_op_noconflict(VarType vt, ReduceOp op
         "    %bit_0 = bitcast i$w 1 to <$w x i1>\n"
         "    %shiftamt_0 = insertelement <$w x i64> undef, i64 $u, i64 0\n"
         "    %shiftamt_1 = shufflevector <$w x i64> %shiftamt_0, <$w x i64> undef, <$w x i32> $z\n"
-        "    %ptrlo_0 = ptrtoint $P %ptr to <$w x i64>\n"
+        "    %ptrlo_0 = ptrtoint <$w x ptr> %ptr to <$w x i64>\n"
         "    %ptrlo_1 = lshr <$w x i64> %ptrlo_0, %shiftamt_1\n"
         "    %ptrlo_2 = trunc <$w x i64> %ptrlo_1 to <$w x i32>\n"
         "    %ptrlo_3 = select <$w x i1> %valid_1, <$w x i32> %ptrlo_2, <$w x i32> $z\n"
         "    br label %loop_prefix\n\n"
-        ""
         "loop_prefix:\n"
         "    %active = phi <$w x i1> [ %valid_2, %prelude ], [ %active_final, %loop_suffix ]\n"
         "    %bit = phi <$w x i1> [ %bit_0, %prelude ], [ %bit_next, %loop_suffix ]\n"
@@ -440,30 +397,27 @@ static const char *jitc_llvm_append_reduce_op_noconflict(VarType vt, ReduceOp op
         "    %active_0 = bitcast <$w x i1> %active to i$w\n"
         "    %active_1 = icmp ne i$w %active_0, 0\n"
         "    br i1 %active_1, label %loop_body, label %loop_end\n\n"
-        ""
         "loop_body:\n"
         "    %active_2 = and <$w x i1> %bit, %active\n"
         "    %active_3 = bitcast <$w x i1> %active_2 to i$w\n"
         "    %active_4 = icmp ne i$w %active_3, 0\n"
         "    br i1 %active_4, label %do_scatter, label %loop_suffix\n\n"
-        ""
         "do_scatter:\n"
-        "    %ptr_p = getelementptr inbounds [$w x $p], {[$w x $p]*} %ptr_a, i32 0, i32 %index\n"
-        "    %ptr_i = load $p, {$p*} %ptr_p, align $u\n"
-        "    %ptrlo_4 = ptrtoint $p %ptr_i to i64\n"
+        "    %ptr_p = getelementptr inbounds [$w x ptr], ptr %ptr_a, i32 0, i32 %index\n"
+        "    %ptr_i = load ptr, ptr %ptr_p, align $u\n"
+        "    %ptrlo_4 = ptrtoint ptr %ptr_i to i64\n"
         "    %ptrlo_5 = lshr i64 %ptrlo_4, $u\n"
         "    %ptrlo_6 = trunc i64 %ptrlo_5 to i32\n"
         "    %ptrlo_7 = insertelement <$w x i32> undef, i32 %ptrlo_6, i32 0\n"
         "    %ptrlo_8 = shufflevector <$w x i32> %ptrlo_7, <$w x i32> undef, <$w x i32> $z\n"
         "    %ptr_diff = icmp ne <$w x i32> %ptrlo_8, %ptrlo_3\n"
         "    %red_in = select <$w x i1> %ptr_diff, $T %identity_1, $T %value\n"
-        "    %red_out = call $s$t @llvm$e.vector.reduce$s.$s.v$w$h($s$T %red_in)\n"
-        "    %before = load $t, $p %ptr_i, align $a\n"
+        "    %red_out = call $s$t @llvm.vector.reduce.$s.v$w$h($s$T %red_in)\n"
+        "    %before = load $t, ptr %ptr_i, align $a\n"
         "    %after = $s\n"
-        "    store $t %after, $p %ptr_i, align $a\n"
+        "    store $t %after, ptr %ptr_i, align $a\n"
         "    %active_next = and <$w x i1> %active, %ptr_diff\n"
         "    br label %loop_suffix\n\n"
-        ""
         "loop_suffix:\n"
         "    %active_final = phi <$w x i1> [ %active, %loop_body ], [ %active_next, %do_scatter ]\n"
         "    %bit_1 = bitcast <$w x i1> %bit to i$w\n"
@@ -471,35 +425,23 @@ static const char *jitc_llvm_append_reduce_op_noconflict(VarType vt, ReduceOp op
         "    %bit_next = bitcast i$w %bit_2 to <$w x i1>\n"
         "    %index_next = add nsw nuw i32 %index, 1\n"
         "    br label %loop_prefix\n\n"
-        ""
         "loop_end:\n"
         "    ret void\n"
-        "$}",
+        "}",
 
         // definition
-        op_name, v, v, v,
-
-        // prelude
-        v, ptr_align_vec,
-        v, v,
-        v, v, ptr_align_vec,
+        op_name, v, v, ptr_align_vec, ptr_align_vec,
         v, v, &id_v,
         v, v,
         cmp_op, v,
-        shiftamt,
-        v,
-
-        // do_scatter
-        v, v,
-        v, v, ptr_align,
-        v,
+        shiftamt, ptr_align,
         shiftamt,
         v, v,
-        vector_reduce_modifier, v, vector_reduce_version, vector_reduce_name, v, vector_reduce_identity, v,
+        vector_reduce_modifier, v, vector_reduce_name, v, vector_reduce_identity, v,
 
-        v, v, v,
+        v, v,
         scalar_op,
-        v, v, v
+        v, v
     );
 
     return "noconflict"; // variant name
@@ -534,41 +476,36 @@ void jitc_llvm_render_scatter_reduce(const Variable *v,
             jitc_fail("jitc_llvm_render_scatter_reduce(): unhandled mode (%i)!", (int) mode);
     }
 
-    fmt("{    $v_0 = bitcast $<i8*$> $v to $<$t*$>\n|}"
-         "    $v_1 = getelementptr inbounds $t, $<$p$> {$v_0|$v}, $V\n"
-         "    $v_2 = bitcast $V to i$w\n"
-         "    call fastcc void @reduce_$s_$h_$s(<$w x $p> $v_1, $V, i$w $v_2)\n",
-        v, ptr, value,
-        v, value, value, v, ptr, index,
+    fmt("    $v_1 = getelementptr inbounds $t, $<ptr$> $v, $V\n"
+        "    $v_2 = bitcast $V to i$w\n"
+        "    call fastcc void @reduce_$s_$h_$s(<$w x ptr> $v_1, $V, i$w $v_2)\n",
+        v, value, ptr, index,
         v, mask,
-        reduce_op_name[(int) op], value, variant, value, v, value, v);
+        reduce_op_name[(int) op], value, variant, v, value, v);
 }
 
 void jitc_llvm_render_scatter_inc(Variable *v, const Variable *ptr,
                                   const Variable *index, const Variable *mask) {
-    fmt("{    $v_0 = bitcast $<i8*$> $v to $<i32*$>\n|}"
-         "    $v_1 = getelementptr inbounds i32, $<{i32*}$> {$v_0|$v}, $V\n"
-         "    $v = call fastcc $T @reduce_inc_u32(<$w x {i32*}> $v_1, $V)\n",
-        v, ptr,
-        v, v, ptr, index,
+    fmt("    $v_1 = getelementptr inbounds i32, $<ptr$> $v, $V\n"
+        "    $v = call fastcc $T @reduce_inc_u32(<$w x ptr> $v_1, $V)\n",
+        v, ptr, index,
         v, v, v, mask);
 
     fmt_intrinsic("declare i32 @llvm.cttz.i32(i32, i1)");
-    fmt_intrinsic("declare i64 @llvm$e.vector.reduce.umax.v$wi64(<$w x i64>)");
+    fmt_intrinsic("declare i64 @llvm.vector.reduce.umax.v$wi64(<$w x i64>)");
 
     fmt_intrinsic(
-        "define internal fastcc <$w x i32> @reduce_inc_u32(<$w x {i32*}> %ptrs_in, <$w x i1> %active_in) local_unnamed_addr #0 ${\n"
+        "define internal fastcc <$w x i32> @reduce_inc_u32(<$w x ptr> %ptrs_in, <$w x i1> %active_in) local_unnamed_addr #0 {\n"
         "L0:\n"
-        "    %ptrs_start_0 = select <$w x i1> %active_in, <$w x {i32*}> %ptrs_in, <$w x {i32*}> $z\n"
-        "    %ptrs_start_1 = ptrtoint <$w x {i32*}> %ptrs_start_0 to <$w x i64>\n"
+        "    %ptrs_start_0 = select <$w x i1> %active_in, <$w x ptr> %ptrs_in, <$w x ptr> $z\n"
+        "    %ptrs_start_1 = ptrtoint <$w x ptr> %ptrs_start_0 to <$w x i64>\n"
         "    br label %L1\n\n"
         "L1:\n"
         "    %ptrs = phi <$w x i64> [ %ptrs_start_1, %L0 ], [ %ptrs_next, %L4 ]\n"
         "    %out = phi <$w x i32> [ $z, %L0 ], [ %out_next, %L4 ]\n"
-        "    %ptr = call i64 @llvm$e.vector.reduce.umax.v$wi64(<$w x i64> %ptrs)\n"
+        "    %ptr = call i64 @llvm.vector.reduce.umax.v$wi64(<$w x i64> %ptrs)\n"
         "    %done = icmp eq i64 %ptr, 0\n"
         "    br i1 %done, label %L5, label %L2\n\n"
-        ""
         "L2:\n"
         "    %ptr_b0 = insertelement <$w x i64> undef, i64 %ptr, i32 0\n"
         "    %ptr_b1 = shufflevector <$w x i64> %ptr_b0, <$w x i64> undef, <$w x i32> $z\n"
@@ -577,7 +514,6 @@ void jitc_llvm_render_scatter_inc(Variable *v, const Variable *ptr,
         "    %active_i1 = zext i$w %active_i0 to i32\n"
         "    %ptrs_next = select <$w x i1> %active_v, <$w x i64> $z, <$w x i64> %ptrs\n"
         "    br label %L3\n\n"
-        ""
         "L3:\n"
         "    %active = phi i32 [ %active_i1, %L2 ], [ %active_next, %L3 ]\n"
         "    %accum = phi i32 [ 0, %L2 ], [ %accum_next, %L3 ]\n"
@@ -589,19 +525,17 @@ void jitc_llvm_render_scatter_inc(Variable *v, const Variable *ptr,
         "    %out_2_next = insertelement <$w x i32> %out_2, i32 %accum, i32 %index\n"
         "    %done_2 = icmp eq i32 %active_next, 0\n"
         "    br i1 %done_2, label %L4, label %L3\n\n"
-        ""
         "L4:\n"
-        "    %ptr_p = inttoptr i64 %ptr to {i32*}\n"
-        "    %prev = atomicrmw add {i32*} %ptr_p, i32 %accum_next monotonic\n"
+        "    %ptr_p = inttoptr i64 %ptr to ptr\n"
+        "    %prev = atomicrmw add ptr %ptr_p, i32 %accum_next monotonic\n"
         "    %prev_b0 = insertelement <$w x i32> undef, i32 %prev, i32 0\n"
         "    %prev_b1 = shufflevector <$w x i32> %prev_b0, <$w x i32> undef, <$w x i32> $z\n"
         "    %sum = add <$w x i32> %prev_b1, %out_2_next\n"
         "    %out_next = select <$w x i1> %active_v, <$w x i32> %sum, <$w x i32> %out\n"
         "    br label %L1;\n"
-        ""
         "L5:\n"
         "    ret <$w x i32> %out\n"
-        "$}"
+        "}"
     );
 
     v->consumed = 1;
@@ -617,17 +551,13 @@ void jitc_llvm_render_scatter_add_kahan(const Variable *v,
 
     fmt_intrinsic("declare $t @llvm.fabs.$h($t)", value, value, value);
 
-    fmt("{    $v_ptr1 = bitcast $<i8*$> $v to $<$t*$>\n|}"
-         "    $v_target1 = getelementptr inbounds $t, $<$p$> {$v_ptr1|$v}, $V\n"
-        "{    $v_ptr2 = bitcast $<i8*$> $v to $<$t*$>\n|}"
-         "    $v_target2 = getelementptr inbounds $t, $<$p$> {$v_ptr2|$v}, $V\n"
-         "    br label %l$u_0\n\n"
-         "l$u_0:\n"
-         "    br label %l$u_1\n\n",
-        v, ptr_1, value,
-        v, value, value, v, ptr_1, index,
-        v, ptr_2, value,
-        v, value, value, v, ptr_2, index,
+    fmt("    $v_target1 = getelementptr inbounds $t, $<ptr$> $v, $V\n"
+        "    $v_target2 = getelementptr inbounds $t, $<ptr$> $v, $V\n"
+        "    br label %l$u_0\n\n"
+        "l$u_0:\n"
+        "    br label %l$u_1\n\n",
+        v, value, ptr_1, index,
+        v, value, ptr_2, index,
         reg_index,
         reg_index,
         reg_index);
@@ -644,9 +574,9 @@ void jitc_llvm_render_scatter_add_kahan(const Variable *v,
         v, reg_index, reg_index);
 
     fmt("l$u_2:\n"
-        "    $v_target1_i = extractelement <$w x $p> $v_target1, i32 $v_index\n"
-        "    $v_target2_i = extractelement <$w x $p> $v_target2, i32 $v_index\n"
-        "    $v_before = atomicrmw fadd $p $v_target1_i, $t $v_value_i monotonic\n"
+        "    $v_target1_i = extractelement <$w x ptr> $v_target1, i32 $v_index\n"
+        "    $v_target2_i = extractelement <$w x ptr> $v_target2, i32 $v_index\n"
+        "    $v_before = atomicrmw fadd ptr $v_target1_i, $t $v_value_i monotonic\n"
         "    $v_after = fadd $t $v_before, $v_value_i\n"
         "    $v_case1_0 = fsub $t $v_before, $v_after\n"
         "    $v_case1 = fadd $t $v_case1_0, $v_value_i\n"
@@ -656,12 +586,12 @@ void jitc_llvm_render_scatter_add_kahan(const Variable *v,
         "    $v_abs_value = call $t @llvm.fabs.$h($t $v_value_i)\n"
         "    $v_pred = fcmp oge $t $v_abs_before, $v_abs_value\n"
         "    $v_result = select i1 $v_pred, $t $v_case1, $t $v_case2\n"
-        "    atomicrmw fadd $p $v_target2_i, $t $v_result monotonic\n"
+        "    atomicrmw fadd ptr $v_target2_i, $t $v_result monotonic\n"
         "    br label %l$u_3\n\n",
         reg_index,
-        v, value, v, v,
-        v, value, v, v,
-        v, value, v, value, v,
+        v, v, v,
+        v, v, v,
+        v, v, value, v,
         v, value, v, v,
         v, value, v, v,
         v, value, v, v,
@@ -670,8 +600,7 @@ void jitc_llvm_render_scatter_add_kahan(const Variable *v,
         v, value, value, value, v,
         v, value, value, value, v,
         v, value, v, v,
-        v, v, value, v, value, v,
-        value, v, value, v,
+        v, v, value, v, value, v, v, value, v,
         reg_index);
 
     fmt("l$u_3:\n"
@@ -695,10 +624,8 @@ void jitc_llvm_render_scatter_exch(Variable *v,
 
     fmt("    br label %l$u_prelude\n"
         "\nl$u_prelude:\n"
-       "{    $v_addr_0 = bitcast $<i8*$> $v to $<$t*$>\n|}"
-        "    $v_addr = getelementptr inbounds $t, $<$p$> {$v_addr_0|$v}, $V\n"
+        "    $v_addr = getelementptr inbounds $t, $<ptr$> $v, $V\n"
         "    br label %l$u_cond\n\n"
-        ""
         "l$u_cond:\n"
         "    $v = phi <$w x $t> [$z, %l$u_prelude], [$v_next, %l$u_end]\n"
         "    $v_i = phi i32 [0, %l$u_prelude], [$v_i_next, %l$u_end]\n"
@@ -706,8 +633,7 @@ void jitc_llvm_render_scatter_exch(Variable *v,
         // prelude
         v->reg_index,
         v->reg_index,
-        v, ptr, value,
-        v, value, value, v, ptr, index,
+        v, value, ptr, index,
         v->reg_index,
 
         // cond
@@ -721,7 +647,6 @@ void jitc_llvm_render_scatter_exch(Variable *v,
             v->reg_index);
     else
         fmt("    br i1 $v_cond, label %l$u_check_mask, label %l$u_exit\n\n"
-            ""
             "l$u_check_mask:\n"
             "    $v_mask = extractelement $V, i32 $v_i\n"
             "    br i1 $v_mask, label %l$u_body, label %l$u_end\n\n",
@@ -732,22 +657,20 @@ void jitc_llvm_render_scatter_exch(Variable *v,
 
     fmt("l$u_body:\n"
         "    $v_value = extractelement $V, i32 $v_i\n"
-        "    $v_target = extractelement <$w x {$p}> $v_addr, i32 $v_i\n"
-        "    $v_ret_i = atomicrmw xchg {$p} $v_target, $t $v_value monotonic\n"
+        "    $v_target = extractelement <$w x ptr> $v_addr, i32 $v_i\n"
+        "    $v_ret_i = atomicrmw xchg ptr $v_target, $t $v_value monotonic\n"
         "    br label %l$u_end\n\n"
-        ""
         "l$u_end:\n"
         "    $v_ret = phi $t [$z, %l$u_check_mask], [$v_ret_i, %l$u_body]\n"
         "    $v_next = insertelement <$w x $t> $v, $t $v_ret, i32 $v_i\n"
         "    $v_i_next = add i32 $v_i, 1\n"
         "    br label %l$u_cond\n\n"
-        ""
         "l$u_exit:\n",
         // body
         v->reg_index,
         v, value, v,
-        v, value, v, v,
-        v, value, v, value, v,
+        v, v, v,
+        v, v, value, v,
         v->reg_index,
 
         // end
@@ -775,10 +698,8 @@ void jitc_llvm_render_scatter_cas(Variable *v,
 
     fmt("    br label %l$u_prelude\n"
         "\nl$u_prelude:\n"
-       "{    $v_addr_0 = bitcast $<i8*$> $v to $<$t*$>\n|}"
-        "    $v_addr = getelementptr inbounds $t, $<$p$> {$v_addr_0|$v}, $V\n"
+        "    $v_addr = getelementptr inbounds $t, $<ptr$> $v, $V\n"
         "    br label %l$u_cond\n\n"
-        ""
         "l$u_cond:\n"
         "    $v_out_0 = phi <$w x $t> [$z, %l$u_prelude], [$v_out_0_next, %l$u_end]\n"
         "    $v_out_1 = phi <$w x i1> [$z, %l$u_prelude], [$v_out_1_next, %l$u_end]\n"
@@ -787,8 +708,7 @@ void jitc_llvm_render_scatter_cas(Variable *v,
         // prelude
         v->reg_index,
         v->reg_index,
-        v, ptr, value,
-        v, value, value, v, ptr, index,
+        v, value, ptr, index,
         v->reg_index,
 
         // cond
@@ -803,7 +723,6 @@ void jitc_llvm_render_scatter_cas(Variable *v,
             v->reg_index);
     else
         fmt("    br i1 $v_cond, label %l$u_check_mask, label %l$u_exit\n\n"
-            ""
             "l$u_check_mask:\n"
             "    $v_mask = extractelement $V, i32 $v_i\n"
             "    br i1 $v_mask, label %l$u_body, label %l$u_end\n\n",
@@ -817,15 +736,12 @@ void jitc_llvm_render_scatter_cas(Variable *v,
         "    $v_cmp_b = bitcast $t $v_cmp to $b\n"
         "    $v_value = extractelement $V, i32 $v_i\n"
         "    $v_value_b = bitcast $t $v_value to $b\n"
-        "    $v_target = extractelement <$w x {$p}> $v_addr, i32 $v_i\n"
-       "{    $v_target_b = bitcast $p $v_target to $b*\n|}"
-        ""
-        "    $v_res = cmpxchg {$b*} $v_target{_b|}, $b $v_cmp_b, $b $v_value_b acquire monotonic\n"
-        "    $v_old_i_b = extractvalue ${ $b, i1 $} $v_res, 0\n"
+        "    $v_target = extractelement <$w x ptr> $v_addr, i32 $v_i\n"
+        "    $v_res = cmpxchg ptr $v_target, $b $v_cmp_b, $b $v_value_b acquire monotonic\n"
+        "    $v_old_i_b = extractvalue { $b, i1 } $v_res, 0\n"
         "    $v_old_i = bitcast $b $v_old_i_b to $t\n"
-        "    $v_success_i = extractvalue ${ $b, i1 $} $v_res, 1\n"
+        "    $v_success_i = extractvalue { $b, i1 } $v_res, 1\n"
         "    br label %l$u_end\n\n"
-        ""
         "l$u_end:\n"
         "    $v_old = phi $t [$z, %l$u_check_mask], [$v_old_i, %l$u_body]\n"
         "    $v_success = phi i1 [$z, %l$u_check_mask], [$v_success_i, %l$u_body]\n"
@@ -833,7 +749,6 @@ void jitc_llvm_render_scatter_cas(Variable *v,
         "    $v_out_1_next = insertelement <$w x i1> $v_out_1, i1 $v_success, i32 $v_i\n"
         "    $v_i_next = add i32 $v_i, 1\n"
         "    br label %l$u_cond\n\n"
-        ""
         "l$u_exit:\n",
         // body
         v->reg_index,
@@ -842,10 +757,9 @@ void jitc_llvm_render_scatter_cas(Variable *v,
         v, compare, v, compare,
         v, value, v,
         v, compare, v, value,
-        v, value, v, v,
-        v, value, v, value,
+        v, v, v,
 
-        v, value, v, compare, v, value, v,
+        v, v, compare, v, value, v,
         v, value, v,
         v, value, v, value,
         v, value, v,

--- a/src/lock.h
+++ b/src/lock.h
@@ -3,6 +3,16 @@
 #if defined(__linux__) && !defined(DRJIT_USE_STD_MUTEX)
 #include <pthread.h>
 
+// Opaque per-thread token used to detect recursive lock acquisition.
+// Prefer __builtin_thread_pointer() over the slower pthread_self() if available.
+#if defined(__has_builtin) && __has_builtin(__builtin_thread_pointer)
+using lock_thread_id_t = void *; // __builtin_thread_pointer() returns void *
+inline lock_thread_id_t lock_thread_id() { return __builtin_thread_pointer(); }
+#else
+using lock_thread_id_t = pthread_t;
+inline lock_thread_id_t lock_thread_id() { return pthread_self(); }
+#endif
+
 /*
  * This recursive spinlock improves the efficiency of @dr.freeze and operations
  * that acquire a lock recursively to avoid repeated atomic memory transactions
@@ -27,7 +37,7 @@
 
 struct Lock {
     pthread_spinlock_t lock;
-    pthread_t owner;
+    lock_thread_id_t owner;
     size_t recursion_count;
 };
 
@@ -40,7 +50,7 @@ inline void lock_init(Lock &lock) {
 }
 inline void lock_destroy(Lock &lock) { pthread_spin_destroy(&lock.lock); }
 inline void lock_acquire(Lock &lock) {
-    pthread_t self = pthread_self();
+    lock_thread_id_t self = lock_thread_id();
     if (lock.owner == self) {
         lock.recursion_count++;
         return;
@@ -53,7 +63,7 @@ inline void lock_acquire(Lock &lock) {
 inline void lock_release(Lock &lock) {
     lock.recursion_count--;
     if (lock.recursion_count == 0) {
-        lock.owner = (pthread_t) -1;
+        lock.owner = (lock_thread_id_t) -1;
         pthread_spin_unlock(&lock.lock);
     }
 }

--- a/src/lock.h
+++ b/src/lock.h
@@ -1,5 +1,20 @@
 #pragma once
 
+#include <atomic>
+
+/*
+ * The recursive locks below have a fast path that skips the atomic transaction
+ * when the current thread already holds the lock. This reads `lock.owner`
+ * without holding the lock, racing with other threads' stores.
+ *
+ * The code below uses a relaxed atomic to make this race-free in the C++ memory
+ * model. Relaxed ordering suffices because `owner` is only a same-thread
+ * recursion hint; all synchronization comes from the underlying lock. The only
+ * value that affects control flow is "equal to my own id", which can only be
+ * observed if this thread wrote it while holding the lock. `recursion_count`
+ * needs no atomic: it is only touched by the owning thread under the lock.
+ */
+
 #if defined(__linux__) && !defined(DRJIT_USE_STD_MUTEX)
 #include <pthread.h>
 
@@ -13,90 +28,69 @@ using lock_thread_id_t = pthread_t;
 inline lock_thread_id_t lock_thread_id() { return pthread_self(); }
 #endif
 
-/*
- * This recursive spinlock improves the efficiency of @dr.freeze and operations
- * that acquire a lock recursively to avoid repeated atomic memory transactions
- * when accessing JIT variables.
- *
- * The code contains unprotected reads/writes of members (`lock.owner`,
- * `lock.recursion_count`) that are likely to be flagged as data races when using
- * thread sanitizers or similar infrastructure. Here is a rationale on why this is
- * safe even on architectures with weakly ordered memory semantics like ARM:
- *
- * The check `lock.owner == self` in lock_acquire avoids taking out the lock if
- * the current thread already holds it. However, the read from `lock.owner` is a
- * data race. Other threads might be reading/writing this value, and there are no
- * guarantees of how these operations are ordered with respect to each other.
- *
- * However, only one possible value of this field matters, which is when
- * `lock.owner` matches the value of `pthread_self()`. This value can only be read
- * if the current thread wrote it, which means that it is still holding the lock.
- * This means that the body of the conditionals is effectively part of a previous
- * critical section.
- */
-
 struct Lock {
     pthread_spinlock_t lock;
-    lock_thread_id_t owner;
+    std::atomic<lock_thread_id_t> owner;
     size_t recursion_count;
 };
 
-// Danger zone: the drjit-core locks are held for an extremely short amount of
+// The drjit-core locks are held for an extremely short amount of
 // time and normally uncontended. Switching to a spin lock cuts tracing time 8-10%
 inline void lock_init(Lock &lock) {
     pthread_spin_init(&lock.lock, PTHREAD_PROCESS_PRIVATE);
-    lock.owner           = 0;
+    lock.owner.store(0, std::memory_order_relaxed);
     lock.recursion_count = 0;
 }
 inline void lock_destroy(Lock &lock) { pthread_spin_destroy(&lock.lock); }
 inline void lock_acquire(Lock &lock) {
     lock_thread_id_t self = lock_thread_id();
-    if (lock.owner == self) {
+    if (lock.owner.load(std::memory_order_relaxed) == self) {
         lock.recursion_count++;
         return;
     }
 
     pthread_spin_lock(&lock.lock);
-    lock.owner           = self;
+    lock.owner.store(self, std::memory_order_relaxed);
     lock.recursion_count = 1;
 }
 inline void lock_release(Lock &lock) {
     lock.recursion_count--;
     if (lock.recursion_count == 0) {
-        lock.owner = (lock_thread_id_t) -1;
+        lock.owner.store(0, std::memory_order_relaxed);
         pthread_spin_unlock(&lock.lock);
     }
 }
 #elif defined(__APPLE__) && !defined(DRJIT_USE_STD_MUTEX)
 #include <os/lock.h>
+#include <pthread.h>
 
 struct Lock {
     os_unfair_lock_s lock;
-    pthread_t owner;
+    std::atomic<pthread_t> owner;
     size_t recursion_count;
 };
 
 inline void lock_init(Lock &lock) {
-    lock.lock            = OS_UNFAIR_LOCK_INIT;
-    lock.owner           = (pthread_t) -1;
+    lock.lock = OS_UNFAIR_LOCK_INIT;
+    lock.owner.store((pthread_t) -1, std::memory_order_relaxed);
     lock.recursion_count = 0;
 }
 inline void lock_destroy(Lock &) {}
 inline void lock_acquire(Lock &lock) {
     pthread_t self = pthread_self();
-    if (pthread_equal(lock.owner, self)) {
+    if (pthread_equal(lock.owner.load(std::memory_order_relaxed), self)) {
         lock.recursion_count++;
         return;
     }
 
     os_unfair_lock_lock(&lock.lock);
-    lock.owner           = self;
+    lock.owner.store(self, std::memory_order_relaxed);
     lock.recursion_count = 1;
 }
 inline void lock_release(Lock &lock) {
     lock.recursion_count--;
     if (lock.recursion_count == 0) {
-        lock.owner = (pthread_t) -1;
+        lock.owner.store((pthread_t) -1, std::memory_order_relaxed);
         os_unfair_lock_unlock(&lock.lock);
     }
 }
@@ -106,39 +100,39 @@ inline void lock_release(Lock &lock) {
 #include <shared_mutex>
 struct Lock {
     std::shared_mutex lock; // Based on the faster Win7 SRWLOCK
-    std::thread::id owner;
+    std::atomic<std::thread::id> owner;
     size_t recursion_count;
 };
 #else
 #include <mutex>
 struct Lock {
     std::mutex lock;
-    std::thread::id owner;
+    std::atomic<std::thread::id> owner;
     size_t recursion_count;
 };
 #endif
 
 inline void lock_init(Lock &lock) {
-    lock.owner           = std::thread::id();
+    lock.owner.store(std::thread::id(), std::memory_order_relaxed);
     lock.recursion_count = 0;
 }
 
 inline void lock_destroy(Lock &) {}
 inline void lock_acquire(Lock &lock) {
     std::thread::id self = std::this_thread::get_id();
-    if (lock.owner == self) {
+    if (lock.owner.load(std::memory_order_relaxed) == self) {
         lock.recursion_count++;
         return;
     }
 
     lock.lock.lock();
-    lock.owner = self;
+    lock.owner.store(self, std::memory_order_relaxed);
     lock.recursion_count = 1;
 }
 inline void lock_release(Lock &lock) {
     lock.recursion_count--;
     if (lock.recursion_count == 0) {
-        lock.owner = std::thread::id();
+        lock.owner.store(std::thread::id(), std::memory_order_relaxed);
         lock.lock.unlock();
     }
 }

--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -266,16 +266,18 @@ void jitc_free(void *ptr) {
     auto [size, backend, shared, device] = alloc_info_decode(info);
     state.alloc_usage[(int) backend] -= size;
 
+    // Look up the thread-local record once and access all fields through it
+    ThreadLocal &tl = jitc_thread_local();
     ThreadState *ts = nullptr;
 
     switch (backend) {
 #if defined(DRJIT_ENABLE_CUDA)
-        case JitBackend::CUDA: ts = thread_state_cuda; break;
+        case JitBackend::CUDA: ts = tl.ts_cuda; break;
 #endif
 #if defined(DRJIT_ENABLE_METAL)
-        case JitBackend::Metal: ts = thread_state_metal; break;
+        case JitBackend::Metal: ts = tl.ts_metal; break;
 #endif
-        case JitBackend::LLVM: ts = thread_state_llvm; break;
+        case JitBackend::LLVM: ts = tl.ts_llvm; break;
         default: break;
     }
 
@@ -310,7 +312,7 @@ void jitc_free(void *ptr) {
         ReleaseRecord *rec2 = (ReleaseRecord *) malloc_check(sizeof(ReleaseRecord));
         *rec2 = rec;
         cuda_check(cuLaunchHostFunc(
-            thread_state_cuda->stream,
+            tl.ts_cuda->stream,
             [](void *p) { release_cb(p); free(p); },
             rec2));
     }

--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -8,21 +8,14 @@
  *  Format  Input          Example result    Description
  * --------------------------------------------------------------------------
  *  $u      uint32_t      `1234`             Decimal number (32 bit)
- *  $U      uint64_t      `1234`             Decimal number (64 bit)
- * --------------------------------------------------------------------------
- *  $x      uint32_t      `4d2`              Hexadecimal number (32 bit)
- *  $X      uint64_t      `4d2`              Hexadecimal number (64 bit)
- *  $Q      uint64_t      `00000000000004d2` Hex. number, 0-filled (64 bit)
  * --------------------------------------------------------------------------
  *  $s      const char *  `foo`              Zero-terminated string
- *  $c      char          `f`                A single ASCII character
  * --------------------------------------------------------------------------
  *  $t      Variable      `float`            Variable type
  * --------------------------------------------------------------------------
  *  $b      Variable      `uint`             Variable type, binary format
  * --------------------------------------------------------------------------
  *  $v      Variable      `r1234`            Variable name
- *  $a      Variable      `4`                Variable alignment in bytes
  * --------------------------------------------------------------------------
  *  $l      Variable      `0x1`              Literal value of variable (hex)
  *  $o      Variable      `2`                Index into ``params.args[]``
@@ -362,7 +355,7 @@ void jitc_metal_assemble(ThreadState *ts, ScheduledGroup group,
     // would duplicate entries and miss scenes reached only through callables.)
     for (size_t i = 0; i < metal_kernel_scenes.size(); ++i) {
         MetalScene *si = metal_kernel_scenes[i];
-        fmt("// Scene properties: scene_$u mask=0x$x fns=[",
+        fmt("// Scene properties: scene_$u mask=$u fns=[",
             (uint32_t) i, si ? si->geometry_types_mask : 0u);
         if (si) {
             for (size_t j = 0; j < si->intersection_fns.size(); ++j) {
@@ -1090,7 +1083,7 @@ static void jitc_metal_render(Variable *v) {
             Variable *smp_h = jitc_var(v->dep[1]);
             Variable *mask  = v->dep[2] ? jitc_var(v->dep[2]) : nullptr;
             TexData *td = (TexData *) v->data;
-            char comp = "xyzw"[td->component & 0x3u];
+            char comp[2] = { "xyzw"[td->component & 0x3u], '\0' };
 
             // For a masked fetch, default to zero and guard the gather with the
             // mask, so the compiler can predicate off the fetch for inactive lanes.
@@ -1100,7 +1093,7 @@ static void jitc_metal_render(Variable *v) {
             } else {
                 fmt("float4 $v_s = ", v);
             }
-            fmt("$v.gather($v, float2($v, $v), int2(0), component::$c);\n",
+            fmt("$v.gather($v, float2($v, $v), int2(0), component::$s);\n",
                 tex_h, smp_h, jitc_var(td->indices[0]),
                 jitc_var(td->indices[1]), comp);
 

--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -832,6 +832,12 @@ static void jitc_metal_render(Variable *v) {
                     fmt("$v = $v;\n", in, out);
             }
 
+            // Reset 'scratch' to not interfere with visited tracking in jit_eval()
+            for (uint32_t i = 0; i < size; ++i) {
+                jitc_var(ld->inner_in[i])->scratch = 0;
+                jitc_var(ld->inner_out[i])->scratch = 0;
+            }
+
             put("}\n");
             break;
         }

--- a/src/metal_eval.h
+++ b/src/metal_eval.h
@@ -11,12 +11,15 @@
 
 #include "common.h"
 
-#define fmt(fmt, ...) buffer.fmt_metal(count_args(__VA_ARGS__), fmt, ##__VA_ARGS__)
-#define put(...)      buffer.put(__VA_ARGS__)
+#define fmt(fmt, ...)                                                          \
+    buffer.fmt_metal(count_args(__VA_ARGS__), fmt_strlen(fmt), fmt,            \
+                     ##__VA_ARGS__)
+#define put(...) buffer.put(__VA_ARGS__)
 #define fmt_intrinsic(fmt, ...)                                                \
     do {                                                                       \
         size_t tmpoff = buffer.size();                                         \
-        buffer.fmt_metal(count_args(__VA_ARGS__), fmt, ##__VA_ARGS__);         \
+        buffer.fmt_metal(count_args(__VA_ARGS__), fmt_strlen(fmt), fmt,        \
+                         ##__VA_ARGS__);                                       \
         jitc_register_global(buffer.get() + tmpoff);                           \
         buffer.rewind_to(tmpoff);                                              \
     } while (0)

--- a/src/strbuf.cpp
+++ b/src/strbuf.cpp
@@ -4,12 +4,24 @@
 #include "eval.h"
 #include <cstdarg>
 
-/// Global string buffer used to generate PTX/LLVM IR
+/// Global string buffer used to generate PTX/LLVM IR or MSL
 StringBuffer buffer { 1024 };
 
-static const char num[] = "0123456789abcdef";
+// ============================================================================
+//  Free cursor-passing helpers used by the formatters. The w_*() functions
+//  write to a caller-held cursor and returns its new position.
+// ============================================================================
 
-// Two-digit lookup table for jeaii unsigned->decimal conversion
+// ============================================================================
+//  Decimal integer formatting
+// ============================================================================
+
+// Fixed-point fractional masks used by the division-free integer formatter.
+static const uint64_t mask24 = (1ull << 24) - 1,
+                      mask32 = (1ull << 32) - 1,
+                      mask57 = (1ull << 57) - 1;
+
+// Two-digit lookup table for jeaiii unsigned->decimal conversion
 static const char digit_pairs[201] =
     "00010203040506070809"
     "10111213141516171819"
@@ -22,7 +34,7 @@ static const char digit_pairs[201] =
     "80818283848586878889"
     "90919293949596979899";
 
-// Version with doubled leading  digits for values < 10
+// Version with doubled leading digits for values < 10
 static const char digit_pairs_lead[201] =
     "00112233445566778899"
     "10111213141516171819"
@@ -35,10 +47,198 @@ static const char digit_pairs_lead[201] =
     "80818283848586878889"
     "90919293949596979899";
 
-// Fixed-point fractional masks used by the division-free integer formatter.
-static const uint64_t mask24 = (1ull << 24) - 1,
-                      mask32 = (1ull << 32) - 1,
-                      mask57 = (1ull << 57) - 1;
+// Division-free unsigned to decimal conversion based on James Anhalt ("jeaiii",
+// https://github.com/jeaiii/itoa). A magnitude cascade produces a scaled
+// fixed-point number whose representation can be used to produce the output two
+// digits at a time. The 2-byte stores may spill one byte past the end, which
+// usage in StringBuffer permits.
+static inline char *w_u32(char *b, uint32_t n) {
+    if (n < 100) {
+        memcpy(b, &digit_pairs_lead[n * 2], 2);
+        return n < 10 ? b + 1 : b + 2;
+    }
+    if (n < 10000) {
+        uint32_t f0 = (uint32_t) (10 * (1 << 24) / 1e3 + 1) * n;
+        memcpy(b, &digit_pairs_lead[(f0 >> 24) * 2], 2);
+        b -= n < 1000;
+        uint32_t f2 = (f0 & mask24) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 24) * 2], 2);
+        return b + 4;
+    }
+    if (n < 1000000) {
+        uint64_t f0 = (uint64_t) (10 * (1ull << 32) / 1e5 + 1) * n;
+        memcpy(b, &digit_pairs_lead[(f0 >> 32) * 2], 2);
+        b -= n < 100000;
+        uint64_t f2 = (f0 & mask32) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 32) * 2], 2);
+        uint64_t f4 = (f2 & mask32) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 32) * 2], 2);
+        return b + 6;
+    }
+    if (n < 100000000) {
+        uint64_t f0 = (uint64_t) (10 * (1ull << 48) / 1e7 + 1) * n >> 16;
+        memcpy(b, &digit_pairs_lead[(f0 >> 32) * 2], 2);
+        b -= n < 10000000;
+        uint64_t f2 = (f0 & mask32) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 32) * 2], 2);
+        uint64_t f4 = (f2 & mask32) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 32) * 2], 2);
+        uint64_t f6 = (f4 & mask32) * 100; memcpy(b + 6, &digit_pairs[(f6 >> 32) * 2], 2);
+        return b + 8;
+    }
+    // 9-10 digits: a single fixed-point cascade scaled by 2^57.
+    uint64_t f0 = (uint64_t) (10 * (1ull << 57) / 1e9 + 1) * n;
+    memcpy(b, &digit_pairs_lead[(f0 >> 57) * 2], 2);
+    b -= n < 1000000000u;
+    uint64_t f2 = (f0 & mask57) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 57) * 2], 2);
+    uint64_t f4 = (f2 & mask57) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 57) * 2], 2);
+    uint64_t f6 = (f4 & mask57) * 100; memcpy(b + 6, &digit_pairs[(f6 >> 57) * 2], 2);
+    uint64_t f8 = (f6 & mask57) * 100; memcpy(b + 8, &digit_pairs[(f8 >> 57) * 2], 2);
+    return b + 10;
+}
+
+// Write 'z' in [0, 1e8) as eight zero-padded digits
+static inline void eight_digits(char *b, uint32_t z) {
+    uint64_t f0 = ((uint64_t) ((1ull << 48) / 1e6 + 1) * z >> 16) + 1;
+    memcpy(b, &digit_pairs[(f0 >> 32) * 2], 2);
+    uint64_t f2 = (f0 & mask32) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 32) * 2], 2);
+    uint64_t f4 = (f2 & mask32) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 32) * 2], 2);
+    uint64_t f6 = (f4 & mask32) * 100; memcpy(b + 6, &digit_pairs[(f6 >> 32) * 2], 2);
+}
+
+// 64-bit unsigned decimal to string conversion
+static inline char *w_u64(char *b, uint64_t value) {
+    if (value <= 0xFFFFFFFFull)
+        return w_u32(b, (uint32_t) value);
+    uint32_t z = (uint32_t) (value % 100000000u);
+    b = w_u64(b, value / 100000000u);
+    eight_digits(b, z);
+    return b + 8;
+}
+
+// ============================================================================
+//  Hexadecimal integer formatting
+// ============================================================================
+
+static const char num[] = "0123456789abcdef";
+
+// Byte -> two lowercase hex chars, for two-digit-at-a-time hex conversion.
+static const char hex_pairs[513] =
+    "000102030405060708090a0b0c0d0e0f"
+    "101112131415161718191a1b1c1d1e1f"
+    "202122232425262728292a2b2c2d2e2f"
+    "303132333435363738393a3b3c3d3e3f"
+    "404142434445464748494a4b4c4d4e4f"
+    "505152535455565758595a5b5c5d5e5f"
+    "606162636465666768696a6b6c6d6e6f"
+    "707172737475767778797a7b7c7d7e7f"
+    "808182838485868788898a8b8c8d8e8f"
+    "909192939495969798999a9b9c9d9e9f"
+    "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"
+    "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+    "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+    "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
+    "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+    "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
+
+// Number of hex digits needed to represent a value.
+static inline unsigned hex_digits(uint64_t v) {
+#if defined(_MSC_VER)
+    unsigned long i;
+    if (!_BitScanReverse64(&i, v)) return 1;
+    return ((unsigned) i >> 2) + 1;
+#else
+    return v ? ((64u - (unsigned) __builtin_clzll(v) + 3) >> 2) : 1;
+#endif
+}
+
+// 64-bit unsigned to hexadecimal string conversion
+static inline char *w_x64(char *d, uint64_t value) {
+    char *end = d + hex_digits(value), *p = end;
+    while (value >= 0x100) {
+        unsigned b = (unsigned) (value & 0xff);
+        p -= 2;
+        memcpy(p, &hex_pairs[b * 2], 2);
+        value >>= 8;
+    }
+    if (value < 0x10)
+        *--p = num[(unsigned) value];
+    else
+        memcpy(p - 2, &hex_pairs[(unsigned) value * 2], 2);
+    return end;
+}
+
+// 32-bit unsigned to hexadecimal string conversion
+static inline char *w_x32(char *d, uint32_t value) {
+    return w_x64(d, value); // fall back to 64 case
+}
+
+// 64-bit unsigned to hexadecimal string conversion with zero padding (16 digits)
+static inline char *w_q64(char *d, uint64_t value) {
+    for (int i = 7; i >= 0; --i) {
+        unsigned b = (unsigned) (value & 0xff);
+        memcpy(d + i * 2, &hex_pairs[b * 2], 2);
+        value >>= 8;
+    }
+    return d + 16;
+}
+
+// ============================================================================
+//  String copying
+// ============================================================================
+
+// Append a short string of unknown length
+static inline char *w_str(char *d, const char *str) {
+    char c;
+    while ((c = *str++) != '\0')
+        *d++ = c;
+    return d;
+}
+
+// Copy a string of known length through the cursor.
+static inline char *w_strn(char *d, const char *str, size_t n) {
+    memcpy(d, str, n);
+    return d + n;
+}
+
+// Copy plain characters from 'p' up to the next '$' (or 'end'),
+// advancing 8 bytes at a time using a SWAR test when possible.
+static inline char *w_run(char *d, const char *&p, const char *end) {
+    const uint64_t dollar = 0x2424242424242424ull; // '$' broadcast
+    while (end - p >= 8) {
+        uint64_t w; memcpy(&w, p, 8);
+        memcpy(d, &w, 8);
+        uint64_t x = w ^ dollar;
+        uint64_t m = (x - 0x0101010101010101ull) & ~x & 0x8080808080808080ull;
+        if (m) {
+            unsigned n = (unsigned) (__builtin_ctzll(m) >> 3);
+            p += n;
+            return d + n;
+        }
+        p += 8; d += 8;
+    }
+    while (p < end && *p != '$')
+        *d++ = *p++;
+    return d;
+}
+
+// ============================================================================
+//  Output-size bound for the single-pass formatters
+// ============================================================================
+
+// Worst-case output length of a format spanning 'fmt_len' characters and
+// consuming 'nargs' arguments.
+//
+// Each format character expands to at most 8 bytes of fixed directive text; the
+// binding case is the widest zero-argument directive, '$z' = "zeroinitializer"
+// (15 bytes from 2 characters, and 2*8 >= 15). Each argument expands to at most
+// 48 bytes (the widest, '$V', needs ~35). The bound is deliberately loose:
+// over-reserving is free, undercounting would overflow the unchecked writes.
+//
+// The size of an arbitrary string insertion ('$s') cannot be upper-bounded,
+// so this calculation must be revisited when one is encountered.
+static inline size_t fmt_bound(size_t fmt_len, size_t nargs) {
+    return fmt_len * 8 + nargs * 48;
+}
+
+// ============================================================================
+//  StringBuffer methods
+// ============================================================================
 
 StringBuffer::StringBuffer(size_t capacity)
     : m_start(nullptr), m_cur(nullptr), m_end(nullptr) {
@@ -114,7 +314,9 @@ void StringBuffer::swap(StringBuffer &b) {
     std::swap(m_end, b.m_end);
 }
 
-void StringBuffer::expand(size_t nbytes) {
+char *StringBuffer::expand(char *cur, size_t nbytes) {
+    m_cur = cur;
+
     // Ensure that that there is space for a trailing zero character
     nbytes += 1;
 
@@ -133,140 +335,37 @@ void StringBuffer::expand(size_t nbytes) {
         m_end = m_start + new_capacity;
         m_cur = m_start + len;
     }
-}
 
-static void reverse_str(char *start, char *end) {
-    end--;
-    while (start < end) {
-        char tmp = *start;
-        *start = *end;
-        *end = tmp;
-        ++start; --end;
-    }
-}
-
-// Division-free unsigned to decimal conversion based on James Anhalt ("jeaiii",
-// https://github.com/jeaiii/itoa). A magnitude cascade produces a a scaled
-// fixed-point number whose representation can be used to produce the output two
-// digits at a time. The 2-byte stores may spill one byte past the end, which
-// usage in StringBuffer permits.
-static inline char *w_u32(char *b, uint32_t n) {
-    if (n < 100) {
-        memcpy(b, &digit_pairs_lead[n * 2], 2);
-        return n < 10 ? b + 1 : b + 2;
-    }
-    if (n < 10000) {
-        uint32_t f0 = (uint32_t) (10 * (1 << 24) / 1e3 + 1) * n;
-        memcpy(b, &digit_pairs_lead[(f0 >> 24) * 2], 2);
-        b -= n < 1000;
-        uint32_t f2 = (f0 & mask24) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 24) * 2], 2);
-        return b + 4;
-    }
-    if (n < 1000000) {
-        uint64_t f0 = (uint64_t) (10 * (1ull << 32) / 1e5 + 1) * n;
-        memcpy(b, &digit_pairs_lead[(f0 >> 32) * 2], 2);
-        b -= n < 100000;
-        uint64_t f2 = (f0 & mask32) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 32) * 2], 2);
-        uint64_t f4 = (f2 & mask32) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 32) * 2], 2);
-        return b + 6;
-    }
-    if (n < 100000000) {
-        uint64_t f0 = (uint64_t) (10 * (1ull << 48) / 1e7 + 1) * n >> 16;
-        memcpy(b, &digit_pairs_lead[(f0 >> 32) * 2], 2);
-        b -= n < 10000000;
-        uint64_t f2 = (f0 & mask32) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 32) * 2], 2);
-        uint64_t f4 = (f2 & mask32) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 32) * 2], 2);
-        uint64_t f6 = (f4 & mask32) * 100; memcpy(b + 6, &digit_pairs[(f6 >> 32) * 2], 2);
-        return b + 8;
-    }
-    // 9-10 digits: a single fixed-point cascade scaled by 2^57.
-    uint64_t f0 = (uint64_t) (10 * (1ull << 57) / 1e9 + 1) * n;
-    memcpy(b, &digit_pairs_lead[(f0 >> 57) * 2], 2);
-    b -= n < 1000000000u;
-    uint64_t f2 = (f0 & mask57) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 57) * 2], 2);
-    uint64_t f4 = (f2 & mask57) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 57) * 2], 2);
-    uint64_t f6 = (f4 & mask57) * 100; memcpy(b + 6, &digit_pairs[(f6 >> 57) * 2], 2);
-    uint64_t f8 = (f6 & mask57) * 100; memcpy(b + 8, &digit_pairs[(f8 >> 57) * 2], 2);
-    return b + 10;
-}
-
-// Write 'z' in [0, 1e8) as eight zero-padded digits, division-free (jeaiii).
-static inline void eight_digits(char *b, uint32_t z) {
-    uint64_t f0 = ((uint64_t) ((1ull << 48) / 1e6 + 1) * z >> 16) + 1;
-    memcpy(b, &digit_pairs[(f0 >> 32) * 2], 2);
-    uint64_t f2 = (f0 & mask32) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 32) * 2], 2);
-    uint64_t f4 = (f2 & mask32) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 32) * 2], 2);
-    uint64_t f6 = (f4 & mask32) * 100; memcpy(b + 6, &digit_pairs[(f6 >> 32) * 2], 2);
-}
-
-// 64-bit unsigned decimal to string conversion based on the jeaiii implementation
-static inline char *w_u64(char *b, uint64_t value) {
-    if (value <= 0xFFFFFFFFull)
-        return w_u32(b, (uint32_t) value);
-    uint32_t z = (uint32_t) (value % 100000000u);
-    b = w_u64(b, value / 100000000u);
-    eight_digits(b, z);
-    return b + 8;
+    return m_cur;
 }
 
 void StringBuffer::put_u32(uint32_t value) {
     if (unlikely(!m_cur || m_cur + MAXSIZE_U32 >= m_end))
-        expand(MAXSIZE_U32);
+        m_cur = expand(m_cur, MAXSIZE_U32);
     put_u32_unchecked(value);
 }
 
 void StringBuffer::put_u64(uint64_t value) {
     if (unlikely(!m_cur || m_cur + MAXSIZE_U64 >= m_end))
-        expand(MAXSIZE_U64);
+        m_cur = expand(m_cur, MAXSIZE_U64);
     put_u64_unchecked(value);
 }
 
-
 void StringBuffer::put_x32(uint32_t value) {
     if (unlikely(!m_cur || m_cur + MAXSIZE_X32 >= m_end))
-        expand(MAXSIZE_X32);
+        m_cur = expand(m_cur, MAXSIZE_X32);
     put_x32_unchecked(value);
 }
 
 void StringBuffer::put_x64(uint64_t value) {
     if (unlikely(!m_cur || m_cur + MAXSIZE_X64 >= m_end))
-        expand(MAXSIZE_X64);
+        m_cur = expand(m_cur, MAXSIZE_X64);
     put_x64_unchecked(value);
 }
 
 void StringBuffer::put_u32_unchecked(uint32_t value) { m_cur = w_u32(m_cur, value); }
 
 void StringBuffer::put_u64_unchecked(uint64_t value) { m_cur = w_u64(m_cur, value); }
-
-// Cursor-passing cores of the hex/string writers, returning the advanced cursor.
-static inline char *w_x32(char *d, uint32_t value) {
-    char *start = d;
-    do { *d++ = num[value % 16]; value /= 16; } while (value);
-    reverse_str(start, d);
-    return d;
-}
-
-static inline char *w_x64(char *d, uint64_t value) {
-    char *start = d;
-    do { *d++ = num[value % 16]; value /= 16; } while (value);
-    reverse_str(start, d);
-    return d;
-}
-
-static inline char *w_q64(char *d, uint64_t value) {
-    for (uint32_t i = 0; i < 16; ++i) {
-        *(d + 15 - i) = num[value % 16];
-        value /= 16;
-    }
-    return d + 16;
-}
-
-static inline char *w_str(char *d, const char *str) {
-    char c;
-    while ((c = *str++) != '\0')
-        *d++ = c;
-    return d;
-}
 
 void StringBuffer::put_x32_unchecked(uint32_t value) { m_cur = w_x32(m_cur, value); }
 
@@ -295,7 +394,7 @@ size_t StringBuffer::fmt(const char *fmt, ...) {
             m_cur += rv;
             return (size_t) rv;
         } else {
-            expand((size_t) rv);
+            m_cur = expand(m_cur, (size_t) rv);
         }
     } while (true);
 }
@@ -320,7 +419,7 @@ size_t StringBuffer::vfmt(const char *fmt, va_list args_) {
             m_cur += rv;
             return (size_t) rv;
         } else {
-            expand((size_t) rv);
+            m_cur = expand(m_cur, (size_t) rv);
         }
     } while (true);
 }
@@ -329,42 +428,39 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
     va_list args2;
     va_start(args2, fmt);
 
-    // Bound the maximum output size: every directive other than the unbounded
-    // '$s' expands to at most 8 bytes per format character + 48 bytes per
-    // argument; '$s' grows the buffer on demand below.
-    size_t bound = fmt_len * 8 + nargs * 48;
+    // Bound the maximum output size needed by the format string and arguments
+    size_t bound = fmt_bound(fmt_len, nargs);
     if (unlikely(!m_cur || m_cur + bound >= m_end))
-        expand(bound);
+        m_cur = expand(m_cur, bound);
 
-    // Convert the format string
-    const char *p = fmt;
+    const char *p = fmt, *fmt_end = fmt + fmt_len;
     char *cur = m_cur;
-    char c;
-    while ((c = *p++) != '\0') {
-        // Fast path, plain copy
-        if (likely(c != '$')) {
-            *cur++ = c;
-            continue;
-        }
+    size_t arg = 0;
+    while (p < fmt_end) {
+        cur = w_run(cur, p, fmt_end);
+        if (p == fmt_end)
+            break;
+        ++p; // consume '$'
 
-        // '$' directive: writes go through 'cur' via the w_*() helpers; only
-        // '$s' (put()/expand()) touches the m_cur member.
         switch (*p++) {
             case 'u': cur = w_u32(cur, va_arg(args2, uint32_t)); break;
+
             case 's': {
                     const char *s = va_arg(args2, const char *);
-                    m_cur = cur;
-                    put(s, strlen(s));
-                    // '$s' is unbounded: put() may have grown the buffer, so
-                    // re-reserve the headroom the unchecked writes assume.
-                    if (unlikely(m_cur + bound >= m_end))
-                        expand(bound);
-                    cur = m_cur;
+                    // Inserting an arbitrary string might break the previous upper bound.
+                    // Re-bound the maximum output size of the remaining fmt string and
+                    // argument count and potentially allocate additional memory.
+                    size_t rest = fmt_bound((size_t) (fmt_end - p), nargs - arg - 1);
+                    size_t len = strlen(s);
+                    if (unlikely(cur + len + rest >= m_end))
+                        cur = expand(cur, len + rest);
+                    cur = w_strn(cur, s, len);
                 }
                 break;
 
             case 'w':
                 cur = w_u32(cur, jitc_llvm_vector_width);
+                --arg;
                 break;
 
             case 't': {
@@ -497,7 +593,7 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                     } else {
                         cur = w_u64(cur, literal);
                     }
-                };
+                }
                 break;
 
             case 'a': {
@@ -520,6 +616,7 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
 
             case 'z':
                 cur = w_str(cur, "zeroinitializer");
+                --arg;
                 break;
 
             case '<':
@@ -528,11 +625,13 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                     cur = w_u32(cur, jitc_llvm_vector_width);
                     *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
                 }
+                --arg;
                 break;
 
             case '>':
                 if (callable_depth > 0)
                     *cur++ = '>';
+                --arg;
                 break;
 
             default:
@@ -541,11 +640,20 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                         "character \"$%c\" in format string!\n", p[-1]);
                 abort();
         }
+
+        ++arg;
     }
     va_end(args2);
 
+    if (unlikely(arg != nargs)) {
+        fprintf(stderr,
+                "StringBuffer::fmt_llvm(): given %zu args, format string "
+                "accessed %zu (%s)\n", nargs, arg, fmt);
+        abort();
+    }
+
+    *cur = '\0';
     m_cur = cur;
-    *m_cur = '\0';
 }
 
 #if defined(DRJIT_ENABLE_CUDA)
@@ -553,37 +661,35 @@ void StringBuffer::fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...) 
     va_list args2;
     va_start(args2, fmt);
 
-    // Bound the maximum output size; see fmt_llvm().
-    size_t bound = fmt_len * 8 + nargs * 48;
+    // Bound the maximum output size needed by the format string and arguments
+    size_t bound = fmt_bound(fmt_len, nargs);
     if (unlikely(!m_cur || m_cur + bound >= m_end))
-        expand(bound);
+        m_cur = expand(m_cur, bound);
 
-    // Convert the format string
-    const char *p = fmt;
+    const char *p = fmt, *fmt_end = fmt + fmt_len;
     char *cur = m_cur;
-    char c;
-    while ((c = *p++) != '\0') {
-        // Fast path, plain copy
-        if (likely(c != '$')) {
-            *cur++ = c;
-            continue;
-        }
+    size_t arg = 0;
+    while (p < fmt_end) {
+        cur = w_run(cur, p, fmt_end);
+        if (p == fmt_end)
+            break;
+        ++p; // consume '$'
 
-        // '$' directive: writes go through 'cur' via the w_*() helpers; only
-        // '$s' (put()/expand()) touches the m_cur member.
         switch (*p++) {
             case 'u': cur = w_u32(cur, va_arg(args2, uint32_t)); break;
+
             case 'Q': cur = w_q64(cur, va_arg(args2, uint64_t)); break;
 
             case 's': {
                     const char *s = va_arg(args2, const char *);
-                    m_cur = cur;
-                    put(s, strlen(s));
-                    // '$s' is unbounded: put() may have grown the buffer, so
-                    // re-reserve the headroom the unchecked writes below assume.
-                    if (unlikely(m_cur + bound >= m_end))
-                        expand(bound);
-                    cur = m_cur;
+                    // Inserting an arbitrary string might break the previous upper bound.
+                    // Re-bound the maximum output size of the remaining fmt string and
+                    // argument count and potentially allocate additional memory.
+                    size_t rest = fmt_bound((size_t) (fmt_end - p), nargs - arg - 1);
+                    size_t len = strlen(s);
+                    if (unlikely(cur + len + rest >= m_end))
+                        cur = expand(cur, len + rest);
+                    cur = w_strn(cur, s, len);
                 }
                 break;
 
@@ -628,7 +734,7 @@ void StringBuffer::fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                     *cur++ = '0';
                     *cur++ = 'x';
                     cur = w_x64(cur, v->literal);
-                };
+                }
                 break;
 
             case 'a': {
@@ -649,11 +755,20 @@ void StringBuffer::fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                         "character \"$%c\" in format string!\n", p[-1]);
                 abort();
         }
+
+        ++arg;
     }
     va_end(args2);
 
+    if (unlikely(arg != nargs)) {
+        fprintf(stderr,
+                "StringBuffer::fmt_cuda(): given %zu args, format string "
+                "accessed %zu (%s)\n", nargs, arg, fmt);
+        abort();
+    }
+
+    *cur = '\0';
     m_cur = cur;
-    *m_cur = '\0';
 }
 #endif
 
@@ -662,34 +777,33 @@ void StringBuffer::fmt_metal(size_t nargs, size_t fmt_len, const char *fmt, ...)
     va_list args2;
     va_start(args2, fmt);
 
-    // Bound the maximum output size; see fmt_llvm().
-    size_t bound = fmt_len * 8 + nargs * 48;
+    // Bound the maximum output size needed by the format string and arguments
+    size_t bound = fmt_bound(fmt_len, nargs);
     if (unlikely(!m_cur || m_cur + bound >= m_end))
-        expand(bound);
+        m_cur = expand(m_cur, bound);
 
-    // Emit the formatted string
-    const char *p = fmt;
+    const char *p = fmt, *fmt_end = fmt + fmt_len;
     char *cur = m_cur;
-    char c;
-    while ((c = *p++) != '\0') {
-        // Fast path, plain copy
-        if (likely(c != '$')) {
-            *cur++ = c;
-            continue;
-        }
+    size_t arg = 0;
+    while (p < fmt_end) {
+        cur = w_run(cur, p, fmt_end);
+        if (p == fmt_end)
+            break;
+        ++p; // consume '$'
 
         switch (*p++) {
             case 'u': cur = w_u32(cur, va_arg(args2, uint32_t)); break;
 
             case 's': {
                     const char *s = va_arg(args2, const char *);
-                    m_cur = cur;
-                    put(s, strlen(s));
-                    // '$s' is unbounded: put() may have grown the buffer, so
-                    // re-reserve the headroom the unchecked writes below assume.
-                    if (unlikely(m_cur + bound >= m_end))
-                        expand(bound);
-                    cur = m_cur;
+                    // Inserting an arbitrary string might break the previous upper bound.
+                    // Re-bound the maximum output size of the remaining fmt string and
+                    // argument count and potentially allocate additional memory.
+                    size_t rest = fmt_bound((size_t) (fmt_end - p), nargs - arg - 1);
+                    size_t len = strlen(s);
+                    if (unlikely(cur + len + rest >= m_end))
+                        cur = expand(cur, len + rest);
+                    cur = w_strn(cur, s, len);
                 }
                 break;
 
@@ -732,10 +846,19 @@ void StringBuffer::fmt_metal(size_t nargs, size_t fmt_len, const char *fmt, ...)
                         "character \"$%c\" in format string!\n", p[-1]);
                 abort();
         }
+
+        ++arg;
     }
     va_end(args2);
 
+    if (unlikely(arg != nargs)) {
+        fprintf(stderr,
+                "StringBuffer::fmt_metal(): given %zu args, format string "
+                "accessed %zu (%s)\n", nargs, arg, fmt);
+        abort();
+    }
+
+    *cur = '\0';
     m_cur = cur;
-    *m_cur = '\0';
 }
 #endif

--- a/src/strbuf.cpp
+++ b/src/strbuf.cpp
@@ -336,9 +336,17 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
 
     // Convert the format string
     const char *p = fmt;
+    char *cur = m_cur;
     char c;
     while ((c = *p++) != '\0') {
-        if (c == '$') {
+        // Fast path, plain copy
+        if (likely(c != '$')) {
+            *cur++ = c;
+            continue;
+        }
+
+        m_cur = cur;
+        {
             switch (*p++) {
                 case 'u': put_u32_unchecked(va_arg(args2, uint32_t)); break;
                 case 's': {
@@ -530,12 +538,14 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                             "character \"$%c\" in format string!\n", p[-1]);
                     abort();
             }
-        } else {
-            *m_cur ++= c;
         }
+
+        // Update 'cur' in case one of the put_*() functions overwrote it
+        cur = m_cur;
     }
     va_end(args2);
 
+    m_cur = cur;
     *m_cur = '\0';
 }
 
@@ -551,9 +561,17 @@ void StringBuffer::fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...) 
 
     // Convert the format string
     const char *p = fmt;
+    char *cur = m_cur;
     char c;
     while ((c = *p++) != '\0') {
-        if (c == '$') {
+        // Fast path, plain copy
+        if (likely(c != '$')) {
+            *cur++ = c;
+            continue;
+        }
+
+        m_cur = cur;
+        {
             switch (*p++) {
                 case 'u': put_u32_unchecked(va_arg(args2, uint32_t)); break;
                 case 'Q': put_q64_unchecked(va_arg(args2, uint64_t)); break;
@@ -631,12 +649,14 @@ void StringBuffer::fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                             "character \"$%c\" in format string!\n", p[-1]);
                     abort();
             }
-        } else {
-            *m_cur ++= c;
         }
+
+        // Update 'cur' in case one of the put_*() functions overwrote it
+        cur = m_cur;
     }
     va_end(args2);
 
+    m_cur = cur;
     *m_cur = '\0';
 }
 #endif
@@ -653,9 +673,17 @@ void StringBuffer::fmt_metal(size_t nargs, size_t fmt_len, const char *fmt, ...)
 
     // Emit the formatted string
     const char *p = fmt;
+    char *cur = m_cur;
     char c;
     while ((c = *p++) != '\0') {
-        if (c == '$') {
+        // Fast path, plain copy
+        if (likely(c != '$')) {
+            *cur++ = c;
+            continue;
+        }
+
+        m_cur = cur;
+        {
             switch (*p++) {
                 case 'u': put_u32_unchecked(va_arg(args2, uint32_t)); break;
 
@@ -709,12 +737,14 @@ void StringBuffer::fmt_metal(size_t nargs, size_t fmt_len, const char *fmt, ...)
                             "character \"$%c\" in format string!\n", p[-1]);
                     abort();
             }
-        } else {
-            *m_cur++ = c;
         }
+
+        // Update 'cur' in case one of the put_*() functions overwrote it
+        cur = m_cur;
     }
     va_end(args2);
 
+    m_cur = cur;
     *m_cur = '\0';
 }
 #endif

--- a/src/strbuf.cpp
+++ b/src/strbuf.cpp
@@ -4,16 +4,12 @@
 #include "eval.h"
 #include <cstdarg>
 
-#if defined(_MSC_VER)
-#  include <intrin.h>
-#endif
-
 /// Global string buffer used to generate PTX/LLVM IR
 StringBuffer buffer { 1024 };
 
 static const char num[] = "0123456789abcdef";
 
-// Two-digit lookup table ("00010203...99") for fast unsigned->decimal conversion
+// Two-digit lookup table for jeaii unsigned->decimal conversion
 static const char digit_pairs[201] =
     "00010203040506070809"
     "10111213141516171819"
@@ -26,54 +22,23 @@ static const char digit_pairs[201] =
     "80818283848586878889"
     "90919293949596979899";
 
-static const uint32_t pow10_u32[10] = {
-    0, 10, 100, 1000, 10000,
-    100000, 1000000, 10000000, 100000000, 1000000000
-};
+// Version with doubled leading  digits for values < 10
+static const char digit_pairs_lead[201] =
+    "00112233445566778899"
+    "10111213141516171819"
+    "20212223242526272829"
+    "30313233343536373839"
+    "40414243444546474849"
+    "50515253545556575859"
+    "60616263646566676869"
+    "70717273747576777879"
+    "80818283848586878889"
+    "90919293949596979899";
 
-static const uint64_t pow10_u64[20] = {
-    0ull, 10ull, 100ull, 1000ull, 10000ull, 100000ull, 1000000ull,
-    10000000ull, 100000000ull, 1000000000ull, 10000000000ull, 100000000000ull,
-    1000000000000ull, 10000000000000ull, 100000000000000ull, 1000000000000000ull,
-    10000000000000000ull, 100000000000000000ull, 1000000000000000000ull,
-    10000000000000000000ull
-};
-
-// Bit length of a *nonzero* 32-bit integer
-static inline unsigned bit_length(uint32_t n) {
-#if defined(_MSC_VER)
-    unsigned long i;
-    _BitScanReverse(&i, (unsigned long) n);
-    return (unsigned) i + 1;
-#else
-    return 32u - (unsigned) __builtin_clz(n);
-#endif
-}
-
-// Bit length of a *nonzero* 64-bit integer
-static inline unsigned bit_length(uint64_t n) {
-#if defined(_MSC_VER)
-    unsigned long i;
-    _BitScanReverse64(&i, n);
-    return (unsigned) i + 1;
-#else
-    return 64u - (unsigned) __builtin_clzll(n);
-#endif
-}
-
-// Number of decimal digits of a 32-bit unsigned value
-static inline unsigned digits10(uint32_t n) {
-    unsigned bits = bit_length(n | 1);
-    unsigned t = (bits * 1233) >> 12;
-    return t + 1 - (n < pow10_u32[t]);
-}
-
-// Number of decimal digits of a 64-bit unsigned value
-static inline unsigned digits10(uint64_t n) {
-    unsigned bits = bit_length(n | 1);
-    unsigned t = (bits * 1233) >> 12;
-    return t + 1 - (n < pow10_u64[t]);
-}
+// Fixed-point fractional masks used by the division-free integer formatter.
+static const uint64_t mask24 = (1ull << 24) - 1,
+                      mask32 = (1ull << 32) - 1,
+                      mask57 = (1ull << 57) - 1;
 
 StringBuffer::StringBuffer(size_t capacity)
     : m_start(nullptr), m_cur(nullptr), m_end(nullptr) {
@@ -180,6 +145,70 @@ static void reverse_str(char *start, char *end) {
     }
 }
 
+// Division-free unsigned to decimal conversion based on James Anhalt ("jeaiii",
+// https://github.com/jeaiii/itoa). A magnitude cascade produces a a scaled
+// fixed-point number whose representation can be used to produce the output two
+// digits at a time. The 2-byte stores may spill one byte past the end, which
+// usage in StringBuffer permits.
+static inline char *w_u32(char *b, uint32_t n) {
+    if (n < 100) {
+        memcpy(b, &digit_pairs_lead[n * 2], 2);
+        return n < 10 ? b + 1 : b + 2;
+    }
+    if (n < 10000) {
+        uint32_t f0 = (uint32_t) (10 * (1 << 24) / 1e3 + 1) * n;
+        memcpy(b, &digit_pairs_lead[(f0 >> 24) * 2], 2);
+        b -= n < 1000;
+        uint32_t f2 = (f0 & mask24) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 24) * 2], 2);
+        return b + 4;
+    }
+    if (n < 1000000) {
+        uint64_t f0 = (uint64_t) (10 * (1ull << 32) / 1e5 + 1) * n;
+        memcpy(b, &digit_pairs_lead[(f0 >> 32) * 2], 2);
+        b -= n < 100000;
+        uint64_t f2 = (f0 & mask32) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 32) * 2], 2);
+        uint64_t f4 = (f2 & mask32) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 32) * 2], 2);
+        return b + 6;
+    }
+    if (n < 100000000) {
+        uint64_t f0 = (uint64_t) (10 * (1ull << 48) / 1e7 + 1) * n >> 16;
+        memcpy(b, &digit_pairs_lead[(f0 >> 32) * 2], 2);
+        b -= n < 10000000;
+        uint64_t f2 = (f0 & mask32) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 32) * 2], 2);
+        uint64_t f4 = (f2 & mask32) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 32) * 2], 2);
+        uint64_t f6 = (f4 & mask32) * 100; memcpy(b + 6, &digit_pairs[(f6 >> 32) * 2], 2);
+        return b + 8;
+    }
+    // 9-10 digits: a single fixed-point cascade scaled by 2^57.
+    uint64_t f0 = (uint64_t) (10 * (1ull << 57) / 1e9 + 1) * n;
+    memcpy(b, &digit_pairs_lead[(f0 >> 57) * 2], 2);
+    b -= n < 1000000000u;
+    uint64_t f2 = (f0 & mask57) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 57) * 2], 2);
+    uint64_t f4 = (f2 & mask57) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 57) * 2], 2);
+    uint64_t f6 = (f4 & mask57) * 100; memcpy(b + 6, &digit_pairs[(f6 >> 57) * 2], 2);
+    uint64_t f8 = (f6 & mask57) * 100; memcpy(b + 8, &digit_pairs[(f8 >> 57) * 2], 2);
+    return b + 10;
+}
+
+// Write 'z' in [0, 1e8) as eight zero-padded digits, division-free (jeaiii).
+static inline void eight_digits(char *b, uint32_t z) {
+    uint64_t f0 = ((uint64_t) ((1ull << 48) / 1e6 + 1) * z >> 16) + 1;
+    memcpy(b, &digit_pairs[(f0 >> 32) * 2], 2);
+    uint64_t f2 = (f0 & mask32) * 100; memcpy(b + 2, &digit_pairs[(f2 >> 32) * 2], 2);
+    uint64_t f4 = (f2 & mask32) * 100; memcpy(b + 4, &digit_pairs[(f4 >> 32) * 2], 2);
+    uint64_t f6 = (f4 & mask32) * 100; memcpy(b + 6, &digit_pairs[(f6 >> 32) * 2], 2);
+}
+
+// 64-bit unsigned decimal to string conversion based on the jeaiii implementation
+static inline char *w_u64(char *b, uint64_t value) {
+    if (value <= 0xFFFFFFFFull)
+        return w_u32(b, (uint32_t) value);
+    uint32_t z = (uint32_t) (value % 100000000u);
+    b = w_u64(b, value / 100000000u);
+    eight_digits(b, z);
+    return b + 8;
+}
+
 void StringBuffer::put_u32(uint32_t value) {
     if (unlikely(!m_cur || m_cur + MAXSIZE_U32 >= m_end))
         expand(MAXSIZE_U32);
@@ -205,74 +234,47 @@ void StringBuffer::put_x64(uint64_t value) {
     put_x64_unchecked(value);
 }
 
-void StringBuffer::put_u32_unchecked(uint32_t value) {
-    unsigned n = digits10(value);
-    char *end = m_cur + n, *p = end;
-    while (value >= 100) {
-        unsigned idx = (value % 100) * 2;
-        value /= 100;
-        p -= 2;
-        memcpy(p, &digit_pairs[idx], 2);
-    }
-    if (value < 10)
-        *--p = (char) ('0' + value);
-    else
-        memcpy(p - 2, &digit_pairs[value * 2], 2);
-    m_cur = end;
+void StringBuffer::put_u32_unchecked(uint32_t value) { m_cur = w_u32(m_cur, value); }
+
+void StringBuffer::put_u64_unchecked(uint64_t value) { m_cur = w_u64(m_cur, value); }
+
+// Cursor-passing cores of the hex/string writers, returning the advanced cursor.
+static inline char *w_x32(char *d, uint32_t value) {
+    char *start = d;
+    do { *d++ = num[value % 16]; value /= 16; } while (value);
+    reverse_str(start, d);
+    return d;
 }
 
-void StringBuffer::put_u64_unchecked(uint64_t value) {
-    unsigned n = digits10(value);
-    char *end = m_cur + n, *p = end;
-    while (value >= 100) {
-        unsigned idx = (unsigned) (value % 100) * 2;
-        value /= 100;
-        p -= 2;
-        memcpy(p, &digit_pairs[idx], 2);
-    }
-    if (value < 10)
-        *--p = (char) ('0' + value);
-    else
-        memcpy(p - 2, &digit_pairs[(unsigned) value * 2], 2);
-    m_cur = end;
+static inline char *w_x64(char *d, uint64_t value) {
+    char *start = d;
+    do { *d++ = num[value % 16]; value /= 16; } while (value);
+    reverse_str(start, d);
+    return d;
 }
 
-void StringBuffer::put_x32_unchecked(uint32_t value) {
-    char *start = m_cur;
-    do {
-        *m_cur++ = num[value % 16];
-        value /= 16;
-    } while (value);
-
-    reverse_str(start, m_cur);
-}
-
-void StringBuffer::put_x64_unchecked(uint64_t value) {
-    char *start = m_cur;
-    do {
-        *m_cur++ = num[value % 16];
-        value /= 16;
-    } while (value);
-
-    reverse_str(start, m_cur);
-}
-
-void StringBuffer::put_q64_unchecked(uint64_t value) {
+static inline char *w_q64(char *d, uint64_t value) {
     for (uint32_t i = 0; i < 16; ++i) {
-        *(m_cur + 15 - i) = num[value % 16];
+        *(d + 15 - i) = num[value % 16];
         value /= 16;
     }
-    m_cur += 16;
+    return d + 16;
 }
 
-void StringBuffer::put_unchecked(const char *str) {
-    while (true) {
-        char c = *str++;
-        if (!c)
-            break;
-        *m_cur++ = c;
-    }
+static inline char *w_str(char *d, const char *str) {
+    char c;
+    while ((c = *str++) != '\0')
+        *d++ = c;
+    return d;
 }
+
+void StringBuffer::put_x32_unchecked(uint32_t value) { m_cur = w_x32(m_cur, value); }
+
+void StringBuffer::put_x64_unchecked(uint64_t value) { m_cur = w_x64(m_cur, value); }
+
+void StringBuffer::put_q64_unchecked(uint64_t value) { m_cur = w_q64(m_cur, value); }
+
+void StringBuffer::put_unchecked(const char *str) { m_cur = w_str(m_cur, str); }
 
 size_t StringBuffer::fmt(const char *fmt, ...) {
     do {
@@ -345,203 +347,200 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
             continue;
         }
 
-        m_cur = cur;
-        {
-            switch (*p++) {
-                case 'u': put_u32_unchecked(va_arg(args2, uint32_t)); break;
-                case 's': {
-                        const char *s = va_arg(args2, const char *);
-                        put(s, strlen(s));
-                        // '$s' is the only unbounded directive: 'put()' grew the
-                        // buffer to fit the string, so restore the worst-case
-                        // headroom assumed by the unchecked writes that follow.
-                        if (unlikely(m_cur + bound >= m_end))
-                            expand(bound);
+        // '$' directive: writes go through 'cur' via the w_*() helpers; only
+        // '$s' (put()/expand()) touches the m_cur member.
+        switch (*p++) {
+            case 'u': cur = w_u32(cur, va_arg(args2, uint32_t)); break;
+            case 's': {
+                    const char *s = va_arg(args2, const char *);
+                    m_cur = cur;
+                    put(s, strlen(s));
+                    // '$s' is unbounded: put() may have grown the buffer, so
+                    // re-reserve the headroom the unchecked writes assume.
+                    if (unlikely(m_cur + bound >= m_end))
+                        expand(bound);
+                    cur = m_cur;
+                }
+                break;
+
+            case 'w':
+                cur = w_u32(cur, jitc_llvm_vector_width);
+                break;
+
+            case 't': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_name_llvm[v->type]);
+                }
+                break;
+
+            case 'b': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_name_llvm_bin[v->type]);
+                }
+                break;
+
+            case 'd': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_name_llvm_big[v->type]);
+                }
+                break;
+
+            case 'H': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, v->type == (uint32_t) VarType::Bool
+                                         ? "i8"
+                                         : type_name_llvm_abbrev[v->type]);
+                }
+                break;
+
+            case 'h': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_name_llvm_abbrev[v->type]);
+                }
+                break;
+
+            case 'm': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    uint32_t type = v->type == (uint32_t) VarType::Bool
+                                        ? (uint32_t) VarType::UInt8
+                                        : v->type;
+                    cur = w_str(cur, type_name_llvm[type]);
+                }
+                break;
+
+            case 'T': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    *cur++ = '<';
+                    cur = w_u32(cur, jitc_llvm_vector_width);
+                    *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
+                    cur = w_str(cur, type_name_llvm[v->type]);
+                    *cur++ = '>';
+                }
+                break;
+
+            case 'B': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    *cur++ = '<';
+                    cur = w_u32(cur, jitc_llvm_vector_width);
+                    *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
+                    cur = w_str(cur, type_name_llvm_bin[v->type]);
+                    *cur++ = '>';
+                }
+                break;
+
+            case 'D': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    *cur++ = '<';
+                    cur = w_u32(cur, jitc_llvm_vector_width);
+                    *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
+                    cur = w_str(cur, type_name_llvm_big[v->type]);
+                    *cur++ = '>';
+                }
+                break;
+
+            case 'M': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    uint32_t type = v->type == (uint32_t) VarType::Bool
+                                        ? (uint32_t) VarType::UInt8
+                                        : v->type;
+                    *cur++ = '<';
+                    cur = w_u32(cur, jitc_llvm_vector_width);
+                    *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
+                    cur = w_str(cur, type_name_llvm[type]);
+                    *cur++ = '>';
+                }
+                break;
+
+            case 'v': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_prefix[v->type]);
+                    cur = w_u32(cur, v->reg_index);
+                }
+                break;
+
+            case 'V': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    *cur++ = '<';
+                    cur = w_u32(cur, jitc_llvm_vector_width);
+                    *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
+                    cur = w_str(cur, type_name_llvm[v->type]);
+                    *cur++ = '>';
+                    *cur++ = ' ';
+                    cur = w_str(cur, type_prefix[v->type]);
+                    cur = w_u32(cur, v->reg_index);
+                }
+                break;
+
+            case 'l': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    VarType vt = (VarType) v->type;
+                    uint64_t literal = v->literal;
+
+                    if (vt == VarType::Float32) {
+                        float f;
+                        memcpy(&f, &literal, sizeof(float));
+                        double d = f;
+                        memcpy(&literal, &d, sizeof(uint64_t));
+                        vt = VarType::Float64;
+                    } else if (vt == VarType::Float16) {
+                        drjit::half h;
+                        memcpy((void*)&h, &literal, sizeof(drjit::half));
+                        double d = float(h);
+                        memcpy(&literal, &d, sizeof(uint64_t));
+                        vt = VarType::Float64;
                     }
-                    break;
 
-                case 'w':
-                    put_u32_unchecked(jitc_llvm_vector_width);
-                    break;
-
-                case 't': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_name_llvm[v->type]);
+                    if (vt == VarType::Float64) {
+                        *cur++ = '0';
+                        *cur++ = 'x';
+                        cur = w_x64(cur, literal);
+                    } else {
+                        cur = w_u64(cur, literal);
                     }
-                    break;
+                };
+                break;
 
-                case 'b': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_name_llvm_bin[v->type]);
-                    }
-                    break;
+            case 'a': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_u32(cur, v->unaligned ? 1 : type_size[v->type]);
+                }
+                break;
 
-                case 'd': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_name_llvm_big[v->type]);
-                    }
-                    break;
+            case 'A': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_u32(cur, v->unaligned ? 1 : (type_size[v->type] * jitc_llvm_vector_width));
+                }
+                break;
 
-                case 'H': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(v->type == (uint32_t) VarType::Bool
-                                          ? "i8"
-                                          : type_name_llvm_abbrev[v->type]);
-                    }
-                    break;
+            case 'o': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_u32(cur, v->param_offset / (uint32_t) sizeof(void *));
+                }
+                break;
 
-                case 'h': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_name_llvm_abbrev[v->type]);
-                    }
-                    break;
+            case 'z':
+                cur = w_str(cur, "zeroinitializer");
+                break;
 
-                case 'm': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        uint32_t type = v->type == (uint32_t) VarType::Bool
-                                            ? (uint32_t) VarType::UInt8
-                                            : v->type;
-                        put_unchecked(type_name_llvm[type]);
-                    }
-                    break;
+            case '<':
+                if (callable_depth > 0) {
+                    *cur++ = '<';
+                    cur = w_u32(cur, jitc_llvm_vector_width);
+                    *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
+                }
+                break;
 
-                case 'T': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        *m_cur ++= '<';
-                        put_u32_unchecked(jitc_llvm_vector_width);
-                        *m_cur ++= ' '; *m_cur ++= 'x'; *m_cur ++= ' ';
-                        put_unchecked(type_name_llvm[v->type]);
-                        *m_cur ++= '>';
-                    }
-                    break;
+            case '>':
+                if (callable_depth > 0)
+                    *cur++ = '>';
+                break;
 
-                case 'B': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        *m_cur ++= '<';
-                        put_u32_unchecked(jitc_llvm_vector_width);
-                        *m_cur ++= ' '; *m_cur ++= 'x'; *m_cur ++= ' ';
-                        put_unchecked(type_name_llvm_bin[v->type]);
-                        *m_cur ++= '>';
-                    }
-                    break;
-
-                case 'D': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        *m_cur ++= '<';
-                        put_u32_unchecked(jitc_llvm_vector_width);
-                        *m_cur ++= ' '; *m_cur ++= 'x'; *m_cur ++= ' ';
-                        put_unchecked(type_name_llvm_big[v->type]);
-                        *m_cur ++= '>';
-                    }
-                    break;
-
-                case 'M': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        uint32_t type = v->type == (uint32_t) VarType::Bool
-                                            ? (uint32_t) VarType::UInt8
-                                            : v->type;
-                        *m_cur ++= '<';
-                        put_u32_unchecked(jitc_llvm_vector_width);
-                        *m_cur ++= ' '; *m_cur ++= 'x'; *m_cur ++= ' ';
-                        put_unchecked(type_name_llvm[type]);
-                        *m_cur ++= '>';
-                    }
-                    break;
-
-                case 'v': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_prefix[v->type]);
-                        put_u32_unchecked(v->reg_index);
-                    }
-                    break;
-
-                case 'V': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        *m_cur ++= '<';
-                        put_u32_unchecked(jitc_llvm_vector_width);
-                        *m_cur ++= ' '; *m_cur ++= 'x'; *m_cur ++= ' ';
-                        put_unchecked(type_name_llvm[v->type]);
-                        *m_cur ++= '>';
-                        *m_cur ++= ' ';
-                        put_unchecked(type_prefix[v->type]);
-                        put_u32_unchecked(v->reg_index);
-                    }
-                    break;
-
-                case 'l': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        VarType vt = (VarType) v->type;
-                        uint64_t literal = v->literal;
-
-                        if (vt == VarType::Float32) {
-                            float f;
-                            memcpy(&f, &literal, sizeof(float));
-                            double d = f;
-                            memcpy(&literal, &d, sizeof(uint64_t));
-                            vt = VarType::Float64;
-                        } else if (vt == VarType::Float16) {
-                            drjit::half h;
-                            memcpy((void*)&h, &literal, sizeof(drjit::half));
-                            double d = float(h);
-                            memcpy(&literal, &d, sizeof(uint64_t));
-                            vt = VarType::Float64;
-                        }
-
-                        if (vt == VarType::Float64) {
-                            *m_cur ++= '0';
-                            *m_cur ++= 'x';
-                            put_x64_unchecked(literal);
-                        } else {
-                            put_u64_unchecked(literal);
-                        }
-                    };
-                    break;
-
-                case 'a': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_u32_unchecked(v->unaligned ? 1 : type_size[v->type]);
-                    }
-                    break;
-
-                case 'A': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_u32_unchecked(v->unaligned ? 1 : (type_size[v->type] * jitc_llvm_vector_width));
-                    }
-                    break;
-
-                case 'o': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_u32_unchecked(v->param_offset / (uint32_t) sizeof(void *));
-                    }
-                    break;
-
-                case 'z':
-                    put_unchecked("zeroinitializer");
-                    break;
-
-                case '<':
-                    if (callable_depth > 0) {
-                        *m_cur ++= '<';
-                        put_u32_unchecked(jitc_llvm_vector_width);
-                        *m_cur ++= ' '; *m_cur ++= 'x'; *m_cur ++= ' ';
-                    }
-                    break;
-
-                case '>':
-                    if (callable_depth > 0)
-                        *m_cur ++= '>';
-                    break;
-
-                default:
-                    fprintf(stderr,
-                            "StringBuffer::fmt_llvm(): encountered unsupported "
-                            "character \"$%c\" in format string!\n", p[-1]);
-                    abort();
-            }
+            default:
+                fprintf(stderr,
+                        "StringBuffer::fmt_llvm(): encountered unsupported "
+                        "character \"$%c\" in format string!\n", p[-1]);
+                abort();
         }
-
-        // Update 'cur' in case one of the put_*() functions overwrote it
-        cur = m_cur;
     }
     va_end(args2);
 
@@ -570,89 +569,86 @@ void StringBuffer::fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...) 
             continue;
         }
 
-        m_cur = cur;
-        {
-            switch (*p++) {
-                case 'u': put_u32_unchecked(va_arg(args2, uint32_t)); break;
-                case 'Q': put_q64_unchecked(va_arg(args2, uint64_t)); break;
+        // '$' directive: writes go through 'cur' via the w_*() helpers; only
+        // '$s' (put()/expand()) touches the m_cur member.
+        switch (*p++) {
+            case 'u': cur = w_u32(cur, va_arg(args2, uint32_t)); break;
+            case 'Q': cur = w_q64(cur, va_arg(args2, uint64_t)); break;
 
-                case 's': {
-                        const char *s = va_arg(args2, const char *);
-                        put(s, strlen(s));
-                        // '$s' is the only unbounded directive: 'put()' grew the
-                        // buffer to fit the string, so restore the worst-case
-                        // headroom assumed by the unchecked writes that follow.
-                        if (unlikely(m_cur + bound >= m_end))
-                            expand(bound);
+            case 's': {
+                    const char *s = va_arg(args2, const char *);
+                    m_cur = cur;
+                    put(s, strlen(s));
+                    // '$s' is unbounded: put() may have grown the buffer, so
+                    // re-reserve the headroom the unchecked writes below assume.
+                    if (unlikely(m_cur + bound >= m_end))
+                        expand(bound);
+                    cur = m_cur;
+                }
+                break;
+
+            case 't': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_name_ptx[v->type]);
+                }
+                break;
+
+            case 'B': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_name_ptx_bin2[v->type]);
+                }
+                break;
+
+            case 'b': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_name_ptx_bin[v->type]);
+                }
+                break;
+
+            case 'V': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    if (v->type == (uint32_t) VarType::Bool) {
+                        cur = w_str(cur, "%w0");
+                    } else {
+                        cur = w_str(cur, type_prefix[v->type]);
+                        cur = w_u32(cur, v->reg_index);
                     }
-                    break;
+                }
+                break;
 
-                case 't': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_name_ptx[v->type]);
-                    }
-                    break;
+            case 'v': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_prefix[v->type]);
+                    cur = w_u32(cur, v->reg_index);
+                }
+                break;
 
-                case 'B': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_name_ptx_bin2[v->type]);
-                    }
-                    break;
+            case 'l': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    *cur++ = '0';
+                    *cur++ = 'x';
+                    cur = w_x64(cur, v->literal);
+                };
+                break;
 
-                case 'b': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_name_ptx_bin[v->type]);
-                    }
-                    break;
+            case 'a': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_u32(cur, type_size[v->type]);
+                }
+                break;
 
-                case 'V': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        if (v->type == (uint32_t) VarType::Bool) {
-                            put_unchecked("%w0");
-                        } else {
-                            put_unchecked(type_prefix[v->type]);
-                            put_u32_unchecked(v->reg_index);
-                        }
-                    }
-                    break;
+            case 'o': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_u32(cur, v->param_offset);
+                }
+                break;
 
-                case 'v': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_prefix[v->type]);
-                        put_u32_unchecked(v->reg_index);
-                    }
-                    break;
-
-                case 'l': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        *m_cur ++= '0';
-                        *m_cur ++= 'x';
-                        put_x64_unchecked(v->literal);
-                    };
-                    break;
-
-                case 'a': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_u32_unchecked(type_size[v->type]);
-                    }
-                    break;
-
-                case 'o': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_u32_unchecked(v->param_offset);
-                    }
-                    break;
-
-                default:
-                    fprintf(stderr,
-                            "StringBuffer::fmt_cuda(): encountered unsupported "
-                            "character \"$%c\" in format string!\n", p[-1]);
-                    abort();
-            }
+            default:
+                fprintf(stderr,
+                        "StringBuffer::fmt_cuda(): encountered unsupported "
+                        "character \"$%c\" in format string!\n", p[-1]);
+                abort();
         }
-
-        // Update 'cur' in case one of the put_*() functions overwrote it
-        cur = m_cur;
     }
     va_end(args2);
 
@@ -682,65 +678,60 @@ void StringBuffer::fmt_metal(size_t nargs, size_t fmt_len, const char *fmt, ...)
             continue;
         }
 
-        m_cur = cur;
-        {
-            switch (*p++) {
-                case 'u': put_u32_unchecked(va_arg(args2, uint32_t)); break;
+        switch (*p++) {
+            case 'u': cur = w_u32(cur, va_arg(args2, uint32_t)); break;
 
-                case 's': {
-                        const char *s = va_arg(args2, const char *);
-                        put(s, strlen(s));
-                        // '$s' is the only unbounded directive: 'put()' grew the
-                        // buffer to fit the string, so restore the worst-case
-                        // headroom assumed by the unchecked writes that follow.
-                        if (unlikely(m_cur + bound >= m_end))
-                            expand(bound);
-                    }
-                    break;
+            case 's': {
+                    const char *s = va_arg(args2, const char *);
+                    m_cur = cur;
+                    put(s, strlen(s));
+                    // '$s' is unbounded: put() may have grown the buffer, so
+                    // re-reserve the headroom the unchecked writes below assume.
+                    if (unlikely(m_cur + bound >= m_end))
+                        expand(bound);
+                    cur = m_cur;
+                }
+                break;
 
-                case 't': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_name_metal[v->type]);
-                    }
-                    break;
+            case 't': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_name_metal[v->type]);
+                }
+                break;
 
-                case 'b': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_unchecked(type_name_metal_bin[v->type]);
-                    }
-                    break;
+            case 'b': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_str(cur, type_name_metal_bin[v->type]);
+                }
+                break;
 
-                case 'v': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        *m_cur++ = 'r';
-                        put_u32_unchecked(v->reg_index);
-                    }
-                    break;
+            case 'v': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    *cur++ = 'r';
+                    cur = w_u32(cur, v->reg_index);
+                }
+                break;
 
-                case 'l': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        *m_cur++ = '0';
-                        *m_cur++ = 'x';
-                        put_x64_unchecked(v->literal);
-                    }
-                    break;
+            case 'l': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    *cur++ = '0';
+                    *cur++ = 'x';
+                    cur = w_x64(cur, v->literal);
+                }
+                break;
 
-                case 'o': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_u32_unchecked(v->param_offset / (uint32_t) sizeof(void *) - 1);
-                    }
-                    break;
+            case 'o': {
+                    const Variable *v = va_arg(args2, const Variable *);
+                    cur = w_u32(cur, v->param_offset / (uint32_t) sizeof(void *) - 1);
+                }
+                break;
 
-                default:
-                    fprintf(stderr,
-                            "StringBuffer::fmt_metal(): encountered unsupported "
-                            "character \"$%c\" in format string!\n", p[-1]);
-                    abort();
-            }
+            default:
+                fprintf(stderr,
+                        "StringBuffer::fmt_metal(): encountered unsupported "
+                        "character \"$%c\" in format string!\n", p[-1]);
+                abort();
         }
-
-        // Update 'cur' in case one of the put_*() functions overwrote it
-        cur = m_cur;
     }
     va_end(args2);
 

--- a/src/strbuf.cpp
+++ b/src/strbuf.cpp
@@ -4,10 +4,76 @@
 #include "eval.h"
 #include <cstdarg>
 
+#if defined(_MSC_VER)
+#  include <intrin.h>
+#endif
+
 /// Global string buffer used to generate PTX/LLVM IR
 StringBuffer buffer { 1024 };
 
 static const char num[] = "0123456789abcdef";
+
+// Two-digit lookup table ("00010203...99") for fast unsigned->decimal conversion
+static const char digit_pairs[201] =
+    "00010203040506070809"
+    "10111213141516171819"
+    "20212223242526272829"
+    "30313233343536373839"
+    "40414243444546474849"
+    "50515253545556575859"
+    "60616263646566676869"
+    "70717273747576777879"
+    "80818283848586878889"
+    "90919293949596979899";
+
+static const uint32_t pow10_u32[10] = {
+    0, 10, 100, 1000, 10000,
+    100000, 1000000, 10000000, 100000000, 1000000000
+};
+
+static const uint64_t pow10_u64[20] = {
+    0ull, 10ull, 100ull, 1000ull, 10000ull, 100000ull, 1000000ull,
+    10000000ull, 100000000ull, 1000000000ull, 10000000000ull, 100000000000ull,
+    1000000000000ull, 10000000000000ull, 100000000000000ull, 1000000000000000ull,
+    10000000000000000ull, 100000000000000000ull, 1000000000000000000ull,
+    10000000000000000000ull
+};
+
+// Bit length of a *nonzero* 32-bit integer
+static inline unsigned bit_length(uint32_t n) {
+#if defined(_MSC_VER)
+    unsigned long i;
+    _BitScanReverse(&i, (unsigned long) n);
+    return (unsigned) i + 1;
+#else
+    return 32u - (unsigned) __builtin_clz(n);
+#endif
+}
+
+// Bit length of a *nonzero* 64-bit integer
+static inline unsigned bit_length(uint64_t n) {
+#if defined(_MSC_VER)
+    unsigned long i;
+    _BitScanReverse64(&i, n);
+    return (unsigned) i + 1;
+#else
+    return 64u - (unsigned) __builtin_clzll(n);
+#endif
+}
+
+// Number of decimal digits of a 32-bit unsigned value
+static inline unsigned digits10(uint32_t n) {
+    unsigned bits = bit_length(n | 1);
+    unsigned t = (bits * 1233) >> 12;
+    return t + 1 - (n < pow10_u32[t]);
+}
+
+// Number of decimal digits of a 64-bit unsigned value
+static inline unsigned digits10(uint64_t n) {
+    unsigned bits = bit_length(n | 1);
+    unsigned t = (bits * 1233) >> 12;
+    return t + 1 - (n < pow10_u64[t]);
+}
 
 StringBuffer::StringBuffer(size_t capacity)
     : m_start(nullptr), m_cur(nullptr), m_end(nullptr) {
@@ -140,23 +206,35 @@ void StringBuffer::put_x64(uint64_t value) {
 }
 
 void StringBuffer::put_u32_unchecked(uint32_t value) {
-    char *start = m_cur;
-    do {
-        *m_cur++ = num[value % 10];
-        value /= 10;
-    } while (value);
-
-    reverse_str(start, m_cur);
+    unsigned n = digits10(value);
+    char *end = m_cur + n, *p = end;
+    while (value >= 100) {
+        unsigned idx = (value % 100) * 2;
+        value /= 100;
+        p -= 2;
+        memcpy(p, &digit_pairs[idx], 2);
+    }
+    if (value < 10)
+        *--p = (char) ('0' + value);
+    else
+        memcpy(p - 2, &digit_pairs[value * 2], 2);
+    m_cur = end;
 }
 
 void StringBuffer::put_u64_unchecked(uint64_t value) {
-    char *start = m_cur;
-    do {
-        *m_cur++ = num[value % 10];
-        value /= 10;
-    } while (value);
-
-    reverse_str(start, m_cur);
+    unsigned n = digits10(value);
+    char *end = m_cur + n, *p = end;
+    while (value >= 100) {
+        unsigned idx = (unsigned) (value % 100) * 2;
+        value /= 100;
+        p -= 2;
+        memcpy(p, &digit_pairs[idx], 2);
+    }
+    if (value < 10)
+        *--p = (char) ('0' + value);
+    else
+        memcpy(p - 2, &digit_pairs[(unsigned) value * 2], 2);
+    m_cur = end;
 }
 
 void StringBuffer::put_x32_unchecked(uint32_t value) {

--- a/src/strbuf.cpp
+++ b/src/strbuf.cpp
@@ -262,14 +262,7 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
         } else {
             c = *p++;
             switch (c) {
-                case '{':
-                case '}': len += 1; break;
-
                 case 'u': len += MAXSIZE_U32; (void) va_arg(args, uint32_t); arg++; break;
-                case 'U': len += MAXSIZE_U64; (void) va_arg(args, uint64_t); arg++; break;
-                case 'x': len += MAXSIZE_X32; (void) va_arg(args, uint32_t); arg++; break;
-                case 'Q':
-                case 'X': len += MAXSIZE_X64; (void) va_arg(args, uint64_t); arg++; break;
 
                 case 's':
                     len += strlen(va_arg(args, const char *));
@@ -286,11 +279,6 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
                     len += MAXSIZE_TYPE;
                     break;
 
-                case 'p':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_TYPE + 1;
-                    break;
-
                 case 'h':
                 case 'H':
                     (void) va_arg(args, const Variable *); arg++;
@@ -305,10 +293,6 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
                     len += MAXSIZE_U32 + MAXSIZE_TYPE + 5;
                     break;
 
-                case 'P':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32 + MAXSIZE_TYPE + 6;
-                    break;
 
                 case 'v':
                     (void) va_arg(args, const Variable *); arg++;
@@ -338,10 +322,6 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
 
                 case 'z':
                     len += 15;
-                    break;
-
-                case 'e':
-                    len += 13;
                     break;
 
                 case '<':
@@ -375,20 +355,11 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
         expand(len);
 
     // Phase 2: convert the string
-    size_t offset = 0;
     p = fmt;
     while ((c = *p++) != '\0') {
         if (c == '$') {
             switch (*p++) {
-                case '{': *m_cur++= '{'; break;
-                case '}': *m_cur++= '}'; break;
-
                 case 'u': put_u32_unchecked(va_arg(args2, uint32_t)); break;
-                case 'U': put_u64_unchecked(va_arg(args2, uint64_t)); break;
-                case 'x': put_x32_unchecked(va_arg(args2, uint32_t)); break;
-                case 'X': put_x64_unchecked(va_arg(args2, uint64_t)); break;
-                case 'Q': put_q64_unchecked(va_arg(args2, uint64_t)); break;
-
                 case 's': {
                         const char *s = va_arg(args2, const char *);
                         put(s, strlen(s));
@@ -402,32 +373,6 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
                 case 't': {
                         const Variable *v = va_arg(args2, const Variable *);
                         put_unchecked(type_name_llvm[v->type]);
-                    }
-                    break;
-
-                case 'p': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        if (jitc_llvm_opaque_pointers) {
-                            put_unchecked("ptr");
-                        } else {
-                            put_unchecked(type_name_llvm[v->type]);
-                            *m_cur ++= '*';
-                        }
-                    }
-                    break;
-
-                case 'P': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        *m_cur ++= '<';
-                        put_u32_unchecked(jitc_llvm_vector_width);
-                        *m_cur ++= ' '; *m_cur ++= 'x'; *m_cur ++= ' ';
-                        if (jitc_llvm_opaque_pointers) {
-                            put_unchecked("ptr");
-                        } else {
-                            put_unchecked(type_name_llvm[v->type]);
-                            *m_cur ++= '*';
-                        }
-                        *m_cur ++= '>';
                     }
                     break;
 
@@ -580,11 +525,6 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
                     put_unchecked("zeroinitializer");
                     break;
 
-                case 'e':
-                    if (jitc_llvm_version_major < 12)
-                        put_unchecked(".experimental");
-                    break;
-
                 case '<':
                     if (callable_depth > 0) {
                         *m_cur ++= '<';
@@ -600,23 +540,6 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
 
                 default:
                     break;
-            }
-        } else if (c == '{') {
-            if (jitc_llvm_opaque_pointers)
-                offset = size();
-        } else if (c == '|') {
-            if (offset) {
-                rewind_to(offset);
-                offset = 0;
-            } else {
-                offset = size();
-            }
-        } else if (c == '}') {
-            if (offset) {
-                rewind_to(offset);
-                if (jitc_llvm_opaque_pointers)
-                    put_unchecked("ptr");
-                offset = 0;
             }
         } else {
             *m_cur ++= c;
@@ -646,12 +569,7 @@ void StringBuffer::fmt_cuda(size_t nargs, const char *fmt, ...) {
             c = *p++;
             switch (c) {
                 case 'u': len += MAXSIZE_U32; (void) va_arg(args, uint32_t); arg++; break;
-                case 'U': len += MAXSIZE_U64; (void) va_arg(args, uint64_t); arg++; break;
-                case 'x': len += MAXSIZE_X32; (void) va_arg(args, uint32_t); arg++; break;
-                case 'Q':
-                case 'X': len += MAXSIZE_X64; (void) va_arg(args, uint64_t); arg++; break;
-
-                case 'c': len++; (void) va_arg(args, int); arg++; break;
+                case 'Q': len += MAXSIZE_X64; (void) va_arg(args, uint64_t); arg++; break;
 
                 case 's':
                     len += strlen(va_arg(args, const char *));
@@ -714,12 +632,7 @@ void StringBuffer::fmt_cuda(size_t nargs, const char *fmt, ...) {
         if (c == '$') {
             switch (*p++) {
                 case 'u': put_u32_unchecked(va_arg(args2, uint32_t)); break;
-                case 'U': put_u64_unchecked(va_arg(args2, uint64_t)); break;
-                case 'x': put_x32_unchecked(va_arg(args2, uint32_t)); break;
-                case 'X': put_x64_unchecked(va_arg(args2, uint64_t)); break;
                 case 'Q': put_q64_unchecked(va_arg(args2, uint64_t)); break;
-
-                case 'c': *m_cur++ = (char) va_arg(args2, int); break;
 
                 case 's': {
                         const char *s = va_arg(args2, const char *);
@@ -815,12 +728,6 @@ void StringBuffer::fmt_metal(size_t nargs, const char *fmt, ...) {
             c = *p++;
             switch (c) {
                 case 'u': len += MAXSIZE_U32; (void) va_arg(args, uint32_t); arg++; break;
-                case 'U': len += MAXSIZE_U64; (void) va_arg(args, uint64_t); arg++; break;
-                case 'x': len += MAXSIZE_X32; (void) va_arg(args, uint32_t); arg++; break;
-                case 'Q':
-                case 'X': len += MAXSIZE_X64; (void) va_arg(args, uint64_t); arg++; break;
-
-                case 'c': len++; (void) va_arg(args, int); arg++; break;
 
                 case 's':
                     len += strlen(va_arg(args, const char *));
@@ -833,16 +740,10 @@ void StringBuffer::fmt_metal(size_t nargs, const char *fmt, ...) {
                     len += MAXSIZE_TYPE;
                     break;
 
-                case 'V':
                 case 'v':
                     (void) va_arg(args, const Variable *); arg++;
                     // ``v<reg_index>`` -- one letter + 32-bit number
                     len += 1 + MAXSIZE_U32;
-                    break;
-
-                case 'a':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32;
                     break;
 
                 case 'l':
@@ -884,12 +785,6 @@ void StringBuffer::fmt_metal(size_t nargs, const char *fmt, ...) {
         if (c == '$') {
             switch (*p++) {
                 case 'u': put_u32_unchecked(va_arg(args2, uint32_t)); break;
-                case 'U': put_u64_unchecked(va_arg(args2, uint64_t)); break;
-                case 'x': put_x32_unchecked(va_arg(args2, uint32_t)); break;
-                case 'X': put_x64_unchecked(va_arg(args2, uint64_t)); break;
-                case 'Q': put_q64_unchecked(va_arg(args2, uint64_t)); break;
-
-                case 'c': *m_cur++ = (char) va_arg(args2, int); break;
 
                 case 's': {
                         const char *s = va_arg(args2, const char *);
@@ -909,7 +804,6 @@ void StringBuffer::fmt_metal(size_t nargs, const char *fmt, ...) {
                     }
                     break;
 
-                case 'V':
                 case 'v': {
                         const Variable *v = va_arg(args2, const Variable *);
                         *m_cur++ = 'r';
@@ -922,12 +816,6 @@ void StringBuffer::fmt_metal(size_t nargs, const char *fmt, ...) {
                         *m_cur++ = '0';
                         *m_cur++ = 'x';
                         put_x64_unchecked(v->literal);
-                    }
-                    break;
-
-                case 'a': {
-                        const Variable *v = va_arg(args2, const Variable *);
-                        put_u32_unchecked(type_size[v->type]);
                     }
                     break;
 

--- a/src/strbuf.cpp
+++ b/src/strbuf.cpp
@@ -196,6 +196,19 @@ static inline char *w_strn(char *d, const char *str, size_t n) {
     return d + n;
 }
 
+// Append a type-name table row (see NameTable in var.h). The row is 8 bytes:
+// up to 6 characters + NUL in bytes 0..6 and the length in byte 7. Emit it with
+// one unconditional 8-byte load+store and advance the cursor by the length; the
+// 1-2 padding bytes written past the string are overwritten by the next
+// directive (the fmt_bound reservation guarantees the store stays in bounds),
+// exactly like the trailing-byte spill in w_u32.
+static inline char *w_type(char *d, const char *row) {
+    uint64_t w;
+    memcpy(&w, row, 8);
+    memcpy(d, &w, 8);
+    return d + (uint8_t) row[7];
+}
+
 // Copy plain characters from 'p' up to the next '$' (or 'end'),
 // advancing 8 bytes at a time using a SWAR test when possible.
 static inline char *w_run(char *d, const char *&p, const char *end) {
@@ -206,7 +219,7 @@ static inline char *w_run(char *d, const char *&p, const char *end) {
         uint64_t x = w ^ dollar;
         uint64_t m = (x - 0x0101010101010101ull) & ~x & 0x8080808080808080ull;
         if (m) {
-            unsigned n = (unsigned) (__builtin_ctzll(m) >> 3);
+            unsigned n = (unsigned) (tzcnt_u64(m) >> 3);
             p += n;
             return d + n;
         }
@@ -465,33 +478,34 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
 
             case 't': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_name_llvm[v->type]);
+                    cur = w_type(cur, type_name_llvm[v->type]);
                 }
                 break;
 
             case 'b': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_name_llvm_bin[v->type]);
+                    cur = w_type(cur, type_name_llvm_bin[v->type]);
                 }
                 break;
 
             case 'd': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_name_llvm_big[v->type]);
+                    cur = w_type(cur, type_name_llvm_big[v->type]);
                 }
                 break;
 
             case 'H': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, v->type == (uint32_t) VarType::Bool
-                                         ? "i8"
-                                         : type_name_llvm_abbrev[v->type]);
+                    if (v->type == (uint32_t) VarType::Bool)
+                        cur = w_strn(cur, "i8", 2);
+                    else
+                        cur = w_type(cur, type_name_llvm_abbrev[v->type]);
                 }
                 break;
 
             case 'h': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_name_llvm_abbrev[v->type]);
+                    cur = w_type(cur, type_name_llvm_abbrev[v->type]);
                 }
                 break;
 
@@ -500,7 +514,7 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                     uint32_t type = v->type == (uint32_t) VarType::Bool
                                         ? (uint32_t) VarType::UInt8
                                         : v->type;
-                    cur = w_str(cur, type_name_llvm[type]);
+                    cur = w_type(cur, type_name_llvm[type]);
                 }
                 break;
 
@@ -509,7 +523,7 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                     *cur++ = '<';
                     cur = w_u32(cur, jitc_llvm_vector_width);
                     *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
-                    cur = w_str(cur, type_name_llvm[v->type]);
+                    cur = w_type(cur, type_name_llvm[v->type]);
                     *cur++ = '>';
                 }
                 break;
@@ -519,7 +533,7 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                     *cur++ = '<';
                     cur = w_u32(cur, jitc_llvm_vector_width);
                     *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
-                    cur = w_str(cur, type_name_llvm_bin[v->type]);
+                    cur = w_type(cur, type_name_llvm_bin[v->type]);
                     *cur++ = '>';
                 }
                 break;
@@ -529,7 +543,7 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                     *cur++ = '<';
                     cur = w_u32(cur, jitc_llvm_vector_width);
                     *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
-                    cur = w_str(cur, type_name_llvm_big[v->type]);
+                    cur = w_type(cur, type_name_llvm_big[v->type]);
                     *cur++ = '>';
                 }
                 break;
@@ -542,14 +556,14 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                     *cur++ = '<';
                     cur = w_u32(cur, jitc_llvm_vector_width);
                     *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
-                    cur = w_str(cur, type_name_llvm[type]);
+                    cur = w_type(cur, type_name_llvm[type]);
                     *cur++ = '>';
                 }
                 break;
 
             case 'v': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_prefix[v->type]);
+                    cur = w_type(cur, type_prefix[v->type]);
                     cur = w_u32(cur, v->reg_index);
                 }
                 break;
@@ -559,10 +573,10 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                     *cur++ = '<';
                     cur = w_u32(cur, jitc_llvm_vector_width);
                     *cur++ = ' '; *cur++ = 'x'; *cur++ = ' ';
-                    cur = w_str(cur, type_name_llvm[v->type]);
+                    cur = w_type(cur, type_name_llvm[v->type]);
                     *cur++ = '>';
                     *cur++ = ' ';
-                    cur = w_str(cur, type_prefix[v->type]);
+                    cur = w_type(cur, type_prefix[v->type]);
                     cur = w_u32(cur, v->reg_index);
                 }
                 break;
@@ -615,7 +629,7 @@ void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) 
                 break;
 
             case 'z':
-                cur = w_str(cur, "zeroinitializer");
+                cur = w_strn(cur, "zeroinitializer", 15);
                 --arg;
                 break;
 
@@ -695,28 +709,28 @@ void StringBuffer::fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...) 
 
             case 't': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_name_ptx[v->type]);
+                    cur = w_type(cur, type_name_ptx[v->type]);
                 }
                 break;
 
             case 'B': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_name_ptx_bin2[v->type]);
+                    cur = w_type(cur, type_name_ptx_bin2[v->type]);
                 }
                 break;
 
             case 'b': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_name_ptx_bin[v->type]);
+                    cur = w_type(cur, type_name_ptx_bin[v->type]);
                 }
                 break;
 
             case 'V': {
                     const Variable *v = va_arg(args2, const Variable *);
                     if (v->type == (uint32_t) VarType::Bool) {
-                        cur = w_str(cur, "%w0");
+                        cur = w_strn(cur, "%w0", 3);
                     } else {
-                        cur = w_str(cur, type_prefix[v->type]);
+                        cur = w_type(cur, type_prefix[v->type]);
                         cur = w_u32(cur, v->reg_index);
                     }
                 }
@@ -724,7 +738,7 @@ void StringBuffer::fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...) 
 
             case 'v': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_prefix[v->type]);
+                    cur = w_type(cur, type_prefix[v->type]);
                     cur = w_u32(cur, v->reg_index);
                 }
                 break;
@@ -809,13 +823,13 @@ void StringBuffer::fmt_metal(size_t nargs, size_t fmt_len, const char *fmt, ...)
 
             case 't': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_name_metal[v->type]);
+                    cur = w_type(cur, type_name_metal[v->type]);
                 }
                 break;
 
             case 'b': {
                     const Variable *v = va_arg(args2, const Variable *);
-                    cur = w_str(cur, type_name_metal_bin[v->type]);
+                    cur = w_type(cur, type_name_metal_bin[v->type]);
                 }
                 break;
 

--- a/src/strbuf.cpp
+++ b/src/strbuf.cpp
@@ -323,117 +323,20 @@ size_t StringBuffer::vfmt(const char *fmt, va_list args_) {
     } while (true);
 }
 
-void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
-    size_t len = 0;
+void StringBuffer::fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...) {
+    va_list args2;
+    va_start(args2, fmt);
 
-    va_list args, args2;
-    va_start(args, fmt);
-    va_copy(args2, args);
+    // Bound the maximum output size: every directive other than the unbounded
+    // '$s' expands to at most 8 bytes per format character + 48 bytes per
+    // argument; '$s' grows the buffer on demand below.
+    size_t bound = fmt_len * 8 + nargs * 48;
+    if (unlikely(!m_cur || m_cur + bound >= m_end))
+        expand(bound);
 
-    // Phase 1: walk through the string and determine its maximal length
+    // Convert the format string
     const char *p = fmt;
-    size_t arg = 0;
     char c;
-    while ((c = *p++) != '\0') {
-        if (c != '$') {
-            len++;
-        } else {
-            c = *p++;
-            switch (c) {
-                case 'u': len += MAXSIZE_U32; (void) va_arg(args, uint32_t); arg++; break;
-
-                case 's':
-                    len += strlen(va_arg(args, const char *));
-                    arg++;
-                    break;
-
-                case 'w': len += MAXSIZE_U32; break;
-
-                case 't':
-                case 'd':
-                case 'b':
-                case 'm':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_TYPE;
-                    break;
-
-                case 'h':
-                case 'H':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_TYPE_ABBREV;
-                    break;
-
-                case 'T':
-                case 'D':
-                case 'B':
-                case 'M':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32 + MAXSIZE_TYPE + 5;
-                    break;
-
-
-                case 'v':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32 + MAXSIZE_TYPE_PREFIX;
-                    break;
-
-                case 'V':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += 2*MAXSIZE_U32 + MAXSIZE_TYPE_PREFIX + 6;
-                    break;
-
-                case 'l':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_X64 + 2;
-                    break;
-
-                case 'a':
-                case 'A':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32;
-                    break;
-
-                case 'o':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32;
-                    break;
-
-                case 'z':
-                    len += 15;
-                    break;
-
-                case '<':
-                    len += MAXSIZE_U32 + 4;
-                    break;
-
-                case '>':
-                    len += 1;
-                    break;
-
-                default:
-                    fprintf(stderr,
-                            "StringBuffer::fmt_llvm(): encountered unsupported "
-                            "character \"$%c\" in format string!\n", c);
-                    abort();
-            }
-        }
-    }
-
-    va_end(args);
-
-    if (nargs != arg) {
-        fprintf(stderr,
-                "StringBuffer::fmt_llvm(): given %zu args, format string "
-                "accessed %zu (%s)\n", nargs, arg, fmt);
-        abort();
-    }
-
-    // Enlarge the buffer if necessary
-    if (unlikely(!m_cur || m_cur + len >= m_end))
-        expand(len);
-
-    // Phase 2: convert the string
-    p = fmt;
     while ((c = *p++) != '\0') {
         if (c == '$') {
             switch (*p++) {
@@ -441,6 +344,11 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
                 case 's': {
                         const char *s = va_arg(args2, const char *);
                         put(s, strlen(s));
+                        // '$s' is the only unbounded directive: 'put()' grew the
+                        // buffer to fit the string, so restore the worst-case
+                        // headroom assumed by the unchecked writes that follow.
+                        if (unlikely(m_cur + bound >= m_end))
+                            expand(bound);
                     }
                     break;
 
@@ -617,7 +525,10 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
                     break;
 
                 default:
-                    break;
+                    fprintf(stderr,
+                            "StringBuffer::fmt_llvm(): encountered unsupported "
+                            "character \"$%c\" in format string!\n", p[-1]);
+                    abort();
             }
         } else {
             *m_cur ++= c;
@@ -629,83 +540,18 @@ void StringBuffer::fmt_llvm(size_t nargs, const char *fmt, ...) {
 }
 
 #if defined(DRJIT_ENABLE_CUDA)
-void StringBuffer::fmt_cuda(size_t nargs, const char *fmt, ...) {
-    size_t len = 0;
+void StringBuffer::fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...) {
+    va_list args2;
+    va_start(args2, fmt);
 
-    va_list args, args2;
-    va_start(args, fmt);
-    va_copy(args2, args);
+    // Bound the maximum output size; see fmt_llvm().
+    size_t bound = fmt_len * 8 + nargs * 48;
+    if (unlikely(!m_cur || m_cur + bound >= m_end))
+        expand(bound);
 
-    // Phase 1: walk through the string and determine its maximal length
+    // Convert the format string
     const char *p = fmt;
-    size_t arg = 0;
     char c;
-    while ((c = *p++) != '\0') {
-        if (c != '$') {
-            len++;
-        } else {
-            c = *p++;
-            switch (c) {
-                case 'u': len += MAXSIZE_U32; (void) va_arg(args, uint32_t); arg++; break;
-                case 'Q': len += MAXSIZE_X64; (void) va_arg(args, uint64_t); arg++; break;
-
-                case 's':
-                    len += strlen(va_arg(args, const char *));
-                    arg++;
-                    break;
-
-                case 'B':
-                case 'b':
-                case 't':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_TYPE;
-                    break;
-
-                case 'v':
-                case 'V':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32 + MAXSIZE_TYPE_PREFIX;
-                    break;
-
-                case 'a':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32;
-                    break;
-
-                case 'l':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_X64 + 2;
-                    break;
-
-                case 'o':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32;
-                    break;
-
-                default:
-                    fprintf(stderr,
-                            "StringBuffer::fmt_cuda(): encountered unsupported "
-                            "character \"$%c\" in format string!\n", c);
-                    abort();
-            }
-        }
-    }
-
-    va_end(args);
-
-    if (nargs != arg) {
-        fprintf(stderr,
-                "StringBuffer::fmt_cuda(): given %zu args, format string "
-                "accessed %zu (%s)\n", nargs, arg, fmt);
-        abort();
-    }
-
-    // Enlarge the buffer if necessary
-    if (unlikely(!m_cur || m_cur + len >= m_end))
-        expand(len);
-
-    // Phase 2: convert the string
-    p = fmt;
     while ((c = *p++) != '\0') {
         if (c == '$') {
             switch (*p++) {
@@ -715,6 +561,11 @@ void StringBuffer::fmt_cuda(size_t nargs, const char *fmt, ...) {
                 case 's': {
                         const char *s = va_arg(args2, const char *);
                         put(s, strlen(s));
+                        // '$s' is the only unbounded directive: 'put()' grew the
+                        // buffer to fit the string, so restore the worst-case
+                        // headroom assumed by the unchecked writes that follow.
+                        if (unlikely(m_cur + bound >= m_end))
+                            expand(bound);
                     }
                     break;
 
@@ -775,7 +626,10 @@ void StringBuffer::fmt_cuda(size_t nargs, const char *fmt, ...) {
                     break;
 
                 default:
-                    break;
+                    fprintf(stderr,
+                            "StringBuffer::fmt_cuda(): encountered unsupported "
+                            "character \"$%c\" in format string!\n", p[-1]);
+                    abort();
             }
         } else {
             *m_cur ++= c;
@@ -788,77 +642,18 @@ void StringBuffer::fmt_cuda(size_t nargs, const char *fmt, ...) {
 #endif
 
 #if defined(DRJIT_ENABLE_METAL)
-void StringBuffer::fmt_metal(size_t nargs, const char *fmt, ...) {
-    size_t len = 0;
+void StringBuffer::fmt_metal(size_t nargs, size_t fmt_len, const char *fmt, ...) {
+    va_list args2;
+    va_start(args2, fmt);
 
-    va_list args, args2;
-    va_start(args, fmt);
-    va_copy(args2, args);
+    // Bound the maximum output size; see fmt_llvm().
+    size_t bound = fmt_len * 8 + nargs * 48;
+    if (unlikely(!m_cur || m_cur + bound >= m_end))
+        expand(bound);
 
-    // Phase 1: walk through the string and determine its maximal length
+    // Emit the formatted string
     const char *p = fmt;
-    size_t arg = 0;
     char c;
-    while ((c = *p++) != '\0') {
-        if (c != '$') {
-            len++;
-        } else {
-            c = *p++;
-            switch (c) {
-                case 'u': len += MAXSIZE_U32; (void) va_arg(args, uint32_t); arg++; break;
-
-                case 's':
-                    len += strlen(va_arg(args, const char *));
-                    arg++;
-                    break;
-
-                case 'b':
-                case 't':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_TYPE;
-                    break;
-
-                case 'v':
-                    (void) va_arg(args, const Variable *); arg++;
-                    // ``v<reg_index>`` -- one letter + 32-bit number
-                    len += 1 + MAXSIZE_U32;
-                    break;
-
-                case 'l':
-                    (void) va_arg(args, const Variable *); arg++;
-                    // ``0x.....ull`` worst case
-                    len += MAXSIZE_X64 + 5;
-                    break;
-
-                case 'o':
-                    (void) va_arg(args, const Variable *); arg++;
-                    len += MAXSIZE_U32;
-                    break;
-
-                default:
-                    fprintf(stderr,
-                            "StringBuffer::fmt_metal(): encountered unsupported "
-                            "character \"$%c\" in format string!\n", c);
-                    abort();
-            }
-        }
-    }
-
-    va_end(args);
-
-    if (nargs != arg) {
-        fprintf(stderr,
-                "StringBuffer::fmt_metal(): given %zu args, format string "
-                "accessed %zu (%s)\n", nargs, arg, fmt);
-        abort();
-    }
-
-    // Enlarge the buffer if necessary
-    if (unlikely(!m_cur || m_cur + len >= m_end))
-        expand(len);
-
-    // Phase 2: emit the formatted string
-    p = fmt;
     while ((c = *p++) != '\0') {
         if (c == '$') {
             switch (*p++) {
@@ -867,6 +662,11 @@ void StringBuffer::fmt_metal(size_t nargs, const char *fmt, ...) {
                 case 's': {
                         const char *s = va_arg(args2, const char *);
                         put(s, strlen(s));
+                        // '$s' is the only unbounded directive: 'put()' grew the
+                        // buffer to fit the string, so restore the worst-case
+                        // headroom assumed by the unchecked writes that follow.
+                        if (unlikely(m_cur + bound >= m_end))
+                            expand(bound);
                     }
                     break;
 
@@ -904,7 +704,10 @@ void StringBuffer::fmt_metal(size_t nargs, const char *fmt, ...) {
                     break;
 
                 default:
-                    break;
+                    fprintf(stderr,
+                            "StringBuffer::fmt_metal(): encountered unsupported "
+                            "character \"$%c\" in format string!\n", p[-1]);
+                    abort();
             }
         } else {
             *m_cur++ = c;

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -156,14 +156,14 @@ public:
      * \brief LLVM-specific formatting routine. Its syntax is described at the
      * top of eval_llvm.cpp
      */
-    void fmt_llvm(size_t nargs, const char *fmt, ...);
+    void fmt_llvm(size_t nargs, size_t fmt_len, const char *fmt, ...);
 
 #if defined(DRJIT_ENABLE_CUDA)
     /**
      * \brief CUDA-specific formatting routine. Its syntax is described at the
      * top of eval_cuda.cpp
      */
-    void fmt_cuda(size_t nargs, const char *fmt, ...);
+    void fmt_cuda(size_t nargs, size_t fmt_len, const char *fmt, ...);
 #endif
 
 #if defined(DRJIT_ENABLE_METAL)
@@ -171,7 +171,7 @@ public:
      * \brief Metal-specific formatting routine. Its syntax is described at
      * the top of metal_eval.cpp.
      */
-    void fmt_metal(size_t nargs, const char *fmt, ...);
+    void fmt_metal(size_t nargs, size_t fmt_len, const char *fmt, ...);
 #endif
 
     /**
@@ -230,3 +230,10 @@ extern StringBuffer buffer;
 template <typename... Ts> constexpr size_t count_args(const Ts &...) {
     return sizeof...(Ts);
 }
+
+/// Macro to compute the length of a string at compile time
+#if defined(_MSC_VER)
+#  define fmt_strlen(s) strlen(s)
+#else
+#  define fmt_strlen(s) __builtin_strlen(s)
+#endif

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -110,7 +110,7 @@ public:
     /// Append a string with the specified length
     void put(const char *str, size_t size) {
         if (unlikely(!m_cur || m_cur + size >= m_end))
-            expand(size);
+            m_cur = expand(m_cur, size);
 
         std::memcpy(m_cur, str, size);
         m_cur += size;
@@ -120,7 +120,7 @@ public:
     /// Append a single character to the buffer
     void put(char c) {
         if (unlikely(!m_cur || m_cur + 1 >= m_end))
-            expand(1);
+            m_cur = expand(m_cur, 1);
         *m_cur++ = c;
         *m_cur = '\0';
     }
@@ -128,7 +128,7 @@ public:
     /// Append multiple copies of a single character to the buffer
     void put(char c, size_t count) {
         if (unlikely(!m_cur || m_cur + count >= m_end))
-            expand(count);
+            m_cur = expand(m_cur, count);
 
         for (size_t i = 0; i < count; ++i)
             *m_cur++ = c;
@@ -210,15 +210,18 @@ public:
     // Append a zero-filled 64 bit hex number. The caller must check that there is space
     void put_q64_unchecked(uint64_t value);
 
-    /// Append a string with the specified length
+    /// Append a zero-terminated string. The caller must check that there is space
     void put_unchecked(const char *str);
 
 private:
     /**
-     * \brief Potentially expand the size of the StringBuffer so that there is
-     * space for at least \c nbytes new bytes, plus a trailing zero.
+     * \brief Potentially expand the StringBuffer so that there is space for at
+     * least \c nbytes new bytes, plus a trailing zero.
+     *
+     * Callers keep the write position in a local cursor: this publishes \c cur
+     * to \c m_cur, expands, and returns the (possibly relocated) cursor.
      */
-    void expand(size_t nbytes);
+    char *expand(char *cur, size_t nbytes);
 
 private:
     char *m_start, *m_cur, *m_end;

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -692,8 +692,13 @@ void jitc_set_source_location(const char *fname, size_t lineno) noexcept {
 /// Append the given variable to the instruction trace and return its ID
 uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
     State &st = ::state;
+
+    // Look up the per-thread data structure once
+    ThreadLocal &tl = jitc_thread_local();
+
+    // Use the default backend if the variable doesn't specify one
     if (unlikely(v.backend == (uint32_t) JitBackend::None))
-        v.backend = (uint32_t) default_backend;
+        v.backend = (uint32_t) tl.def_backend;
 
 #if defined(DRJIT_ENABLE_METAL)
     // Metal does not support double precision
@@ -716,8 +721,20 @@ uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
     }
 #endif
 
-    ThreadState *ts = thread_state(v.backend);
-    uint32_t flags = jitc_flags();
+    ThreadState *ts;
+    switch ((JitBackend) v.backend) {
+#if defined(DRJIT_ENABLE_CUDA)
+        case JitBackend::CUDA:  ts = tl.ts_cuda;  break;
+#endif
+#if defined(DRJIT_ENABLE_METAL)
+        case JitBackend::Metal: ts = tl.ts_metal; break;
+#endif
+        case JitBackend::LLVM:  ts = tl.ts_llvm;  break;
+        default:                ts = nullptr;      break;
+    }
+    if (unlikely(!ts))
+        ts = jitc_init_thread_state((JitBackend) v.backend);
+    uint32_t flags = tl.flags;
 
     bool lvn = !disable_lvn && (VarType) v.type != VarType::Void &&
                !v.is_evaluated() && (flags & (uint32_t) JitFlag::ValueNumbering);
@@ -1426,11 +1443,16 @@ uint32_t jitc_var_eval_force(uint32_t index, Variable &v_, void **ptr_out) {
     if (v.is_undefined()) {
         // Notify the thread_state that this allocation should not be
         // initialized for recording.
-        if (thread_state_llvm)
-            thread_state_llvm->notify_init_undefined(result);
+        ThreadLocal &tl = jitc_thread_local();
+        if (tl.ts_llvm)
+            tl.ts_llvm->notify_init_undefined(result);
 #if defined(DRJIT_ENABLE_CUDA)
-        if (thread_state_cuda)
-            thread_state_cuda->notify_init_undefined(result);
+        if (tl.ts_cuda)
+            tl.ts_cuda->notify_init_undefined(result);
+#endif
+#if defined(DRJIT_ENABLE_METAL)
+        if (tl.ts_metal)
+            tl.ts_metal->notify_init_undefined(result);
 #endif
     }
 

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -763,14 +763,17 @@ uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
                 "jit_var_new(): selected entry of variable r%u "
                 "is already used.", index);
 
-    // Snapshot the LVN key before overwriting the slot
+    // Snapshot the LVN key before overwriting the slot. Hash it here rather
+    // than inside the table's insert so that the hash dependency chain
+    // overlaps the slot write below.
     VariableKey key(v);
+    size_t key_hash = lvn ? VariableKeyHasher()(key) : 0;
     v.counter = vo->counter;
     *vo = v;
 
     bool cse_hit = false;
     if (lvn) {
-        auto [it, inserted] = st.lvn_map.try_emplace(key, index);
+        auto [it, inserted] = st.lvn_map.try_emplace_hash(key_hash, key, index);
 
         if (unlikely(!inserted)) {
             // CSE hit: undo the speculative allocation and reuse the existing

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -390,7 +390,7 @@ JIT_NOINLINE void jitc_var_free(uint32_t index, Variable *v) noexcept {
             }
 
             free(label);
-            state_.unused_extra.push(index2);
+            state_.unused_extra.push_back(index2);
         }
 
         // Remove from unused variable list
@@ -736,14 +736,13 @@ uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
 
     if (likely(!lvn || lvn_key_inserted)) {
         bool reuse_indices = flags & (uint32_t) JitFlag::ReuseIndices;
-        UnusedPQ &unused = st.unused_variables;
+        FreeSlots &unused = st.unused_variables;
 
         if (unlikely(unused.empty() || !reuse_indices)) {
             index = (uint32_t) st.variables.size();
             st.variables.emplace_back();
         } else {
-            index = unused.top();
-            unused.pop();
+            index = unused.pop();
         }
 
         if (lvn_key_inserted)
@@ -2026,13 +2025,13 @@ VariableExtra *jitc_var_extra(Variable *v) {
 
     uint32_t index = v->extra;
     if (!index) {
-        UnusedPQ &unused = st.unused_extra;
+        std::vector<uint32_t> &unused = st.unused_extra;
         if (unused.empty()) {
             index = (uint32_t) st.extra.size();
             st.extra.emplace_back();
         } else {
-            index = unused.top();
-            unused.pop();
+            index = unused.back();
+            unused.pop_back();
         }
         v->extra = index;
         st.extra[index] = VariableExtra();

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -741,38 +741,65 @@ uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
 
     v.scope = ts->scope;
 
-    // Check if this exact statement already exists ..
-    LVNMap::iterator key_it;
-    bool lvn_key_inserted = false;
-    if (lvn)
-        std::tie(key_it, lvn_key_inserted) =
-            st.lvn_map.try_emplace(VariableKey(v), 0);
+    // Allocate a variable slot and move 'v' into it. This is done speculatively
+    // assuming that the LVN lookup below misses, which permits overlapping the
+    // OoO latency of the two steps. In the case of a hit, return the slot.
+    bool reuse_indices = flags & (uint32_t) JitFlag::ReuseIndices;
+    FreeSlots &unused = st.unused_variables;
 
     uint32_t index;
-    Variable *vo;
+    bool from_unused;
+    if (unlikely(unused.empty() || !reuse_indices)) {
+        index = (uint32_t) st.variables.size();
+        st.variables.emplace_back();
+        from_unused = false;
+    } else {
+        index = unused.pop();
+        from_unused = true;
+    }
 
-    if (likely(!lvn || lvn_key_inserted)) {
-        bool reuse_indices = flags & (uint32_t) JitFlag::ReuseIndices;
-        FreeSlots &unused = st.unused_variables;
+    Variable *vo = &st.variables[index];
+    jitc_assert(vo->ref_count == 0 && vo->ref_count_se == 0,
+                "jit_var_new(): selected entry of variable r%u "
+                "is already used.", index);
 
-        if (unlikely(unused.empty() || !reuse_indices)) {
-            index = (uint32_t) st.variables.size();
-            st.variables.emplace_back();
-        } else {
-            index = unused.pop();
+    // Snapshot the LVN key before overwriting the slot
+    VariableKey key(v);
+    v.counter = vo->counter;
+    *vo = v;
+
+    bool cse_hit = false;
+    if (lvn) {
+        auto [it, inserted] = st.lvn_map.try_emplace(key, index);
+
+        if (unlikely(!inserted)) {
+            // CSE hit: undo the speculative allocation and reuse the existing
+            // variable. The slot's contents do not matter while it is unused
+            // (its generation 'counter' was preserved by the write above).
+            cse_hit = true;
+            if (from_unused)
+                unused.push(index);
+            else
+                st.variables.pop_back();
+
+            if (likely(!v.write_ptr)) {
+                for (int i = 0; i < 4; ++i)
+                    jitc_var_dec_ref(v.dep[i]);
+            } else {
+                jitc_var_dec_ref_se(v.dep[3]);
+            }
+
+            index = it.value();
+            vo = &st.variables[index];
+            jitc_assert(VariableKey(*vo) == key,
+                        "jit_var_new(): LVN data structure is out of sync! (1)");
+            jitc_assert(vo->ref_count != 0 || vo->ref_count_se != 0,
+                        "jit_var_new(): LVN data structure is out of sync! (2)");
         }
+    }
 
-        if (lvn_key_inserted)
-            key_it.value() = index;
-
-        vo = &st.variables[index];
-        jitc_assert(vo->ref_count == 0 && vo->ref_count_se == 0,
-                    "jit_var_new(): selected entry of variable r%u "
-                    "is already used.", index);
-
-        v.counter = vo->counter;
-        *vo = v;
-
+    // If a new variable was created, attach an optional label
+    if (likely(!cse_hit)) {
         bool has_prefix = ts->prefix != nullptr,
              has_loc = (flags & (uint32_t) JitFlag::Debug) && (source_location_buf[0] != '\0');
 
@@ -795,20 +822,6 @@ uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
         }
 
         st.variable_counter++;
-    } else {
-        if (likely(!v.write_ptr)) {
-            for (int i = 0; i < 4; ++i)
-                jitc_var_dec_ref(v.dep[i]);
-        } else {
-            jitc_var_dec_ref_se(v.dep[3]);
-        }
-
-        index = key_it.value();
-        vo = &st.variables[index];
-        jitc_assert(VariableKey(*vo) == VariableKey(v),
-                    "jit_var_new(): LVN data structure is out of sync! (1)");
-        jitc_assert(vo->ref_count != 0 || vo->ref_count_se != 0,
-                    "jit_var_new(): LVN data structure is out of sync! (2)");
     }
 
     if (unlikely(std::max(st.log_level_stderr, st.log_level_callback) >=
@@ -838,7 +851,7 @@ uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
             var_buffer.put(")");
         }
 
-        bool lvn_hit = lvn && !lvn_key_inserted,
+        bool lvn_hit = cse_hit,
              show_lit = v.is_node() && !v.is_undefined() &&
                         (VarKind) v.kind != VarKind::BoundsCheck &&
                         (VarType) v.type != VarType::Void && v.literal;
@@ -873,7 +886,7 @@ uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
     jitc_sanitation_checkpoint();
 #endif
 
-#ifndef NDEBUG
+#if !defined(NDEBUG)
     if (v.is_evaluated())
         state.ptr_to_variable.insert({ v.data, index });
 #endif

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -47,70 +47,70 @@ const char *type_name_short[(int) VarType::Count] {
     "u32", "i64", "u64", "ptr", "???", "f16", "f32", "f64"
 };
 
+// ------- NameTable tables for the StringFormatter -------
+// Note: entries must be shorter than 6 characters (or they
+// will be truncated.)
+
 /// CUDA PTX type names
-const char *type_name_ptx[(int) VarType::Count] {
+const NameTable<(size_t) VarType::Count> type_name_ptx({
     "???", "pred", "???", "s8",  "u8",  "s16", "u16", "s32",
     "u32", "s64",  "u64", "u64", "???", "f16", "f32", "f64"
-};
+});
 
 /// CUDA PTX type names (binary view, even for masks)
-const char *type_name_ptx_bin2[(int) VarType::Count] {
+const NameTable<(size_t) VarType::Count> type_name_ptx_bin2({
     "???", "b8", "???", "b8",  "b8",  "b16", "b16", "b32",
     "b32", "b64",  "b64", "b64", "???", "b16", "b32", "b64"
-};
+});
 
 /// CUDA PTX type names (binary view)
-const char *type_name_ptx_bin[(int) VarType::Count] {
+const NameTable<(size_t) VarType::Count> type_name_ptx_bin({
     "???", "pred", "???", "b8",  "b8",  "b16", "b16", "b32",
     "b32", "b64",  "b64", "b64", "???", "b16", "b32", "b64"
-};
+});
 
 /// LLVM IR type names (does not distinguish signed vs unsigned)
-const char *type_name_llvm[(int) VarType::Count] {
+const NameTable<(size_t) VarType::Count> type_name_llvm({
     "???", "i1",  "???", "i8",  "i8",   "i16",   "i16",   "i32",
     "i32", "i64", "i64", "i64", "???", "half", "float", "double"
-};
+});
 
-/// Metal Shading Language type names. Apple GPUs have no hardware FP64, so
-/// Float64 is promoted to Float32 in jitc_var_new() and never reaches codegen;
-/// its slot maps to `float` defensively. Pointer is folded to ulong, matching
-/// how PTX uses u64.
-const char *type_name_metal[(int) VarType::Count] {
+/// Metal Shading Language type names (with Float64->Float32 promotion)
+const NameTable<(size_t) VarType::Count> type_name_metal({
     "void",  "bool",  "???",   "char",  "uchar", "short", "ushort", "int",
     "uint",  "long",  "ulong", "ulong", "???",   "half",  "float",  "float"
-};
+});
 
 /// Metal Shading Language binary view (used for bitcasts and bit-wise ops).
-/// Bool is 1 byte but we treat it as ``uchar`` for binary access. The Float64
-/// slot is unused (promoted to Float32) but kept consistent at 32 bits.
-const char *type_name_metal_bin[(int) VarType::Count] {
+/// Bool is 1 byte but we treat it as ``uchar`` for binary access.
+const NameTable<(size_t) VarType::Count> type_name_metal_bin({
     "???",   "uchar", "???",   "uchar", "uchar", "ushort", "ushort", "uint",
     "uint",  "ulong", "ulong", "ulong", "???",   "ushort", "uint",   "uint"
-};
+});
 
 /// Double size integer arrays for mul_hi()
-const char *type_name_llvm_big[(int) VarType::Count] {
+const NameTable<(size_t) VarType::Count> type_name_llvm_big({
     "???", "???",  "???", "i16",  "i16", "i32", "i32", "i64",
     "i64", "i128", "i128", "???", "???", "???", "???", "???"
-};
+});
 
 /// Abbreviated LLVM IR type names
-const char *type_name_llvm_abbrev[(int) VarType::Count] {
+const NameTable<(size_t) VarType::Count> type_name_llvm_abbrev({
     "???", "i1",  "???", "i8",  "i8",  "i16", "i16", "i32",
     "i32", "i64", "i64", "i64", "???", "f16", "f32", "f64"
-};
+});
 
 /// LLVM IR type names (binary view)
-const char *type_name_llvm_bin[(int) VarType::Count] {
+const NameTable<(size_t) VarType::Count> type_name_llvm_bin({
     "???", "i1",  "???", "i8",  "i8",  "i16", "i16", "i32",
     "i32", "i64", "i64", "i64", "???", "i16", "i32", "i64"
-};
+});
 
 /// LLVM/CUDA register name prefixes
-const char *type_prefix[(int) VarType::Count] {
+const NameTable<(size_t) VarType::Count> type_prefix({
     "%u", "%p", "???", "%b", "%b", "%w", "%w", "%r",
     "%r", "%rd", "%rd", "%rd", "???", "%h", "%f", "%d"
-};
+});
 
 /// Maps types to byte sizes
 const uint32_t type_size[(int) VarType::Count] {

--- a/src/var.h
+++ b/src/var.h
@@ -353,17 +353,39 @@ extern const char *type_name      [(int) VarType::Count];
 extern const char *type_name_short[(int) VarType::Count];
 extern const uint32_t type_size   [(int) VarType::Count];
 
+/// Fixed-width, length-tagged storage for the per-VarType name tables that the
+/// IR formatters consult on the hot codegen path. Entries must be shorter than
+/// 6 characters or they will be truncated.
+template <size_t N> struct NameTable {
+    char data[N][8];
+    constexpr NameTable(const char *const (&src)[N]) : data{} {
+        for (size_t i = 0; i < N; ++i) {
+            size_t j = 0;
+            for (; j < 8 && src[i][j] != '\0'; ++j) // j < 8: never write OOB
+                data[i][j] = src[i][j];
+
+#if !defined(NDEBUG)
+            if (j > 6)
+                throw "NameTable entry exceeds 6 characters";
+#endif
+
+            data[i][7] = (char) j; // length tag in byte 7
+        }
+    }
+    constexpr const char *operator[](size_t i) const { return data[i]; }
+};
+
 /// Type names and register names for CUDA and LLVM
-extern const char *type_name_llvm       [(int) VarType::Count];
-extern const char *type_name_llvm_bin   [(int) VarType::Count];
-extern const char *type_name_llvm_abbrev[(int) VarType::Count];
-extern const char *type_name_llvm_big   [(int) VarType::Count];
-extern const char *type_name_ptx        [(int) VarType::Count];
-extern const char *type_name_ptx_bin    [(int) VarType::Count];
-extern const char *type_name_ptx_bin2   [(int) VarType::Count];
-extern const char *type_name_metal      [(int) VarType::Count];
-extern const char *type_name_metal_bin  [(int) VarType::Count];
-extern const char *type_prefix          [(int) VarType::Count];
+extern const NameTable<(size_t) VarType::Count> type_name_llvm;
+extern const NameTable<(size_t) VarType::Count> type_name_llvm_bin;
+extern const NameTable<(size_t) VarType::Count> type_name_llvm_abbrev;
+extern const NameTable<(size_t) VarType::Count> type_name_llvm_big;
+extern const NameTable<(size_t) VarType::Count> type_name_ptx;
+extern const NameTable<(size_t) VarType::Count> type_name_ptx_bin;
+extern const NameTable<(size_t) VarType::Count> type_name_ptx_bin2;
+extern const NameTable<(size_t) VarType::Count> type_name_metal;
+extern const NameTable<(size_t) VarType::Count> type_name_metal_bin;
+extern const NameTable<(size_t) VarType::Count> type_prefix;
 extern const char *type_size_str        [(int) VarType::Count];
 
 void jitc_var_set_data(Variable &v, void *data);

--- a/tests/microbenchmark.cpp
+++ b/tests/microbenchmark.cpp
@@ -4,10 +4,17 @@
 // the Collatz sequence). However, in doing so, it exercises various internal
 // data structures (locks, variable table, hash table for local value numbering)
 // and can therefore be used to identify performance bottlenecks.
+//
+// By default the program only *traces* the computation (building a large
+// expression graph) without ever evaluating it. Pass the '-e' flag to also
+// evaluate the result of each outer iteration. This additionally exercises the
+// scheduling, code generation, kernel hashing, and kernel cache lookup paths
+// (the first evaluation compiles a kernel, the rest are cache hits).
 
 #include <drjit-core/array.h>
 #include <chrono>
 #include <cstdio>
+#include <cstring>
 
 namespace dr = drjit;
 
@@ -17,18 +24,40 @@ UInt32 collatz(UInt32 x) {
     return select(eq(x & UInt32(1), 0), x / 2, x*3 + 1);
 }
 
-int main(int, char **) {
+int main(int argc, char **argv) {
+    bool evaluate = false;
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "-e") == 0)
+            evaluate = true;
+        else {
+            fprintf(stderr, "Usage: %s [-e]\n", argv[0]);
+            return 1;
+        }
+    }
+
+    jit_set_log_level_stderr(LogLevel::Warn);
+    jit_llvm_set_thread_count(0);
     jit_init(1u << (uint32_t) JitBackend::LLVM);
 
     using namespace std::chrono;
 
+    // When evaluating, the per-iteration kernel is much heavier, so use a
+    // smaller chain to keep runtimes comparable.
+    uint32_t outer = evaluate ? 1024 : 1024;
+    uint32_t steps = evaluate ? 256 : 4096;
+
+    printf("Mode: %s, outer=%u, steps=%u\n",
+           evaluate ? "trace+eval" : "trace-only", outer, steps);
+
     for (int k = 0; k < 3; ++k) {
         auto start = high_resolution_clock::now();
 
-        for (uint32_t j = 0; j < 1024; ++j) {
+        for (uint32_t j = 0; j < outer; ++j) {
             UInt32 i = dr::arange<UInt32>(1024);
-            for (uint32_t l = 0; l < 4096; ++l)
+            for (uint32_t l = 0; l < steps; ++l)
                 i = collatz(i);
+            if (evaluate)
+                i.eval();
         }
 
         auto end = high_resolution_clock::now();

--- a/tests/microbenchmark.py
+++ b/tests/microbenchmark.py
@@ -1,0 +1,45 @@
+# Dr.Jit data structure microbenchmark (Python port of microbenchmark.cpp)
+#
+# Mirrors tests/microbenchmark.cpp: pointless symbolic Collatz arithmetic that
+# stresses the tracing hot path (locks, variable table, LVN hash table).
+#
+# By default it only *traces*. Pass '-e' to also evaluate each outer iteration
+# (exercises scheduling, codegen, kernel hashing and cache-hit paths).
+
+import sys
+import time
+import drjit as dr
+from drjit.llvm import UInt32
+
+
+def collatz(x):
+    return dr.select((x & UInt32(1)) == 0, x // 2, x * 3 + 1)
+
+
+def main():
+    evaluate = "-e" in sys.argv[1:]
+
+    dr.set_log_level(dr.LogLevel.Warn)
+    dr.set_thread_count(0)
+
+    # Match the C++ benchmark's sizes exactly.
+    outer = 1024
+    steps = 256 if evaluate else 4096
+
+    print("Mode: %s, outer=%u, steps=%u"
+          % ("trace+eval" if evaluate else "trace-only", outer, steps))
+
+    for k in range(3):
+        start = time.perf_counter()
+        for j in range(outer):
+            i = dr.arange(UInt32, 1024)
+            for _ in range(steps):
+                i = collatz(i)
+            if evaluate:
+                dr.eval(i)
+        end = time.perf_counter()
+        print("Iteration %i took %.2f ms" % (k, (end - start) * 1000.0))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Dr.Jit (when used without the `@dr.freeze` feature) is often bottlenecked by tracing costs. This involves variable creation/teardown and the cost of generating and hashing the kernel code. It turns out that both of these code paths have quite a bit of optimization potential.

This sequence of commits was created by analyzing the critical path of a microbenchmark, both for tracing alone, and tracing+evaluation of a simple test workload. Each commit lists the individual and compound improvement.

What I found surprising is that the bottleneck often wasn't related to the # of instructions being executed, but long term dependencies that harmed out-of-order execution. By breaking dependency chains and doing some steps speculatively, latencies can be better overlapped, which gives substantial speedups for simple steps like "create a Dr.Jit variable".

Final state:
```
Compound improvement:
instructions:  -34.3% trace, -42.6% codegen
trace:         3596.09 -> 1971.71 ms (45.2% faster)
trace+codegen: 371.62 -> 201.59 ms (45.8% faster)
```