### PR TITLE
Better handling of failed `jit_eval()` calls

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -452,6 +452,30 @@ void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
                                           v->reg_index, v->param_offset });
     }
 
+    /// Restore changes to 'schedule' when the function returns or throw
+    struct RestoreGuard {
+        std::vector<JitBackupRecord> &backup;
+
+        ~RestoreGuard() {
+            for (ScheduledVariable &sv : schedule) {
+                Variable *v = jitc_var(sv.index);
+                v->reg_index = 0;
+                v->output_flag = false;
+                jitc_var_dec_ref(sv.index, v);
+            }
+
+            schedule.clear();
+            for (const JitBackupRecord &b : backup) {
+                Variable *v = jitc_var(b.sv.index);
+                v->param_type = b.param_type;
+                v->output_flag = b.output_flag;
+                v->reg_index = b.reg_index;
+                v->param_offset = b.param_offset;
+                schedule.push_back(b.sv);
+            }
+        }
+    } restore_guard { backup };
+
     // =========================================================
     // 2. Determine size and alignment of parameter and return
     //    value buffers. Unreferenced return values present an
@@ -575,15 +599,7 @@ void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
     // 4. Restore previously backed-up JIT state
     // =====================================================
 
-    schedule.clear();
-    for (const JitBackupRecord &b : backup) {
-        Variable *v = jitc_var(b.sv.index);
-        v->param_type = b.param_type;
-        v->output_flag = b.output_flag;
-        v->reg_index = b.reg_index;
-        v->param_offset = b.param_offset;
-        schedule.push_back(b.sv);
-    }
+    // Main cleanup happens when 'restore_guard' leaves the scope
 
     // Undo previous change (for more sensible debug out put about buffer sizes)
     if (jitc_is_llvm(call->backend))

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -782,8 +782,14 @@ Task *jitc_run(ThreadState *ts, ScheduledGroup group) {
     if(unlikely(jit_flag(JitFlag::KernelHistory)))
         e = &kernel_history_entry;
 
-    return ts->launch(kernel, kernel_key, kernel_hash, group.size,
-                      kernel_params, kernel_param_ids, e);
+    Task *task = ts->launch(kernel, kernel_key, kernel_hash, group.size,
+                            kernel_params, kernel_param_ids, e);
+
+    // The kernel history now owns the entry's 'ir' string (if enabled);
+    // jitc_eval_rollback() frees this pointer when it is still non-null
+    kernel_history_entry.ir = nullptr;
+
+    return task;
 }
 
 static ProfilerRegion profiler_region_eval("jit_eval");
@@ -857,6 +863,44 @@ static void jitc_schedule_sort() {
     schedule.swap(schedule_scratch);
 }
 
