### PR TITLE
Fix loop codegen crash when two state variables share one update value

### DIFF
--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -441,7 +441,7 @@ void jitc_cuda_render_loop_end(Variable *a0) {
 
         fmt("    .reg.$b $v_tmp;\n"
             "    mov.$b $v_tmp, $v;\n",
-            in, in, in, in, out);
+            out, out, out, out, out);
 
         // Mark that we have created a temporary
         out->scratch = 2;
@@ -455,7 +455,7 @@ void jitc_cuda_render_loop_end(Variable *a0) {
             continue;
 
         if (out->scratch == 2)
-            fmt("    mov.$b $v, $v_tmp;\n", in, in, in);
+            fmt("    mov.$b $v, $v_tmp;\n", in, in, out);
         else
             fmt("    mov.$b $v, $v;\n", in, in, out);
     }

--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -814,7 +814,7 @@ static void jitc_metal_render(Variable *v) {
                 if (in == out || !in->reg_index || !out->reg_index ||
                     in->is_array() || out->scratch != 1)
                     continue;
-                fmt("$t $v_tmp = $v;\n", in, in, out);
+                fmt("$t $v_tmp = $v;\n", out, out, out);
                 out->scratch = 2;
             }
 
@@ -825,7 +825,7 @@ static void jitc_metal_render(Variable *v) {
                     in->is_array())
                     continue;
                 if (out->scratch == 2)
-                    fmt("$v = $v_tmp;\n", in, in);
+                    fmt("$v = $v_tmp;\n", in, out);
                 else
                     fmt("$v = $v;\n", in, out);
             }


### PR DESCRIPTION
At the end of a symbolic loop, the CUDA and Metal backends use temporaries to break aliasing between state slots. The temporary was keyed on the destination register, so when two state variables take their next value from the same source, only the first temporary was declared and the second writeback referenced an undeclared register, ptxas then rejected the kernel (`Unknown symbol '%f10_tmp'`); similar error for MSL on Metal.

Fix: key the temporary on the source register, so all slots reading the same variable share one snapshot.

Minimal reproducer:

```python
​import drjit as dr
from drjit.cuda import Float, UInt32

@dr.syntax
def f():
    a, b, c = Float(1, 2), Float(3, 4), Float(5, 6)
    i = UInt32(0, 0)
    while i < 3:
        a, b, c = c, c + 0, a
        i += 1
    return a, b, c

f()  # before: ptxas fatal; after: ([5, 6], [5, 6], [1, 2])
```