+/* Called when an exception interrupts jitc_eval_impl() partway through.
+   (E.g. when running out of memory or when a code generation routine throws).
+   Release references and memory. */
+static void jitc_eval_rollback(size_t callbacks_baseline) {
+    for (ScheduledVariable &sv : schedule) {
+        Variable *v = jitc_var(sv.index);
+        v->reg_index = 0;
+        v->output_flag = false;
+        if (sv.data)
+            jitc_free(sv.data);
+        jitc_var_dec_ref(sv.index, v);
+    }
+    schedule.clear();
+
+    // Temporary references taken during root collection
+    for (uint32_t index : eval_roots)
+        jitc_var_dec_ref(index);
+    eval_roots.clear();
+
+    // References owned by the dequeued side effects.
+    for (const EvalTask &t : eval_tasks) {
+        if (t.side_effect)
+            jitc_var_dec_ref(t.index);
+    }
+    eval_tasks.clear();
+    visit_later.clear();
+
+    // Callbacks enqueued on behalf of kernels that never ran
+    while (eval_callbacks.size() > callbacks_baseline) {
+        jitc_var_dec_ref(eval_callbacks.back());
+        eval_callbacks.pop_back();
+    }
+
+    // IR string of a kernel history entry that no launch consumed
+    free(kernel_history_entry.ir);
+    kernel_history_entry.ir = nullptr;
+}
+
 /// Evaluate all computation that is queued on the given ThreadState
 void jitc_eval(ThreadState *ts) {
     if (!ts || (ts->scheduled.empty() && ts->side_effects.empty()))
@@ -876,7 +920,14 @@ void jitc_eval(ThreadState *ts) {
         lock_release(state.lock);
         lock_guard guard(state.eval_lock);
         lock_acquire(state.lock);
-        jitc_eval_impl(ts);
+
+        size_t callbacks_baseline = eval_callbacks.size();
+        try {
+            jitc_eval_impl(ts);
+        } catch (...) {
+            jitc_eval_rollback(callbacks_baseline);
+            throw;
+        }
     }
 
     if (unlikely(!eval_callbacks.empty())) {
@@ -979,6 +1030,7 @@ void jitc_eval_impl(ThreadState *ts) {
     // Release the temporary references taken during root collection.
     for (uint32_t index: eval_roots)
         jitc_var_dec_ref(index);
+    eval_roots.clear();
 
     if (schedule.empty())
         return;
@@ -1088,7 +1140,12 @@ XXH128_hash_t jitc_assemble_func(const CallData *call, uint32_t inst,
     jitc_visit_new_gen();
     visit_later.clear();
     schedule.clear();
-    callable_depth++;
+
+    // Track callable depth using an RAII guard (assembly may raise)
+    struct ScopedCallableDepth {
+        ScopedCallableDepth() { callable_depth++; }
+        ~ScopedCallableDepth() { callable_depth--; }
+    } scoped_callable_depth;
 
     const std::vector<uint32_t> &check = call->checkpoints;
 
@@ -1152,7 +1209,6 @@ XXH128_hash_t jitc_assemble_func(const CallData *call, uint32_t inst,
         default:
             jitc_fail("jitc_assemble_func(): unsupported backend!");
     }
-    callable_depth--;
 
     size_t kernel_length = buffer.size() - kernel_offset;
 
@@ -1199,6 +1255,10 @@ XXH128_hash_t jitc_assemble_func(const CallData *call, uint32_t inst,
         v->output_flag = false;
         jitc_var_dec_ref(sv.index, v);
     }
+
+    // The references owned by the schedule entries are now consumed (the
+    // unwind path of jitc_var_call_assemble() releases any still present)
+    schedule.clear();
 
     return kernel_hash;
 }

--- a/tests/mem.cpp
+++ b/tests/mem.cpp
@@ -325,3 +325,91 @@ TEST_ALL(18_scatter_inc_mask) {
     UInt32 arbitrary = scatter_inc(counter, idx, all_false);
     jit_assert(jit_var_size(arbitrary.index()) == 7);
 }
+
+TEST_ALL(19_eval_exception_rollback) {
+    /* An exception raised during jit_eval() (here: a kernel that depends on
+       an already-consumed scatter_inc() result) must not leak variable
+       references or output buffers, and must not leave side effect targets
+       in a permanently dirty state. */
+    constexpr uint32_t n = 1024;
+
+    // Produce a consumed variable: 'offset' is computed and consumed by the
+    // kernel that evaluates 'y' and cannot be recomputed afterwards
+    UInt32 counter(0);
+    UInt32 offset = scatter_inc(counter, UInt32(0), full<Mask>(true, n));
+    UInt32 y = offset + 1;
+    UInt32 z = offset + 2; // not scheduled below; 'offset' expires under it
+    y.eval();
+    jit_assert(all(eq(counter, n)));
+
+    // Queue a side effect; it is later discarded by the failed evaluation
+    UInt32 idx = arange<UInt32>(n);
+    UInt32 target = zeros<UInt32>(n);
+    scatter(target, idx, idx);
+    jit_assert(jit_var_state(target.index()) == VarState::Dirty);
+
+    for (int i = 0; i < 2; ++i) {
+        try {
+            z.eval();
+            jit_fail("19_eval_exception_rollback(): Exception not raised!");
+        } catch (const std::exception &e) {
+            jit_assert(strstr(e.what(), "consumed") != nullptr);
+        }
+
+        // References taken during the failed evaluation were released again
+        jit_assert(jit_var_ref(z.index()) == 1);
+        jit_assert(jit_var_ref(offset.index()) == 2); // user ref + 'z'
+
+        // The discarded side effect no longer marks 'target' as dirty
+        jit_assert(jit_var_state(target.index()) == VarState::Evaluated);
+    }
+
+    // 'target' remains usable, with its pre-scatter contents
+    jit_assert(all(eq(target, zeros<UInt32>(n))));
+
+    // Unrelated computation evaluates fine afterwards
+    UInt32 w = idx * 3;
+    w.eval();
+    jit_assert(all(eq(w, arange<UInt32>(n) * 3)));
+}
+
+TEST_ALL(20_eval_exception_rollback_partial) {
+    /* Variant of the above where the exception strikes while a kernel is
+       being assembled: a kernel of the same jit_eval() call that was already
+       launched must be rolled back as well (in particular, its not-yet-
+       attached output buffer). The error is triggered via an inconsistent
+       scope nesting, which jitc_assemble() detects. */
+    constexpr uint32_t n = 1024;
+
+    // This (larger) variable forms a separate kernel that is launched first
+    UInt32 big = arange<UInt32>(2 * n);
+    UInt32 a = big + 5;
+
+    // Construct a variable whose dependency has a *higher* scope ID
+    UInt32 x = arange<UInt32>(n) + 1;
+    uint32_t lo = jit_scope(Backend);
+    jit_new_scope(Backend);
+    UInt32 xh = x + 3;
+    jit_set_scope(Backend, lo);
+    UInt32 y = xh + 7; // y's scope precedes that of its dependency 'xh'
+    jit_new_scope(Backend);
+
+    jit_var_schedule(a.index());
+    jit_var_schedule(y.index());
+
+    try {
+        jit_eval();
+        jit_fail("20_eval_exception_rollback_partial(): Exception not raised!");
+    } catch (const std::exception &e) {
+        jit_assert(strstr(e.what(), "scope") != nullptr);
+    }
+
+    // References taken during the failed evaluation were released again
+    jit_assert(jit_var_ref(a.index()) == 1);
+    jit_assert(jit_var_ref(y.index()) == 1);
+
+    // 'a' was rolled back rather than committed, and can be evaluated again
+    jit_assert(jit_var_state(a.index()) == VarState::Unevaluated);
+    a.eval();
+    jit_assert(all(eq(a, arange<UInt32>(2 * n) + 5)));
+}


### PR DESCRIPTION
Operations within the central kernel evaluation function ``jitc_eval()`` can raise an exception, e.g., when when the target device runs out of memory. This previously left Dr.Jit in an unsatisfactory state involving reference leaks, memory leaks, variables with pending side effects that could never execute. This commit adds guards that catch exceptions and properly clean up.