### PR TITLE
Function calls v2.0

### DIFF
--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -906,6 +906,33 @@ extern JIT_EXPORT uint32_t jit_var_gather(uint32_t source, uint32_t index,
                                           uint32_t mask);
 
 /**
+ * \brief Build a getter as a gather from the kernel's call data buffer.
+ *
+ * This function generates IR that conceptually evaluates the expression
+ * ```
+ * result = (mask && index != 0) ? values[index-1] : 0
+ * ```
+ * on the device (taking some freedom with the notation).
+ *
+ * In particular, note that ``values`` is an array of ``count`` indices of
+ * scalar literal or scalar evaluated variables (a zero entry denotes an absent
+ * source that reads as zero). ``index`` and ``mask`` are device-side arrays (a
+ * 32-bit unsigned integer and a boolean, respectively).
+ *
+ * The result is therefore an indirection that fetches a scalar from one of
+ * multiple sources. Dr.Jit uses this functionality to efficiently compile
+ * "getters" for C++ instance arrays.
+ *
+ * Dr.Jit emits efficient machine code for this operation by placing the
+ * data into the call data buffer shared with ``jit_var_call()``.
+ */
+extern JIT_EXPORT uint32_t jit_var_call_getter(JIT_ENUM VarType type,
+                                               uint32_t count,
+                                               const uint32_t *values,
+                                               uint32_t index,
+                                               uint32_t mask);
+
+/**
  * \brief Gather a contiguous packet of values
  *
  * This function is analogous to (but generally more efficient than)

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -822,6 +822,13 @@ uint32_t jit_var_gather(uint32_t source, uint32_t index, uint32_t mask) {
     return jitc_var_gather(source, index, mask);
 }
 
+uint32_t jit_var_call_getter(VarType type, uint32_t count,
+                             const uint32_t *values, uint32_t index,
+                             uint32_t mask) {
+    lock_guard guard(state.lock);
+    return jitc_var_call_getter(type, count, values, index, mask);
+}
+
 void jit_var_gather_packet(size_t n, uint32_t source, uint32_t index, uint32_t mask, uint32_t *out) {
     lock_guard guard(state.lock);
     jitc_var_gather_packet(n, source, index, mask, out);

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -29,6 +29,41 @@ std::vector<CallData *> calls_assembled;
 extern void jitc_var_call_analyze(CallData *call, uint32_t inst_id,
                                   uint32_t index, uint32_t &data_offset);
 
+// Dr.Jit callables receive captured state through a flat per-instance data
+// block storing pointers to referenced opaque scalars and pointers. This
+// function walks through all such references ("slots") of an instance ``inst``,
+// populating their ``param_offset`` member with the logical variable offset
+// within the data block.
+void jitc_call_bind_slots(const CallData *call, uint32_t inst) {
+    for (uint32_t k = call->slot_range[inst]; k < call->slot_range[inst + 1]; ++k) {
+        if (Variable *v = jitc_var(call->slots[k].ref))
+            v->param_offset = k;
+    }
+}
+
+/// Given an opaque variable ``v`` encountered in a function call ``call``, this
+/// function checks if the variable has a corresponding capture slot, and it then
+/// returns the relative position in the data block. Otherwise it fails with an
+/// error message. This extra check is important to catch situations where new
+/// IR nodes haven't been correctly wired up in the DFS traversal in call.cpp.
+uint32_t jitc_call_slot_rel_offset(const CallData *call, uint32_t inst,
+                                   const Variable *v, uint32_t index) {
+    uint32_t k = v->param_offset;
+    if (likely(k >= call->slot_range[inst] &&
+               k <  call->slot_range[inst + 1] &&
+               jitc_var(call->slots[k].ref) == v))
+        return call->slots[k].offset - call->instance_offset[inst];
+
+    if (v->is_evaluated())
+        jitc_fail("jitc_call_slot_rel_offset(): variable r%u is referenced by a "
+                  "recorded function call. However, it was evaluated between the "
+                  "recording step and code generation (which is happening now). "
+                  "This is not allowed.", index);
+    else
+        jitc_fail("jitc_call_slot_rel_offset(): could not find call-data slot for "
+                  "variable r%u in function %s", index, call->name.c_str());
+}
+
 /// Weave a virtual function call into the computation graph
 void jitc_var_call(const char *name, bool symbolic, uint32_t self,
                    uint32_t mask_, uint32_t n_inst, uint32_t max_inst_id,
@@ -215,9 +250,11 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
     // 4. Collect evaluated data accessed by the instances
     // =====================================================
 
-    call->data_offset.reserve(n_inst);
+    call->instance_offset.reserve(n_inst);
+    call->slot_range.reserve(n_inst + 1);
 
-    // Collect accesses to evaluated variables/pointers
+    // Collect accesses to evaluated variables/pointers, appending a slot (with
+    // its byte offset) to 'slots' for each one in traversal order.
     uint32_t data_size = 0, inst_id_max = 0;
     for (uint32_t i = 0; i < n_inst; ++i) {
         if (unlikely(checkpoints[i] > checkpoints[i + 1]))
@@ -225,7 +262,12 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
                        "monotonically increasing!");
 
         uint32_t id = inst_id[i];
-        call->data_offset.push_back(data_size);
+
+        // Advance the traversal generation counter
+        jitc_visit_new_gen();
+
+        call->instance_offset.push_back(data_size);
+        call->slot_range.push_back((uint32_t) call->slots.size());
 
         for (uint32_t j = 0; j < n_out; ++j)
             jitc_var_call_analyze(call.get(), i, inner_out[j + i * n_out],
@@ -236,22 +278,24 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
                                   call->side_effects[j - checkpoints[0]],
                                   data_size);
 
-        // Restore to full alignment
-        data_size = (data_size + 7) / 8 * 8;
+        // Restore to full (8-byte) alignment
+        data_size = align_up(data_size, 8);
+
         inst_id_max = std::max(id, inst_id_max);
     }
+    call->slot_range.push_back((uint32_t) call->slots.size());
 
     // Allocate memory + wrapper variables for call offset and data arrays
-    call->offset_size = (inst_id_max + 1) * sizeof(uint64_t);
+    call->offset_table_size = (inst_id_max + 1) * sizeof(uint64_t);
 
-    call->offset = (uint64_t *) jitc_malloc(backend, call->offset_size);
+    call->offset_table = (uint64_t *) jitc_malloc(backend, call->offset_table_size);
     uint8_t *data_d = (uint8_t *) jitc_malloc(backend, data_size);
 
     Ref data_buf, data_v,
         offset_buf = steal(jitc_var_mem_map(
-            backend, VarType::UInt64, call->offset, inst_id_max + 1, 1)),
+            backend, VarType::UInt64, call->offset_table, inst_id_max + 1, 1)),
         offset_v =
-            steal(jitc_var_pointer(backend, call->offset, offset_buf, 0));
+            steal(jitc_var_pointer(backend, call->offset_table, offset_buf, 0));
 
     char temp[128];
     snprintf(temp, sizeof(temp), "Call: %s [offsets]", name);
@@ -265,35 +309,27 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
 
         data_v = steal(jitc_var_pointer(backend, data_d, data_buf, 0));
 
-        size_t agg_size = sizeof(AggregationEntry) * call->data_map.size();
+        size_t agg_size = sizeof(AggregationEntry) * call->slots.size();
         AggregationEntry *agg = (AggregationEntry *)
             jitc_malloc(backend, agg_size, /*shared=*/true);
 
         AggregationEntry *p = agg;
 
-        for (auto kv : call->data_map) {
-            uint32_t index = (uint32_t) kv.first, offset = kv.second;
-            if (offset == (uint32_t) -1)
-                continue;
-
-            const Variable *v = jitc_var(index);
+        // 'slots' holds only real slots, with offsets assigned ascending
+        // within each instance and instances concatenated in order, so the flat
+        // list is already globally offset-ascending (no skip, no sort needed).
+        for (const CallData::CaptureSlot &slot : call->slots) {
+            const Variable *v = jitc_var(slot.ref);
             bool is_pointer = (VarType) v->type == VarType::Pointer;
-            p->offset = offset;
+            p->offset = slot.offset;
             p->size = is_pointer ? (int16_t) 8 : (int16_t) -(int) type_size[v->type];
             p->resource_kind = is_pointer ? (uint16_t) v->resource_kind() : (uint16_t) 0;
             p->src = is_pointer ? (const void *) v->literal : v->data;
             p++;
         }
 
-        std::sort(agg, p,
-                  [](const AggregationEntry &a, const AggregationEntry &b) {
-                      return a.offset < b.offset;
-                  });
-
         jitc_aggregate(backend, data_d, agg, (uint32_t) (p - agg));
         jitc_free(agg);
-    } else {
-        call->data_map.clear();
     }
 
     // =====================================================
@@ -532,10 +568,8 @@ void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
         out_align = in_align;
 
         // Ensure alignment given that we're appending to the input buffer
-        if (!call_perm.empty()) {
-            const uint32_t size = call_perm[0].size;
-            out_size = (out_size + size - 1) / size * size;
-        }
+        if (!call_perm.empty())
+            out_size = align_up(out_size, call_perm[0].size);
     }
 
     for (PermKey k : call_perm) {
@@ -622,12 +656,14 @@ void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
 /// Collect scalar / pointer variables referenced by a computation
 void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
                            uint32_t &data_offset) {
-    uint64_t key = (uint64_t) index + (((uint64_t) inst_id) << 32);
-    auto it_and_status = call->data_map.emplace(key, (uint32_t) -1);
-    if (!it_and_status.second)
-        return;
+    Variable *v = jitc_var(index);
 
-    const Variable *v = jitc_var(index);
+    // Do not visit nodes multiple times. See eval.cpp for details on
+    // the visit generation counting scheme.
+    uint32_t stamp = visit_gen << 1;
+    if (v->scratch == stamp)
+        return;
+    v->scratch = stamp;
 
     if (v->optix)
         call->use_optix |= true;
@@ -693,10 +729,12 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
                 jitc_var_call_analyze(call, inst_id, td->values[i], data_offset);
         }
     } else if (v->is_evaluated() || (VarType) v->type == VarType::Pointer) {
-        uint32_t tsize = type_size[v->type],
-                 offset = (data_offset + tsize - 1) / tsize * tsize;
-        it_and_status.first.value() = offset;
-        data_offset = offset + tsize;
+        // Real data slot. Assign a byte offset with natural alignment and append
+        // it to the current instance's run in 'slots'.
+        uint32_t tsize = type_size[v->type];
+        data_offset = align_up(data_offset, tsize);
+        call->slots.push_back({ WeakRef(index, v->counter), data_offset });
+        data_offset += tsize;
 
         if (v->size != 1)
             jitc_raise(
@@ -719,9 +757,9 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
 void jitc_call_upload(ThreadState *ts) {
     for (CallData *call : calls_assembled) {
         uint64_t *data = (uint64_t *) jitc_malloc(
-            (JitBackend) ts->backend, call->offset_size, /*shared=*/true);
+            (JitBackend) ts->backend, call->offset_table_size, /*shared=*/true);
 
-        memset(data, 0, call->offset_size);
+        memset(data, 0, call->offset_table_size);
 
         for (uint32_t i = 0; i < call->n_inst; ++i) {
             auto it = globals_map.find(GlobalKey(call->inst_hash[i], call->n_inst != 1 ? GlobalType::IndirectCallable : GlobalType::Callable));
@@ -731,11 +769,11 @@ void jitc_call_upload(ThreadState *ts) {
 
             // high part: instance data offset, low part: callable index
             data[call->inst_id[i]] =
-                (((uint64_t) call->data_offset[i]) << 32) |
+                (((uint64_t) call->instance_offset[i]) << 32) |
                 callable_index;
         }
 
-        jitc_memcpy_async(ts->backend, call->offset, data, call->offset_size);
+        jitc_memcpy_async(ts->backend, call->offset_table, data, call->offset_table_size);
         jitc_free(data);
     }
 

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -26,6 +26,13 @@
 
 std::vector<CallData *> calls_assembled;
 
+/// Shared state for the per-kernel call-data buffer (see call.h).
+CallBufferState call_buffer;
+
+/// Reused scratch buffer holding one call's dense offset table while
+/// jitc_call_upload() builds the aggregate.
+static std::vector<uint64_t> offset_entries;
+
 extern void jitc_var_call_analyze(CallData *call, uint32_t inst_id,
                                   uint32_t index, uint32_t &data_offset);
 
@@ -285,69 +292,21 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
     }
     call->slot_range.push_back((uint32_t) call->slots.size());
 
-    // Allocate memory + wrapper variables for call offset and data arrays
-    call->offset_table_size = (inst_id_max + 1) * sizeof(uint64_t);
-
-    call->offset_table = (uint64_t *) jitc_malloc(backend, call->offset_table_size);
-    uint8_t *data_d = (uint8_t *) jitc_malloc(backend, data_size);
-
-    Ref data_buf, data_v,
-        offset_buf = steal(jitc_var_mem_map(
-            backend, VarType::UInt64, call->offset_table, inst_id_max + 1, 1)),
-        offset_v =
-            steal(jitc_var_pointer(backend, call->offset_table, offset_buf, 0));
+    // Record information needed at launch time to reserve a suitably sized
+    // region to store offsets this call's captured slots for jitc_aggregate()
+    call->data_size = data_size;
+    call->offset_count = inst_id_max + 1;
 
     char temp[128];
-    snprintf(temp, sizeof(temp), "Call: %s [offsets]", name);
-    jitc_var_set_label(offset_buf, temp);
-
-    if (data_size) {
-        data_buf = steal(
-            jitc_var_mem_map(backend, VarType::UInt8, data_d, data_size, 1));
-        snprintf(temp, sizeof(temp), "Call: %s [data]", name);
-        jitc_var_set_label(data_buf, temp);
-
-        data_v = steal(jitc_var_pointer(backend, data_d, data_buf, 0));
-
-        size_t agg_size = sizeof(AggregationEntry) * call->slots.size();
-        AggregationEntry *agg = (AggregationEntry *)
-            jitc_malloc(backend, agg_size, /*shared=*/true);
-
-        AggregationEntry *p = agg;
-
-        // 'slots' holds only real slots, with offsets assigned ascending
-        // within each instance and instances concatenated in order, so the flat
-        // list is already globally offset-ascending (no skip, no sort needed).
-        for (const CallData::CaptureSlot &slot : call->slots) {
-            const Variable *v = jitc_var(slot.ref);
-            bool is_pointer = (VarType) v->type == VarType::Pointer;
-            p->offset = slot.offset;
-            p->size = is_pointer ? (int16_t) 8 : (int16_t) -(int) type_size[v->type];
-            p->resource_kind = is_pointer ? (uint16_t) v->resource_kind() : (uint16_t) 0;
-            p->src = is_pointer ? (const void *) v->literal : v->data;
-            p++;
-        }
-
-        jitc_aggregate(backend, data_d, agg, (uint32_t) (p - agg));
-        jitc_free(agg);
-    }
 
     // =====================================================
     // 5. Create special variable representing the call op.
     // =====================================================
 
-    Ref call_v;
-
-    if (data_size)
-        call_v = steal(jitc_var_new_node_4(
-            backend, VarKind::Call, VarType::Void, size, symbolic, self,
-            jitc_var(self), mask, jitc_var(mask), offset_v, jitc_var(offset_v),
-            data_v, jitc_var(data_v)));
-    else
-        call_v = steal(
-            jitc_var_new_node_3(backend, VarKind::Call, VarType::Void, size,
-                                symbolic, self, jitc_var(self), mask,
-                                jitc_var(mask), offset_v, jitc_var(offset_v)));
+    Ref call_v = steal(
+        jitc_var_new_node_2(backend, VarKind::Call, VarType::Void, size,
+                            symbolic, self, jitc_var(self), mask,
+                            jitc_var(mask)));
 
     call->id = call_v;
     {
@@ -463,10 +422,24 @@ static std::vector<PermKey> call_perm;
 
 /// Called when Dr.Jit compiles a function call, specifically the 'Call' IR node
 void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
-                            uint32_t self_reg, uint32_t mask_reg,
-                            uint32_t offset_reg, uint32_t data_reg) {
+                            uint32_t self_reg, uint32_t mask_reg) {
 
     ProfilerPhase profiler(profiler_region_call_assemble);
+
+    // Reserve this call's slice of the call-data buffer. Nested calls reserve
+    // their slices the same way when the recursion below assembles them.
+    call->offset_base = call_buffer.fused_offset_size;
+    call->data_base   = call_buffer.fused_data_size;
+    call_buffer.fused_offset_size += call->offset_count * (uint32_t) sizeof(uint64_t);
+    call_buffer.fused_data_size   += call->data_size;
+
+    // Record this call's capture slots
+    for (const CallData::CaptureSlot &slot : call->slots) {
+        if (!jitc_var(slot.ref))
+            continue;
+        call_buffer.data_entries.push_back(
+            { borrow(slot.ref.index), call->data_base + slot.offset });
+    }
 
     // =====================================================
     // 1. Need to backup state before we can JIT recursively
@@ -613,17 +586,17 @@ void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
 
     if (jitc_is_llvm(call->backend))
         jitc_var_call_assemble_llvm(call, call_reg, self_reg, mask_reg,
-                                    offset_reg, data_reg, out_size, out_align);
+                                    out_size, out_align);
 #if defined(DRJIT_ENABLE_METAL)
     else if (jitc_is_metal(call->backend))
         jitc_var_call_assemble_metal(call, call_reg, self_reg, mask_reg,
-                                     offset_reg, data_reg, in_size, in_align,
+                                     in_size, in_align,
                                      out_size, out_align);
 #endif
 #if defined(DRJIT_ENABLE_CUDA)
     else
         jitc_var_call_assemble_cuda(call, call_reg, self_reg, mask_reg,
-                                    offset_reg, data_reg, in_size, in_align,
+                                    in_size, in_align,
                                     out_size, out_align);
 #else
     else
@@ -684,6 +657,10 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
         call->use_optix |= call2->use_optix;
         call->use_index |= call2->use_index;
         call->use_thread_id |= call2->use_thread_id;
+
+        // The enclosing callable contains a nested call, so it must receive
+        // a pointer to the buffer containing captured opaque state.
+        call->use_nested = true;
         for (uint32_t index_2: call2->outer_in)
             jitc_var_call_analyze(call, inst_id, index_2, data_offset);
     } else if (kind == VarKind::LoopCond) {
@@ -755,27 +732,92 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
 }
 
 void jitc_call_upload(ThreadState *ts) {
-    for (CallData *call : calls_assembled) {
-        uint64_t *data = (uint64_t *) jitc_malloc(
-            (JitBackend) ts->backend, call->offset_table_size, /*shared=*/true);
+    JitBackend backend = (JitBackend) ts->backend;
 
-        memset(data, 0, call->offset_table_size);
+    if (calls_assembled.empty()) {
+        jitc_assert(call_buffer.base_v == 0,
+                    "jitc_call_upload(): base allocated without calls!");
+        return;
+    }
+
+    jitc_assert(call_buffer.base_v != 0,
+                "jitc_call_upload(): kernel performs calls but has no "
+                "base pointer!");
+
+    const uint32_t off_size = call_buffer.fused_offset_size,
+                   total    = off_size + call_buffer.fused_data_size;
+
+    // Compute the number of aggregation entries. One per data slot, and
+    // two per offset. ``off_size`` counts 8 bytes per offset, so divide by 4.
+    size_t n_entries = call_buffer.data_entries.size() + off_size / 4;
+
+    AggregationEntry *agg = (AggregationEntry *) jitc_malloc(
+        backend, sizeof(AggregationEntry) * n_entries, /*shared=*/true);
+    AggregationEntry *p = agg;
+
+    // Part 1: offset tables. We deliberately store 64-bit offsets via two
+    // 32-bit writes so that ``record_ts.cpp`` wont try to to interpret the
+    // pointer address as a variable reference.
+    for (CallData *call : calls_assembled) {
+        offset_entries.assign(call->offset_count, 0);
 
         for (uint32_t i = 0; i < call->n_inst; ++i) {
-            auto it = globals_map.find(GlobalKey(call->inst_hash[i], call->n_inst != 1 ? GlobalType::IndirectCallable : GlobalType::Callable));
+            auto it = globals_map.find(GlobalKey(
+                call->inst_hash[i], call->n_inst != 1 ? GlobalType::IndirectCallable
+                                                      : GlobalType::Callable));
             if (it == globals_map.end())
                 jitc_fail("jitc_call_upload(): could not find callable!");
             uint32_t callable_index = it->second.callable_index;
 
-            // high part: instance data offset, low part: callable index
-            data[call->inst_id[i]] =
-                (((uint64_t) call->instance_offset[i]) << 32) |
-                callable_index;
+            // entry.hi = absolute byte offset of the instance's data block (from
+            // the start of the buffer); entry.lo = callable index.
+            uint64_t data_off = (uint64_t) off_size + call->data_base +
+                                call->instance_offset[i];
+            offset_entries[call->inst_id[i]] = (data_off << 32) | callable_index;
         }
 
-        jitc_memcpy_async(ts->backend, call->offset_table, data, call->offset_table_size);
-        jitc_free(data);
+        for (uint32_t i = 0; i < call->offset_count; ++i) {
+            uint64_t e = offset_entries[i];
+            uint32_t pos = call->offset_base + i * (uint32_t) sizeof(uint64_t);
+
+            p->offset = pos;
+            p->size = 4;
+            p->resource_kind = 0;
+            p->src = (const void *) (uintptr_t) (uint32_t) e;
+            p++;
+
+            p->offset = pos + 4;
+            p->size = 4;
+            p->resource_kind = 0;
+            p->src = (const void *) (uintptr_t) (uint32_t) (e >> 32);
+            p++;
+        }
     }
+
+    // Part 2: capture slots
+    for (const CallBufferState::CaptureSlotRef &e : call_buffer.data_entries) {
+        const Variable *v = jitc_var((uint32_t) e.src);
+        bool is_pointer = (VarType) v->type == VarType::Pointer;
+        p->offset        = e.offset + off_size;
+        p->size          = is_pointer ? (int16_t) 8 : (int16_t) -(int) type_size[v->type];
+        p->resource_kind = is_pointer ? (uint16_t) v->resource_kind() : (uint16_t) 0;
+        p->src           = is_pointer ? (const void *) v->literal : v->data;
+        p++;
+    }
+
+    uint8_t *buf = (uint8_t *) jitc_malloc(backend, total);
+    jitc_aggregate(backend, buf, agg, (uint32_t) (p - agg));
+    jitc_free(agg);
+
+    // Swap the aggregate buffer into the base pointer variable
+    Variable *base_src = jitc_var(call_buffer.base_src);
+    void *placeholder = base_src->data;
+    base_src->data = buf;
+    base_src->size = total;
+    if (placeholder)
+        jitc_free(placeholder);
+
+    jitc_var(call_buffer.base_v)->literal = (uint64_t) (uintptr_t) buf;
 
     for (CallData *call : calls_assembled)
         jitc_var_dec_ref(call->id);

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -5,6 +5,39 @@
 
     All rights reserved. Use of this source code is governed by a BSD-style
     license that can be found in the LICENSE file.
+
+    ==========================================================
+
+    This file implements the compilation of indirect ("virtual") function calls.
+    An indirect call dispatches each array element to one of several callables,
+    selected at runtime by a per-element instance index ('self'). Dr.Jit traces
+    every callable once, emits it as a separate function in the kernel, and
+    generates dispatch code that routes each lane to the matching callable.
+
+    A callable cannot reach into the surrounding computation directly. Instead,
+    any evaluated scalars and buffer/resource pointers it references are
+    captured into a per-instance "call data" block that the callable reads at
+    runtime. Entries in this block are denoted "slots". Each instance owns
+    a contiguous region in the call data block storing its slots.
+
+    Hoisting this data out of the callable body is also what makes callables
+    mergeable: instances whose IR differs only in captured values compile to the
+    same callable and are deduplicated. This shrinks the number of compiled
+    functions (reducing compilation time) and routes more lanes through the same
+    callable (improving SIMD/warp coherence).
+
+    All indirect calls in a kernel share a single device buffer laid out as
+
+        [ offset tables | data blocks ]
+
+    The dispatch indexes the offset table by 'self' to obtain the callable index
+    and the absolute offset of that instance's data block, from which it reads
+    the captured values.
+
+    Slots within an instance's datablock are arranged and padded so that data
+    can be efficiently loaded using wide packet memory transactions. Some fields
+    are excluded from this (e.g., opaque resource handles on Metal) because the
+    compilation model forbids reading them in this way.
 */
 
 #include <set>
@@ -13,6 +46,7 @@
 #include "call.h"
 #include "eval.h"
 #include "internal.h"
+#include "llvm.h"
 #include "log.h"
 #include "loop.h"
 #include "op.h"
@@ -26,40 +60,86 @@
 
 std::vector<CallData *> calls_assembled;
 
-/// Shared state for the per-kernel call-data buffer (see call.h).
+/// This global field stores the running call data state during compilation
 CallBufferState call_buffer;
 
-/// Reused scratch buffer holding one call's dense offset table while
-/// jitc_call_upload() builds the aggregate.
+/// Scratch buffer holding one call's offset table. Used in jitc_call_update().
 static std::vector<uint64_t> offset_entries;
 
-extern void jitc_var_call_analyze(CallData *call, uint32_t inst_id,
-                                  uint32_t index, uint32_t &data_offset);
+/// Widest call-data packet gather the LLVM backend may issue, in elements.
+static uint32_t llvm_call_data_packet_cap() {
+    return std::max(1u, std::min(8u, jitc_llvm_vector_width));
+}
 
-// Dr.Jit callables receive captured state through a flat per-instance data
-// block storing pointers to referenced opaque scalars and pointers. This
-// function walks through all such references ("slots") of an instance ``inst``,
-// populating their ``param_offset`` member with the logical variable offset
-// within the data block.
+/// Classify a call-data variable into a size bucket
+CallData::SizeBucket::SizeBucket(const Variable *v) {
+    bool coalesceable = true;
+
+#if defined(DRJIT_ENABLE_METAL)
+    if ((JitBackend) v->backend == JitBackend::Metal) {
+        VarType vt = (VarType) v->type;
+
+        // Opaque resource handles cannot be loaded through call-data packets.
+        if (vt == VarType::Pointer && v->resource_kind() != ResourceKind::Buffer)
+            coalesceable = false;
+
+        // Metal currently miscompiles 1-byte fields when reconstructed from
+        // packet words, so leave them in uncoalesced buckets.
+        if (vt == VarType::Bool || vt == VarType::Int8 || vt == VarType::UInt8)
+            coalesceable = false;
+    }
+#endif
+
+    m_value = (uint8_t) ((coalesceable ? 0u : 4u) +
+                         size_class_from_size(type_size[v->type]));
+}
+
+/// Byte alignment of each per-instance data block, so that concatenated blocks
+/// stay aligned for the widest packet load this backend/device can issue.
+static uint32_t call_data_align(const ThreadState *ts, bool uses_optix_) {
+#if !defined(DRJIT_ENABLE_CUDA)
+    (void) uses_optix_;
+#endif
+
+    switch ((JitBackend) ts->backend) {
+#if defined(DRJIT_ENABLE_CUDA)
+        case JitBackend::CUDA: // 256-bit (32B) needs CC >= 12.0, else 128-bit
+            return jitc_cuda_supports_256bit(ts, uses_optix_) ? 32u : 16u;
+#endif
+#if defined(DRJIT_ENABLE_METAL)
+        case JitBackend::Metal:
+            return 16u;
+#endif
+        case JitBackend::LLVM: // packet cap x widest field (8B)
+            return llvm_call_data_packet_cap() * 8u;
+
+        default:
+            return 8u;
+    }
+}
+
+// Walk through all slots of instance ``inst`` and populate the ``param_offset``
+// member with the logical variable offset within the data block.
 void jitc_call_bind_slots(const CallData *call, uint32_t inst) {
-    for (uint32_t k = call->slot_range[inst]; k < call->slot_range[inst + 1]; ++k) {
+    const CallData::InstanceLayout &layout = call->instance_layout[inst];
+    for (uint32_t k = layout.slot_start; k < layout.slot_end(); ++k) {
         if (Variable *v = jitc_var(call->slots[k].ref))
             v->param_offset = k;
     }
 }
 
-/// Given an opaque variable ``v`` encountered in a function call ``call``, this
-/// function checks if the variable has a corresponding capture slot, and it then
-/// returns the relative position in the data block. Otherwise it fails with an
-/// error message. This extra check is important to catch situations where new
-/// IR nodes haven't been correctly wired up in the DFS traversal in call.cpp.
+/// Given an opaque variable ``v`` in ``call``, check if the variable has a
+/// capture slot. Return its rel. position in the data block in that case or
+/// fail. This is useful to catch situations where new IR nodes haven't been
+/// correctly wired up in the recursive traversal in call.cpp or eval.cpp.
 uint32_t jitc_call_slot_rel_offset(const CallData *call, uint32_t inst,
                                    const Variable *v, uint32_t index) {
+    const CallData::InstanceLayout &layout = call->instance_layout[inst];
     uint32_t k = v->param_offset;
-    if (likely(k >= call->slot_range[inst] &&
-               k <  call->slot_range[inst + 1] &&
+    if (likely(k >= layout.slot_start &&
+               k <  layout.slot_end() &&
                jitc_var(call->slots[k].ref) == v))
-        return call->slots[k].offset - call->instance_offset[inst];
+        return call->slots[k].offset - layout.data_offset;
 
     if (v->is_evaluated())
         jitc_fail("jitc_call_slot_rel_offset(): variable r%u is referenced by a "
@@ -69,6 +149,148 @@ uint32_t jitc_call_slot_rel_offset(const CallData *call, uint32_t inst,
     else
         jitc_fail("jitc_call_slot_rel_offset(): could not find call-data slot for "
                   "variable r%u in function %s", index, call->name.c_str());
+}
+
+/**
+ * \brief Map an instance's captured call data to a concrete byte layout.
+ *
+ * Call data slots are originally in traversal order and still lack a memory
+ * layout. This function turns the slot subrange ``[lo, hi)`` into the physical
+ * layout used by the call-data buffer. It performs the following steps:
+ *
+ *   1. Group slots by their size bucket: 8/4/2/1-byte packet-loadable
+ *      values, followed by uncoalesced values of the same sizes.
+ *
+ *   2. Place packet-loadable buckets first. The generated LLVM IR
+ *      packet-loads each size bucket separately, while CUDA/Metal issue
+ *      vectorized loads over the contiguous coalesceable byte range.
+ *
+ *   3. Uncoalesced fields follow in naturally aligned scalar slots.
+ *
+ * The accompanying InstanceLayout record stashes information for later use
+ * during code generation: the slot range, data-block base offset,
+ * coalesceable byte prefix, and the four coalesceable size buckets.
+ * ``reordered`` is a caller-provided scratch buffer.
+ */
+static void jitc_call_layout_instance(CallData *call, uint32_t lo, uint32_t hi,
+                                      JitBackend backend, uint32_t alignment,
+                                      uint32_t llvm_pkt_cap, uint32_t &data_size,
+                                      std::vector<CallData::CaptureSlot> &reordered) {
+    // Histogram by SizeBucket ID: 0..3 are packet-loadable 8/4/2/1-byte
+    // buckets, 4..7 are uncoalesced buckets of the same sizes.
+    uint32_t bucket_count[8] = { },
+             max_field_size = 1u,
+             coalesceable_bytes = 0;
+
+    for (uint32_t k = lo; k < hi; ++k) {
+        CallData::SizeBucket bucket = call->slots[k].bucket;
+        uint32_t bucket_id = bucket.id(),
+                 size      = bucket.size();
+        bucket_count[bucket_id]++;
+        max_field_size = std::max(max_field_size, size);
+        if (bucket.coalesceable())
+            coalesceable_bytes += size;
+    }
+
+    // LLVM loads loads buckets individually. The code below computes the
+    // alignment that each size bucket will need to satisfy the widest packet
+    // load instruction that the backend may emit. CUDA/Metal vector loads start
+    // from the beginning of the block (with alignment ``block_align``), hence
+    // the individual buckets only require natural alignment.
+    uint32_t bucket_align[4];
+    for (uint32_t c = 0; c < 4; ++c) {
+        uint32_t nelems = 1;
+        if (backend == JitBackend::LLVM)
+            nelems = jitc_call_pick_llvm_packet_count(bucket_count[c], llvm_pkt_cap);
+        bucket_align[c] = nelems * CallData::SizeBucket::size_from_id(c);
+    }
+
+    // Pick the block's start alignment so the coalesceable region can be read back
+    // with the widest access the backend will issue, but never below the widest
+    // field. LLVM must satisfy the strictest bucket; CUDA/Metal load the
+    // contiguous coalesceable byte range in 32-bit chunks, widened when the
+    // word-rounded range fills a vector load to >= 75% utilization
+    // (jitc_call_pick_word_chunk_size).
+    uint32_t block_align = max_field_size;
+    if (backend == JitBackend::LLVM) {
+        for (uint32_t c = 0; c < 4; ++c)
+            if (bucket_count[c])
+                block_align = std::max(block_align, bucket_align[c]);
+    } else {
+        uint32_t region_bytes = (coalesceable_bytes + 3u) & ~3u;
+        block_align = std::max(max_field_size,
+                               jitc_call_pick_word_chunk_size(0, region_bytes, alignment));
+    }
+
+    uint32_t base = align_up(data_size, block_align);
+
+    CallData::InstanceLayout layout;
+    layout.slot_start  = lo;
+    layout.slot_count  = hi - lo;
+    layout.data_offset = base;
+
+    uint32_t bucket_order[4] = { 0, 1, 2, 3 };
+    if (backend == JitBackend::LLVM) {
+        // Insertion-sort the packet-loadable bucket IDs by descending packet
+        // alignment to avoid padding between buckets. CUDA/Metal don't need this.
+        for (uint32_t i = 1; i < 4; ++i) {
+            uint32_t c = bucket_order[i], j = i;
+            while (j > 0 && bucket_align[bucket_order[j - 1]] < bucket_align[c]) {
+                bucket_order[j] = bucket_order[j - 1];
+                --j;
+            }
+            bucket_order[j] = c;
+        }
+    }
+
+    uint32_t bucket_slot[8] = { },   // next output slot per bucket
+             bucket_offset[8] = { }, // next byte offset per bucket
+             next_slot = 0,          // next free slot in ``reordered``
+             next_offset = base;     // next free byte offset in the data block
+
+    // Assign each non-empty bucket a start index in ``reordered`` and an aligned
+    // byte offset. Keep slots sorted by ascending offset so CUDA/Metal can emit
+    // vectorized loads over the coalesceable prefix.
+    auto place_bucket = [&](uint32_t bucket_id, uint32_t align) {
+        if (!bucket_count[bucket_id])
+            return;
+
+        next_offset              = align_up(next_offset, align);
+        bucket_slot[bucket_id]   = next_slot;
+        bucket_offset[bucket_id] = next_offset;
+
+        uint32_t size  = CallData::SizeBucket::size_from_id(bucket_id),
+                 bytes = bucket_count[bucket_id] * size;
+
+        if (bucket_id < 4) {
+            layout.bucket[bucket_id] = { lo + next_slot, bucket_count[bucket_id] };
+            layout.coalesce_end =
+                std::max(layout.coalesce_end, next_offset - base + bytes);
+            layout.coalesce_count += bucket_count[bucket_id];
+        }
+
+        next_slot += bucket_count[bucket_id];
+        next_offset += bytes;
+    };
+
+    for (uint32_t i = 0; i < 4; ++i)
+        place_bucket(bucket_order[i], bucket_align[bucket_order[i]]);
+    for (uint32_t c = 0; c < 4; ++c)
+        place_bucket(4u + c, CallData::SizeBucket::size_from_id(c));
+
+    // Scatter each slot into its bucket, preserving the traversal order within
+    reordered.resize(hi - lo);
+    for (uint32_t k = lo; k < hi; ++k) {
+        const CallData::CaptureSlot &slot = call->slots[k];
+        uint32_t bucket_id = slot.bucket.id();
+        reordered[bucket_slot[bucket_id]++] =
+            { slot.ref, bucket_offset[bucket_id], slot.bucket };
+        bucket_offset[bucket_id] += slot.bucket.size();
+    }
+
+    std::copy(reordered.begin(), reordered.end(), call->slots.begin() + lo);
+    call->instance_layout.push_back(layout);
+    data_size = next_offset;
 }
 
 /// Weave a virtual function call into the computation graph
@@ -257,12 +479,22 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
     // 4. Collect evaluated data accessed by the instances
     // =====================================================
 
-    call->instance_offset.reserve(n_inst);
-    call->slot_range.reserve(n_inst + 1);
+    call->instance_layout.reserve(n_inst);
 
-    // Collect accesses to evaluated variables/pointers, appending a slot (with
-    // its byte offset) to 'slots' for each one in traversal order.
+    // Collect accesses to evaluated variables/pointers, appending a slot to
+    // ``slots`` for each one in traversal order. Byte offsets are assigned per
+    // instance by jitc_call_layout_instance(), not by the scan.
     uint32_t data_size = 0, inst_id_max = 0;
+
+    // Scratch reused across instances by the layout pass.
+    std::vector<CallData::CaptureSlot> reordered;
+
+    // ``alignment`` is the per-backend block alignment; ``llvm_pkt_cap`` is the
+    // LLVM gather width (in elements) that aligns each size bucket, and 1 elsewhere
+    // (so those backends pack blocks contiguously).
+    uint32_t align = call_data_align(ts, /*uses_optix_=*/ false),
+             llvm_pkt_cap = backend == JitBackend::LLVM
+                                ? llvm_call_data_packet_cap() : 1u;
     for (uint32_t i = 0; i < n_inst; ++i) {
         if (unlikely(checkpoints[i] > checkpoints[i + 1]))
             jitc_raise("jitc_var_call(): values in 'checkpoints' are not "
@@ -273,28 +505,25 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
         // Advance the traversal generation counter
         jitc_visit_new_gen();
 
-        call->instance_offset.push_back(data_size);
-        call->slot_range.push_back((uint32_t) call->slots.size());
+        uint32_t slot_start = (uint32_t) call->slots.size();
 
         for (uint32_t j = 0; j < n_out; ++j)
-            jitc_var_call_analyze(call.get(), i, inner_out[j + i * n_out],
-                                  data_size);
+            jitc_var_call_analyze(call.get(), i, inner_out[j + i * n_out]);
 
         for (uint32_t j = checkpoints[i]; j != checkpoints[i + 1]; ++j)
             jitc_var_call_analyze(call.get(), i,
-                                  call->side_effects[j - checkpoints[0]],
-                                  data_size);
+                                  call->side_effects[j - checkpoints[0]]);
 
-        // Restore to full (8-byte) alignment
-        data_size = align_up(data_size, 8);
+        jitc_call_layout_instance(call.get(), slot_start,
+                                  (uint32_t) call->slots.size(), backend,
+                                  align, llvm_pkt_cap, data_size,
+                                  reordered);
 
         inst_id_max = std::max(id, inst_id_max);
     }
-    call->slot_range.push_back((uint32_t) call->slots.size());
 
-    // Record information needed at launch time to reserve a suitably sized
-    // region to store offsets this call's captured slots for jitc_aggregate()
-    call->data_size = data_size;
+    // Pad the data block so each call's slice stays aligned once concatenated.
+    call->data_size = align_up(data_size, align);
     call->offset_count = inst_id_max + 1;
 
     char temp[128];
@@ -519,9 +748,8 @@ void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
 
         call->in_active[i] = !unused;
 
-        if (unused) {
+        if (unused)
             continue;
-        }
 
         in_size_all += size;
         v->param_offset = in_size;
@@ -587,21 +815,23 @@ void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
     if (jitc_is_llvm(call->backend))
         jitc_var_call_assemble_llvm(call, call_reg, self_reg, mask_reg,
                                     out_size, out_align);
+
 #if defined(DRJIT_ENABLE_METAL)
     else if (jitc_is_metal(call->backend))
         jitc_var_call_assemble_metal(call, call_reg, self_reg, mask_reg,
                                      in_size, in_align,
                                      out_size, out_align);
 #endif
+
 #if defined(DRJIT_ENABLE_CUDA)
-    else
+    else if (jitc_is_cuda(call->backend))
         jitc_var_call_assemble_cuda(call, call_reg, self_reg, mask_reg,
                                     in_size, in_align,
                                     out_size, out_align);
-#else
-    else
-        jitc_fail("jit_var_call_assemble(): CUDA backend is not available!");
 #endif
+
+    else
+        jitc_fail("jit_var_call_assemble(): unsupported backend!");
 
     // =====================================================
     // 4. Restore previously backed-up JIT state
@@ -627,8 +857,7 @@ void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
 }
 
 /// Collect scalar / pointer variables referenced by a computation
-void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
-                           uint32_t &data_offset) {
+void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index) {
     Variable *v = jitc_var(index);
 
     // Do not visit nodes multiple times. See eval.cpp for details on
@@ -662,7 +891,7 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
         // a pointer to the buffer containing captured opaque state.
         call->use_nested = true;
         for (uint32_t index_2: call2->outer_in)
-            jitc_var_call_analyze(call, inst_id, index_2, data_offset);
+            jitc_var_call_analyze(call, inst_id, index_2);
     } else if (kind == VarKind::LoopCond) {
         LoopData *loop = (LoopData *) jitc_var(v->dep[0])->data;
 
@@ -676,21 +905,21 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
             if (loop->outer_in[i] == loop->inner_in[i])
                 continue;
 
-            jitc_var_call_analyze(call, inst_id, loop->inner_out[i], data_offset);
-            jitc_var_call_analyze(call, inst_id, loop->outer_in[i], data_offset);
+            jitc_var_call_analyze(call, inst_id, loop->inner_out[i]);
+            jitc_var_call_analyze(call, inst_id, loop->outer_in[i]);
         }
     } else if (kind == VarKind::PacketScatter) {
         PacketScatterData *psd = (PacketScatterData *) v->data;
         for (uint32_t i : psd->values)
-            jitc_var_call_analyze(call, inst_id, i, data_offset);
+            jitc_var_call_analyze(call, inst_id, i);
     } else if (kind == VarKind::CoopVecPack) {
         CoopVecPackData *cvid = (CoopVecPackData *) v->data;
         for (uint32_t i : cvid->indices)
-            jitc_var_call_analyze(call, inst_id, i, data_offset);
+            jitc_var_call_analyze(call, inst_id, i);
     } else if (kind == VarKind::TraceRay) {
         TraceData *td = (TraceData *) v->data;
         for (uint32_t index_2: td->indices)
-            jitc_var_call_analyze(call, inst_id, index_2, data_offset);
+            jitc_var_call_analyze(call, inst_id, index_2);
     } else if (kind == VarKind::TexLookup || kind == VarKind::TexFetchBilerp ||
                kind == VarKind::TexWrite) {
         // Texture writes always reference their coordinates and values. On
@@ -701,17 +930,15 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
         if (v->data && refs_coords) {
             TexData *td = (TexData *) v->data;
             for (uint32_t i = 0; i < td->ndim; ++i)
-                jitc_var_call_analyze(call, inst_id, td->indices[i], data_offset);
+                jitc_var_call_analyze(call, inst_id, td->indices[i]);
             for (uint32_t i = 0; i < td->n_values; ++i)
-                jitc_var_call_analyze(call, inst_id, td->values[i], data_offset);
+                jitc_var_call_analyze(call, inst_id, td->values[i]);
         }
     } else if (v->is_evaluated() || (VarType) v->type == VarType::Pointer) {
-        // Real data slot. Assign a byte offset with natural alignment and append
-        // it to the current instance's run in 'slots'.
-        uint32_t tsize = type_size[v->type];
-        data_offset = align_up(data_offset, tsize);
-        call->slots.push_back({ WeakRef(index, v->counter), data_offset });
-        data_offset += tsize;
+        // Real data slot. Append it to the current instance's run in ``slots``; the
+        // byte offset is assigned later by the layout pass in jitc_var_call().
+        call->slots.push_back({ WeakRef(index, v->counter), 0,
+                                CallData::SizeBucket(v) });
 
         if (v->size != 1)
             jitc_raise(
@@ -727,10 +954,13 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index,
         if (!index_2)
             break;
 
-        jitc_var_call_analyze(call, inst_id, index_2, data_offset);
+        jitc_var_call_analyze(call, inst_id, index_2);
     }
 }
 
+/// Build the shared call-data buffer (offset tables + data blocks) for every
+/// call assembled in the current kernel and bind it to the base pointer
+/// parameter. Runs at the end of jitc_{cuda,llvm,metal}_assemble.
 void jitc_call_upload(ThreadState *ts) {
     JitBackend backend = (JitBackend) ts->backend;
 
@@ -744,8 +974,12 @@ void jitc_call_upload(ThreadState *ts) {
                 "jitc_call_upload(): kernel performs calls but has no "
                 "base pointer!");
 
+    // Align the start of the data region so each call's slice lands at an
+    // absolute address suitable for the widest packet load.
+    uint32_t align = call_data_align(ts, uses_optix);
     const uint32_t off_size = call_buffer.fused_offset_size,
-                   total    = off_size + call_buffer.fused_data_size;
+                   data_start = align_up(off_size, align),
+                   total      = data_start + call_buffer.fused_data_size;
 
     // Compute the number of aggregation entries. One per data slot, and
     // two per offset. ``off_size`` counts 8 bytes per offset, so divide by 4.
@@ -771,8 +1005,9 @@ void jitc_call_upload(ThreadState *ts) {
 
             // entry.hi = absolute byte offset of the instance's data block (from
             // the start of the buffer); entry.lo = callable index.
-            uint64_t data_off = (uint64_t) off_size + call->data_base +
-                                call->instance_offset[i];
+            uint64_t data_off =
+                (uint64_t) data_start + call->data_base +
+                call->instance_layout[i].data_offset;
             offset_entries[call->inst_id[i]] = (data_off << 32) | callable_index;
         }
 
@@ -798,7 +1033,7 @@ void jitc_call_upload(ThreadState *ts) {
     for (const CallBufferState::CaptureSlotRef &e : call_buffer.data_entries) {
         const Variable *v = jitc_var((uint32_t) e.src);
         bool is_pointer = (VarType) v->type == VarType::Pointer;
-        p->offset        = e.offset + off_size;
+        p->offset        = e.offset + data_start;
         p->size          = is_pointer ? (int16_t) 8 : (int16_t) -(int) type_size[v->type];
         p->resource_kind = is_pointer ? (uint16_t) v->resource_kind() : (uint16_t) 0;
         p->src           = is_pointer ? (const void *) v->literal : v->data;
@@ -807,6 +1042,7 @@ void jitc_call_upload(ThreadState *ts) {
 
     uint8_t *buf = (uint8_t *) jitc_malloc(backend, total);
     jitc_aggregate(backend, buf, agg, (uint32_t) (p - agg));
+
     jitc_free(agg);
 
     // Swap the aggregate buffer into the base pointer variable

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -629,6 +629,136 @@ void jitc_var_call(const char *name, bool symbolic, uint32_t self,
     jitc_var_mark_side_effect(se_v.release());
 }
 
+/// Build a getter as a gather from the shared per-kernel call-data buffer. See
+/// the documentation of 'jit_var_call_getter' in the public header for details.
+uint32_t jitc_var_call_getter(VarType type, uint32_t count,
+                              const uint32_t *values, uint32_t index,
+                              uint32_t mask) {
+    if (index == 0 || mask == 0)
+        jitc_raise("jit_var_call_getter(): 'index'/'mask' are uninitialized!");
+
+    const Variable *index_v = jitc_var(index),
+                   *mask_v   = jitc_var(mask);
+
+    JitBackend backend = (JitBackend) index_v->backend;
+
+    if ((VarType) index_v->type != VarType::UInt32)
+        jitc_raise("jit_var_call_getter(): 'index' must be an unsigned 32-bit "
+                   "integer array!");
+    if ((VarType) mask_v->type != VarType::Bool)
+        jitc_raise("jit_var_call_getter(): 'mask' must be a boolean array!");
+    if ((JitBackend) mask_v->backend != backend)
+        jitc_raise("jit_var_call_getter(): 'index' and 'mask' have different "
+                   "backends!");
+
+    // Collect the per-callable values. Literals stay as-is; opaque variables are
+    // evaluated now so a device pointer exists at upload. Absent -> empty Ref.
+    std::unique_ptr<GetterData> gd(new GetterData());
+    gd->type = type;
+    gd->count = count;
+    gd->values.resize(count);
+
+    for (uint32_t j = 0; j < count; ++j) {
+        uint32_t vi = values[j];
+        if (!vi)
+            continue; // absent callable -> empty reference -> reads zero
+
+        const Variable *vv = jitc_var(vi);
+        if (vv->size != 1)
+            jitc_raise("jit_var_call_getter(): value r%u of callable %u has "
+                       "size %u (must be 1)!", vi, j, vv->size);
+        if ((VarType) vv->type != type)
+            jitc_raise("jit_var_call_getter(): value r%u of callable %u has an "
+                       "unexpected type!", vi, j);
+        if ((JitBackend) vv->backend != backend)
+            jitc_raise("jit_var_call_getter(): value r%u of callable %u has a "
+                       "different backend!", vi, j);
+
+        if (vv->is_literal()) {
+            gd->values[j] = borrow(vi);
+        } else {
+            void *ptr = nullptr;
+            gd->values[j] = steal(jitc_var_data(vi, /*eval_dirty=*/true, &ptr));
+        }
+    }
+
+    // Apply the active mask and broadcast the size, as 'jit_var_gather' would.
+    uint32_t size = std::max(jitc_var(index)->size, jitc_var(mask)->size);
+    Ref mask_2 = steal(jitc_var_mask_apply(mask, size));
+    size = std::max(size, jitc_var(mask_2)->size);
+
+    // Build the node by hand with LVN disabled: the value table is outside
+    // 'VariableKey', so LVN could wrongly merge getters sharing [index, mask].
+    bool symbolic = jitc_var(index)->symbolic || jitc_var(mask_2)->symbolic;
+
+    Variable v;
+    v.kind = (uint32_t) VarKind::CallGetter;
+    v.type = (uint32_t) type;
+    v.backend = (uint32_t) backend;
+    v.size = size;
+    v.symbolic = symbolic;
+    v.dep[0] = index;
+    v.dep[1] = (uint32_t) mask_2;
+
+    jitc_var_inc_ref(index);
+    jitc_var_inc_ref(mask_2);
+
+    uint32_t result = jitc_var_new(v, /*disable_lvn=*/true);
+
+    // Re-read the node type in case 'jitc_var_new' demoted it (Metal
+    // Float64 -> Float32), so the header slice matches the emitted load.
+    Variable *rv = jitc_var(result);
+    gd->id = result;
+    gd->type = (VarType) rv->type;
+    rv->data = gd.get();
+
+    jitc_var_set_callback(
+        result,
+        [](uint32_t, int free, void *p) {
+            if (free)
+                delete (GetterData *) p;
+        },
+        gd.release(), true);
+
+    jitc_log(Debug, "jit_var_call_getter(): r%u = getter(index=r%u, mask=r%u) "
+             "over %u callable%s", result, index, (uint32_t) mask_2, count,
+             count == 1 ? "" : "s");
+
+    return result;
+}
+
+/// Reserve a getter's slice of the buffer's header region, register it for
+/// upload, and dispatch to the backend-specific masked-load renderer.
+void jitc_var_call_getter_assemble(Variable *v, const Variable *index,
+                                   const Variable *mask) {
+    GetterData *gd = (GetterData *) v->data;
+    uint32_t tsize = type_size[(int) gd->type];
+
+    // The header region is physically first, so 'header_offset' is the table's
+    // absolute byte offset. Round up to 8 bytes to keep later u64 tables aligned.
+    gd->header_offset = call_buffer.fused_offset_size;
+    call_buffer.fused_offset_size += align_up((gd->count + 1) * tsize, 8u);
+
+    // Keep the node (hence its value references, hence the source data) alive
+    // through the aggregate, mirroring how calls_assembled pins call nodes.
+    jitc_var_inc_ref(gd->id);
+    call_buffer.getters.push_back(gd);
+
+    JitBackend backend = (JitBackend) v->backend;
+    if (jitc_is_llvm(backend))
+        jitc_var_call_getter_assemble_llvm(v, index, mask);
+#if defined(DRJIT_ENABLE_METAL)
+    else if (jitc_is_metal(backend))
+        jitc_var_call_getter_assemble_metal(v, index, mask);
+#endif
+#if defined(DRJIT_ENABLE_CUDA)
+    else if (jitc_is_cuda(backend))
+        jitc_var_call_getter_assemble_cuda(v, index, mask);
+#endif
+    else
+        jitc_fail("jitc_var_call_getter_assemble(): unsupported backend!");
+}
+
 static ProfilerRegion profiler_region_call_assemble("jit_var_call_assemble");
 
 /// Data structure to sort function arguments/return values in order of
@@ -892,6 +1022,10 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index) {
         call->use_nested = true;
         for (uint32_t index_2: call2->outer_in)
             jitc_var_call_analyze(call, inst_id, index_2);
+    } else if (kind == VarKind::CallGetter) {
+        // A nested getter reads the shared buffer, so Dr.Jit must forward the
+        // base pointer into the callable.
+        call->use_nested = true;
     } else if (kind == VarKind::LoopCond) {
         LoopData *loop = (LoopData *) jitc_var(v->dep[0])->data;
 
@@ -964,14 +1098,14 @@ void jitc_var_call_analyze(CallData *call, uint32_t inst_id, uint32_t index) {
 void jitc_call_upload(ThreadState *ts) {
     JitBackend backend = (JitBackend) ts->backend;
 
-    if (calls_assembled.empty()) {
+    if (calls_assembled.empty() && call_buffer.getters.empty()) {
         jitc_assert(call_buffer.base_v == 0,
-                    "jitc_call_upload(): base allocated without calls!");
+                    "jitc_call_upload(): base allocated without calls/getters!");
         return;
     }
 
     jitc_assert(call_buffer.base_v != 0,
-                "jitc_call_upload(): kernel performs calls but has no "
+                "jitc_call_upload(): kernel performs calls/getters but has no "
                 "base pointer!");
 
     // Align the start of the data region so each call's slice lands at an
@@ -981,9 +1115,14 @@ void jitc_call_upload(ThreadState *ts) {
                    data_start = align_up(off_size, align),
                    total      = data_start + call_buffer.fused_data_size;
 
-    // Compute the number of aggregation entries. One per data slot, and
-    // two per offset. ``off_size`` counts 8 bytes per offset, so divide by 4.
-    size_t n_entries = call_buffer.data_entries.size() + off_size / 4;
+    // One aggregation entry per data slot, two per offset-table slot (lo + hi),
+    size_t n_entries = call_buffer.data_entries.size();
+    for (CallData *call : calls_assembled)
+        n_entries += 2 * call->offset_count;
+
+    // ..and 'count + 1' per getter (1 per instance, 1 for the null instance)
+    for (GetterData *gd : call_buffer.getters)
+        n_entries += gd->count + 1;
 
     AggregationEntry *agg = (AggregationEntry *) jitc_malloc(
         backend, sizeof(AggregationEntry) * n_entries, /*shared=*/true);
@@ -1040,24 +1179,62 @@ void jitc_call_upload(ThreadState *ts) {
         p++;
     }
 
+    // Part 3: getter value tables. They live in the header region, so
+    // 'header_offset' is absolute (no 'data_start' shift).
+    for (GetterData *gd : call_buffer.getters) {
+        uint32_t tsize = type_size[(int) gd->type];
+
+        // Null slot (index 0): masked out at read time, zeroed defensively.
+        p->offset = gd->header_offset;
+        p->size = (int16_t) tsize;
+        p->src = 0;
+        p->resource_kind = 0;
+        p++;
+
+        for (uint32_t j = 0; j < gd->count; ++j) {
+            uint32_t off = gd->header_offset + (j + 1) * tsize,
+                     vi  = (uint32_t) gd->values[j];
+            p->offset = off;
+            p->resource_kind = 0;
+            if (!vi) { // absent callable -> zero
+                p->size = (int16_t) tsize;
+                p->src  = 0;
+            } else {
+                const Variable *vv = jitc_var(vi);
+                if (vv->is_literal()) { // literal -> embed by value
+                    p->size = (int16_t) tsize;
+                    p->src  = (const void *) vv->literal;
+                } else { // opaque -> copy by pointer
+                    p->size = (int16_t) -(int) tsize;
+                    p->src  = vv->data;
+                }
+            }
+            p++;
+        }
+    }
+
     uint8_t *buf = (uint8_t *) jitc_malloc(backend, total);
     jitc_aggregate(backend, buf, agg, (uint32_t) (p - agg));
 
     jitc_free(agg);
 
-    // Swap the aggregate buffer into the base pointer variable
+    // Hand the freshly built buffer to the base pointer variable. 'base_src'
+    // had no backing storage (see jitc_assemble), so there is nothing to free;
+    // it now owns 'buf' and releases it after the launch barrier.
     Variable *base_src = jitc_var(call_buffer.base_src);
-    void *placeholder = base_src->data;
     base_src->data = buf;
     base_src->size = total;
-    if (placeholder)
-        jitc_free(placeholder);
 
     jitc_var(call_buffer.base_v)->literal = (uint64_t) (uintptr_t) buf;
 
     for (CallData *call : calls_assembled)
         jitc_var_dec_ref(call->id);
     calls_assembled.clear();
+
+    // Release getter nodes collected during assembly
+    for (GetterData *gd : call_buffer.getters)
+        jitc_var_dec_ref(gd->id);
+    call_buffer.getters.clear();
 }
 
 // Compute a permutation to reorder an array of registered pointers

--- a/src/call.h
+++ b/src/call.h
@@ -47,20 +47,92 @@ struct CallData {
     /// Array of size 'n_inst' storing hashes of compiled callables
     std::vector<XXH128_hash_t> inst_hash;
 
-    /// A single evaluated/pointer value captured into the per-instance closure
-    struct CaptureSlot {
-        WeakRef  ref;     ///< weak reference to the variable (index + generation)
-        uint32_t offset;  ///< byte offset within this call's data block
+    /// Encodes how one capture slot participates in the call-data layout.
+    class SizeBucket {
+    public:
+        SizeBucket() = default;
+
+        /// Classify a captured variable by storage size and packet-load eligibility.
+        explicit SizeBucket(const Variable *v);
+
+        /// Bucket ID: 0..3 for coalesceable 8/4/2/1-byte
+        /// slots, 4..7 for uncoalesced slots of the same sizes.
+        uint32_t id() const { return m_value; }
+
+        /// Low two bits encoding the 8/4/2/1-byte size class.
+        uint32_t size_class() const { return m_value & 3u; }
+
+        /// Does this bucket belong to the packet-loadable prefix?
+        bool coalesceable() const { return m_value < 4; }
+
+        /// Storage size in bytes represented by this bucket.
+        uint32_t size() const { return size_from_id(m_value); }
+
+        /// Return the byte size represented by a size class or full bucket ID.
+        static uint32_t size_from_id(uint32_t bucket_id) {
+            return 8u >> (bucket_id & 3u);
+        }
+
+    private:
+        static uint32_t size_class_from_size(uint32_t size) {
+            return size == 8 ? 0u : size == 4 ? 1u : size == 2 ? 2u : 3u;
+        }
+
+        uint8_t m_value = 0;
     };
 
-    /// Capture slots, concatenated per instance (offset-ascending)
-    std::vector<CaptureSlot> slots;
-    /// Size 'n_inst+1'; entries [i],[i+1) bound instance i's slots in 'slots'
-    std::vector<uint32_t> slot_range;
-    /// Base byte offset of each instance's data block into the data buffer
-    std::vector<uint32_t> instance_offset;
+    /// A single evaluated/pointer value captured into the per-instance closure
+    struct CaptureSlot {
+        WeakRef     ref;    ///< weak reference to the variable (index + generation)
+        uint32_t    offset; ///< byte offset after layout within this call's data block
 
-    /// Total size (in bytes, 8-aligned) of this call's data block
+        /// Size bucket assigned when the slot is captured. Keeping this on the
+        /// slot avoids a temporary per-instance bucket vector and repeated
+        /// coalescing classification in the layout/codegen hot path.
+        SizeBucket bucket;
+    };
+
+    /// Capture slots, concatenated per instance (traversal-ordered while being
+    /// collected, then offset-ascending after each instance is laid out).
+    std::vector<CaptureSlot> slots;
+
+    /// Slot and byte layout of a single callable instance's captured data.
+    ///
+    /// ``slots[slot_start, slot_start+slot_count)`` contains this instance's
+    /// captured values sorted by increasing byte offset. The first part of that
+    /// slot range contains fields that may be loaded via packet operations,
+    /// grouped into the four size classes 8/4/2/1 bytes. Fields that must be
+    /// loaded individually (for example opaque Metal resource handles) follow in
+    /// uncoalesced buckets.
+    struct InstanceLayout {
+        struct Bucket {
+            uint32_t slot_start = 0; ///< first slot in this size class
+            uint32_t slot_count = 0; ///< number of slots in this size class
+
+            uint32_t slot_end() const { return slot_start + slot_count; }
+        };
+
+        uint32_t slot_start = 0;     ///< first slot belonging to this instance
+        uint32_t slot_count = 0;     ///< number of slots belonging to it
+        uint32_t data_offset = 0;    ///< byte offset of the instance data block
+
+        /// Relative byte offset just past all coalesceable fields. CUDA/Metal
+        /// use this to bound vectorized loads over the contiguous coalesceable
+        /// byte range. LLVM uses the size-class buckets below, since its packet
+        /// loads are homogeneous.
+        uint32_t coalesce_end = 0;
+        uint32_t coalesce_count = 0; ///< number of coalesceable slots
+
+        /// Coalesceable slots by size class: 0=8B, 1=4B, 2=2B, 3=1B.
+        Bucket bucket[4];
+
+        uint32_t slot_end() const { return slot_start + slot_count; }
+    };
+
+    /// Per-instance call-data layout, size 'n_inst'.
+    std::vector<InstanceLayout> instance_layout;
+
+    /// Total size (in bytes) of this call's backend-aligned data block
     uint32_t data_size = 0;
     /// Number of offset-table slots (= max instance id + 1)
     uint32_t offset_count = 0;
@@ -103,6 +175,39 @@ struct CallData {
     }
 };
 
+/// This data structure maintains the running call data state during kernel
+/// compilation. See the top of call.h for details on this.
+struct CallBufferState {
+    /// Combined size (bytes) of all offset tables / all data blocks so far.
+    uint32_t fused_offset_size = 0;
+    uint32_t fused_data_size = 0;
+
+    /// Base pointer variable (0 if the kernel performs no calls) and the
+    /// mem-mapped variable owning its device allocation.
+    uint32_t base_v = 0;
+    uint32_t base_src = 0;
+
+    /// Register holding the base pointer, and its slot index in 'kernel_params'.
+    uint32_t base_reg = 0;
+    uint32_t base_param_index = 0;
+
+    // Projection of a CallData::CaptureSlot: a strong reference plus a byte
+    // offset into the data region following the offset tables.
+    struct CaptureSlotRef {
+        Ref      src;     ///< captured source variable
+        uint32_t offset;  ///< byte offset within the fused data region
+    };
+
+    std::vector<CaptureSlotRef> data_entries;
+
+    void reset() {
+        fused_offset_size = fused_data_size = 0;
+        base_v = base_src = base_reg = base_param_index = 0;
+        data_entries.clear();
+    }
+};
+
+extern CallBufferState call_buffer;
 extern std::vector<CallData *> calls_assembled;
 
 extern void jitc_call_bind_slots(const CallData *call, uint32_t inst);
@@ -110,18 +215,36 @@ extern void jitc_call_bind_slots(const CallData *call, uint32_t inst);
 extern uint32_t jitc_call_slot_rel_offset(const CallData *call, uint32_t inst,
                                           const Variable *v, uint32_t index);
 
+/// Minimum utilization (in percent) for a packet transfer to be worthwhile.
+static constexpr uint32_t jitc_packet_min_util = 75;
+
+/// Pick the widest LLVM call-data packet gather count. Returns 1 when
+/// packetization is not useful, so callers can fall back to scalar gathers.
+inline uint32_t jitc_call_pick_llvm_packet_count(uint32_t remaining,
+                                                 uint32_t max_count) {
+    for (uint32_t cand = max_count; cand >= 2; cand /= 2) {
+        uint32_t useful = remaining < cand ? remaining : cand;
+        if (useful * 100 >= cand * jitc_packet_min_util)
+            return cand;
+    }
+    return 1;
+}
+
+/// Pick the widest naturally aligned CUDA/Metal load width over a contiguous
+/// byte range. Returns 4 when no vector load stays sufficiently utilized.
+inline uint32_t jitc_call_pick_word_chunk_size(uint32_t offset,
+                                               uint32_t remaining,
+                                               uint32_t max_chunk) {
+    for (uint32_t cand = max_chunk; cand >= 8; cand /= 2) {
+        uint32_t useful = remaining < cand ? remaining : cand;
+        if ((offset % cand) == 0 && useful * 100 >= cand * jitc_packet_min_util)
+            return cand;
+    }
+    return 4;
+}
+
 extern uint32_t jitc_var_loop_init(uint32_t *indices, uint32_t n_indices);
 
-extern void jitc_var_call(const char *domain, bool symbolic, uint32_t self,
-                          uint32_t mask, uint32_t n_inst, uint32_t max_inst_id,
-                          const uint32_t *inst_id, uint32_t n_in,
-                          const uint32_t *in, uint32_t n_inner_out,
-                          const uint32_t *inner_out,
-                          const uint32_t *checkpoints, uint32_t *out);
-
-/// Build the shared call-data buffer (offset tables + data blocks) for every
-/// call assembled in the current kernel and bind it to the base pointer
-/// parameter. Runs at the end of jitc_{cuda,llvm,metal}_assemble.
 extern void jitc_call_upload(ThreadState *ts);
 
 extern CallBucket *jitc_var_call_reduce(JitBackend backend, const char *variant,
@@ -145,46 +268,12 @@ extern void jitc_var_call_assemble_metal(CallData *call, uint32_t call_reg,
                                          uint32_t in_size, uint32_t in_align,
                                          uint32_t out_size, uint32_t out_align);
 
-/// All indirect calls in a kernel share a single device buffer that holds every
-/// call's offset table followed by every call's data block:
-///
-///     [ offset tables | data blocks ]
-///
-/// A dispatch indexes its offset table by 'self' to obtain a callable index and
-/// the absolute byte offset of the matching data block, from which it reads the
-/// captured state.
-///
-/// This state is reset in jitc_assemble(), populated as calls are assembled
-/// (each reserves a slice via 'offset_base'/'data_base'), and turned into the
-/// actual buffer by jitc_call_upload().
-struct CallBufferState {
-    /// Combined size (bytes) of all offset tables / all data blocks so far.
-    uint32_t fused_offset_size = 0;
-    uint32_t fused_data_size = 0;
+extern void jitc_var_call(const char *domain, bool symbolic, uint32_t self,
+                          uint32_t mask, uint32_t n_inst, uint32_t max_inst_id,
+                          const uint32_t *inst_id, uint32_t n_in,
+                          const uint32_t *in, uint32_t n_inner_out,
+                          const uint32_t *inner_out,
+                          const uint32_t *checkpoints, uint32_t *out);
 
-    /// Base pointer variable (0 if the kernel performs no calls) and the
-    /// mem-mapped variable owning its device allocation.
-    uint32_t base_v = 0;
-    uint32_t base_src = 0;
-
-    /// Register holding the base pointer at kernel level, and its slot index in
-    /// 'kernel_params'.
-    uint32_t base_reg = 0;
-    uint32_t base_param_index = 0;
-
-    // Projection of a CallData::CaptureSlot: a strong reference plus a byte
-    // offset into the data region following the offset tables.
-    struct CaptureSlotRef {
-        Ref      src;     ///< captured source variable
-        uint32_t offset;  ///< byte offset within the fused data region
-    };
-    std::vector<CaptureSlotRef> data_entries;
-
-    void reset() {
-        fused_offset_size = fused_data_size = 0;
-        base_v = base_src = base_reg = base_param_index = 0;
-        data_entries.clear();
-    }
-};
-
-extern CallBufferState call_buffer;
+extern void jitc_var_call_analyze(CallData *call, uint32_t inst_id,
+                                  uint32_t index);

--- a/src/call.h
+++ b/src/call.h
@@ -175,6 +175,24 @@ struct CallData {
     }
 };
 
+/// Payload of a 'CallGetter' IR node
+struct GetterData {
+    /// Index of the 'CallGetter' variable owning this payload
+    uint32_t id = 0;
+
+    /// Return type / element type of the value table.
+    VarType type = VarType::Void;
+
+    /// Callable count. The table has 'count + 1' entries (entry 0 is the null instance).
+    uint32_t count = 0;
+
+    /// Byte offset of the table in the header region, assigned during codegen.
+    uint32_t header_offset = 0;
+
+    /// Strong reference to the values. Entry 'i' maps to instance 'i+1'.
+    std::vector<Ref> values;
+};
+
 /// This data structure maintains the running call data state during kernel
 /// compilation. See the top of call.h for details on this.
 struct CallBufferState {
@@ -191,19 +209,24 @@ struct CallBufferState {
     uint32_t base_reg = 0;
     uint32_t base_param_index = 0;
 
-    // Projection of a CallData::CaptureSlot: a strong reference plus a byte
-    // offset into the data region following the offset tables.
+    // Projection of a CallData::CaptureSlot into one jitc_aggregate() input:
+    // 'src' is the value to copy, 'offset' is where it lands in the buffer.
     struct CaptureSlotRef {
-        Ref      src;     ///< captured source variable
-        uint32_t offset;  ///< byte offset within the fused data region
+        Ref      src;     ///< captured source variable (what to deposit)
+        uint32_t offset;  ///< deposit offset into the fused data region (pre 'data_start')
     };
 
+    /// Capture slots that will be materialized into the call data
     std::vector<CaptureSlotRef> data_entries;
+
+    /// Getter values that will be materialized into the call data
+    std::vector<GetterData *> getters;
 
     void reset() {
         fused_offset_size = fused_data_size = 0;
         base_v = base_src = base_reg = base_param_index = 0;
         data_entries.clear();
+        getters.clear();
     }
 };
 
@@ -277,3 +300,17 @@ extern void jitc_var_call(const char *domain, bool symbolic, uint32_t self,
 
 extern void jitc_var_call_analyze(CallData *call, uint32_t inst_id,
                                   uint32_t index);
+
+extern uint32_t jitc_var_call_getter(VarType type, uint32_t count,
+                                     const uint32_t *values, uint32_t index,
+                                     uint32_t mask);
+
+extern void jitc_var_call_getter_assemble(Variable *v, const Variable *index,
+                                          const Variable *mask);
+
+extern void jitc_var_call_getter_assemble_cuda(Variable *v, const Variable *index,
+                                               const Variable *mask);
+extern void jitc_var_call_getter_assemble_llvm(Variable *v, const Variable *index,
+                                               const Variable *mask);
+extern void jitc_var_call_getter_assemble_metal(Variable *v, const Variable *index,
+                                                const Variable *mask);

--- a/src/call.h
+++ b/src/call.h
@@ -47,12 +47,21 @@ struct CallData {
     /// Array of size 'n_inst' storing hashes of compiled callables
     std::vector<XXH128_hash_t> inst_hash;
 
-    /// Mapping from variable index to offset into call data
-    tsl::robin_map<uint64_t, uint32_t, UInt64Hasher> data_map;
-    std::vector<uint32_t> data_offset;
+    /// A single evaluated/pointer value captured into the per-instance closure
+    struct CaptureSlot {
+        WeakRef  ref;     ///< weak reference to the variable (index + generation)
+        uint32_t offset;  ///< absolute byte offset into the data buffer
+    };
 
-    uint64_t *offset = nullptr;
-    size_t offset_size = 0;
+    /// Capture slots, concatenated per instance (offset-ascending)
+    std::vector<CaptureSlot> slots;
+    /// Size 'n_inst+1'; entries [i],[i+1) bound instance i's slots in 'slots'
+    std::vector<uint32_t> slot_range;
+    /// Base byte offset of each instance's data block into the data buffer
+    std::vector<uint32_t> instance_offset;
+
+    uint64_t *offset_table = nullptr;
+    size_t offset_table_size = 0;
 
     /// Does this call contain a 'CallSelf' variable?
     bool use_self = false;
@@ -82,6 +91,11 @@ struct CallData {
 };
 
 extern std::vector<CallData *> calls_assembled;
+
+extern void jitc_call_bind_slots(const CallData *call, uint32_t inst);
+
+extern uint32_t jitc_call_slot_rel_offset(const CallData *call, uint32_t inst,
+                                          const Variable *v, uint32_t index);
 
 extern uint32_t jitc_var_loop_init(uint32_t *indices, uint32_t n_indices);
 

--- a/src/call.h
+++ b/src/call.h
@@ -50,7 +50,7 @@ struct CallData {
     /// A single evaluated/pointer value captured into the per-instance closure
     struct CaptureSlot {
         WeakRef  ref;     ///< weak reference to the variable (index + generation)
-        uint32_t offset;  ///< absolute byte offset into the data buffer
+        uint32_t offset;  ///< byte offset within this call's data block
     };
 
     /// Capture slots, concatenated per instance (offset-ascending)
@@ -60,11 +60,24 @@ struct CallData {
     /// Base byte offset of each instance's data block into the data buffer
     std::vector<uint32_t> instance_offset;
 
-    uint64_t *offset_table = nullptr;
-    size_t offset_table_size = 0;
+    /// Total size (in bytes, 8-aligned) of this call's data block
+    uint32_t data_size = 0;
+    /// Number of offset-table slots (= max instance id + 1)
+    uint32_t offset_count = 0;
+
+    /// Byte offset of this call's offset table within the fused buffer's offset
+    /// region. Assigned once per call during code generation (see
+    /// jitc_var_call_assemble).
+    uint32_t offset_base = 0;
+    /// Byte offset of this call's data block within the fused buffer's data
+    /// region. Assigned once per call during code generation.
+    uint32_t data_base = 0;
 
     /// Does this call contain a 'CallSelf' variable?
     bool use_self = false;
+    /// Does this call contain a nested 'Call' node? Such callables receive the
+    /// base pointer so the nested dispatch can reach its own buffer slice.
+    bool use_nested = false;
     /// Does this call contain a 'Counter' variable?
     bool use_index = false;
     /// Does this call contain a 'ThreadIndex' variable?
@@ -106,6 +119,9 @@ extern void jitc_var_call(const char *domain, bool symbolic, uint32_t self,
                           const uint32_t *inner_out,
                           const uint32_t *checkpoints, uint32_t *out);
 
+/// Build the shared call-data buffer (offset tables + data blocks) for every
+/// call assembled in the current kernel and bind it to the base pointer
+/// parameter. Runs at the end of jitc_{cuda,llvm,metal}_assemble.
 extern void jitc_call_upload(ThreadState *ts);
 
 extern CallBucket *jitc_var_call_reduce(JitBackend backend, const char *variant,
@@ -113,22 +129,62 @@ extern CallBucket *jitc_var_call_reduce(JitBackend backend, const char *variant,
                                         uint32_t *bucket_count_out);
 
 extern void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
-                                   uint32_t self_reg, uint32_t mask_reg,
-                                   uint32_t offset_reg, uint32_t data_reg);
+                                   uint32_t self_reg, uint32_t mask_reg);
 
 extern void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
                                         uint32_t self_reg, uint32_t mask_reg,
-                                        uint32_t offset_reg, uint32_t data_reg,
                                         uint32_t buf_size, uint32_t buf_align);
 
 extern void jitc_var_call_assemble_cuda(CallData *call, uint32_t call_reg,
                                         uint32_t self_reg, uint32_t mask_reg,
-                                        uint32_t offset_reg, uint32_t data_reg,
                                         uint32_t in_size, uint32_t in_align,
                                         uint32_t out_size, uint32_t out_align);
 
 extern void jitc_var_call_assemble_metal(CallData *call, uint32_t call_reg,
                                          uint32_t self_reg, uint32_t mask_reg,
-                                         uint32_t offset_reg, uint32_t data_reg,
                                          uint32_t in_size, uint32_t in_align,
                                          uint32_t out_size, uint32_t out_align);
+
+/// All indirect calls in a kernel share a single device buffer that holds every
+/// call's offset table followed by every call's data block:
+///
+///     [ offset tables | data blocks ]
+///
+/// A dispatch indexes its offset table by 'self' to obtain a callable index and
+/// the absolute byte offset of the matching data block, from which it reads the
+/// captured state.
+///
+/// This state is reset in jitc_assemble(), populated as calls are assembled
+/// (each reserves a slice via 'offset_base'/'data_base'), and turned into the
+/// actual buffer by jitc_call_upload().
+struct CallBufferState {
+    /// Combined size (bytes) of all offset tables / all data blocks so far.
+    uint32_t fused_offset_size = 0;
+    uint32_t fused_data_size = 0;
+
+    /// Base pointer variable (0 if the kernel performs no calls) and the
+    /// mem-mapped variable owning its device allocation.
+    uint32_t base_v = 0;
+    uint32_t base_src = 0;
+
+    /// Register holding the base pointer at kernel level, and its slot index in
+    /// 'kernel_params'.
+    uint32_t base_reg = 0;
+    uint32_t base_param_index = 0;
+
+    // Projection of a CallData::CaptureSlot: a strong reference plus a byte
+    // offset into the data region following the offset tables.
+    struct CaptureSlotRef {
+        Ref      src;     ///< captured source variable
+        uint32_t offset;  ///< byte offset within the fused data region
+    };
+    std::vector<CaptureSlotRef> data_entries;
+
+    void reset() {
+        fused_offset_size = fused_data_size = 0;
+        base_v = base_src = base_reg = base_param_index = 0;
+        data_entries.clear();
+    }
+};
+
+extern CallBufferState call_buffer;

--- a/src/common.h
+++ b/src/common.h
@@ -109,6 +109,11 @@ inline uint32_t ceil_div(uint32_t a, uint32_t b) {
     return (a + b - 1) / b;
 }
 
+/// Round 'x' up to the next multiple of 'a'
+inline uint32_t align_up(uint32_t x, uint32_t a) {
+    return ceil_div(x, a) * a;
+}
+
 inline Ref steal(uint32_t index) {
     Ref r;
     r.index = index;

--- a/src/coop_vec.cpp
+++ b/src/coop_vec.cpp
@@ -396,7 +396,7 @@ MatrixDescr jitc_coop_vec_compute_layout(uint32_t index,
                 "offset %u, which is not divisible by 64.", offset_in_bytes);
 
         uint32_t out_align = is_vector ? 16 : 64;
-        offset = (ceil_div(offset * tsize, out_align) * out_align) / tsize;
+        offset = align_up(offset * tsize, out_align) / tsize;
     }
 #else
     (void) index;

--- a/src/cuda.h
+++ b/src/cuda.h
@@ -12,6 +12,8 @@
 #include "cuda_api.h"
 #include <utility>
 
+struct ThreadState;
+
 /// Major version of the detected CUDA version
 extern int jitc_cuda_version_major;
 
@@ -113,8 +115,8 @@ extern CUfunction jitc_cuda_reduce_dot_function(int device, VarType vt);
 extern CUfunction jitc_cuda_gemm_function(int device, VarType vt, int tile,
                                           int transpose);
 
-/// Check if the current CUDA device supports 256-bit (32-byte) vector operations
-extern bool jitc_cuda_supports_256bit();
+/// Does ``ts``'s device support 256-bit (32-byte) vector loads/stores?
+extern bool jitc_cuda_supports_256bit(const ThreadState *ts, bool uses_optix);
 
 /// Event API functions for CUDA backend
 typedef struct JitEvent_* JitEvent;

--- a/src/cuda_core.cpp
+++ b/src/cuda_core.cpp
@@ -16,6 +16,13 @@ int jitc_cuda_version_major = 0;
 int jitc_cuda_version_minor = 0;
 uint32_t jitc_cuda_arg_limit = 0;
 
+bool jitc_cuda_supports_256bit(const ThreadState *ts, bool uses_optix) {
+    return ts->compute_capability >= 120 &&
+           (!uses_optix ||
+            jitc_cuda_version_major > 13 ||
+            (jitc_cuda_version_major == 13 && jitc_cuda_version_minor >= 2));
+}
+
 // Dr.Jit kernel functions
 CUfunction *jitc_cuda_fill_64 = nullptr;
 CUfunction *jitc_cuda_block_mkperm_phase_1_tiny = nullptr;

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -1081,6 +1081,10 @@ static void jitc_cuda_render(Variable *v) {
                                    a0->reg_index, a1->reg_index);
             break;
 
+        case VarKind::CallGetter:
+            jitc_var_call_getter_assemble(v, a0, a1);
+            break;
+
         case VarKind::CallOutput:
             break;
 
@@ -1582,6 +1586,52 @@ static void jitc_cuda_render_reorder(const Variable *v, const Variable *key) {
     }
 }
 #endif
+
+/// Getter masked load (CUDA/PTX). Mirrors the 'Gather' case, sourcing from
+/// 'base + header_offset'; 'index' is always within [0, count], so no bounds check.
+void jitc_var_call_getter_assemble_cuda(Variable *v, const Variable *index,
+                                        const Variable *mask) {
+    GetterData *gd = (GetterData *) v->data;
+    uint32_t tsize = type_size[(int) gd->type],
+             header_offset = gd->header_offset;
+
+    // Name of the base pointer holding the kernel's combined call data
+    char base[32];
+    if (callable_depth == 0)
+        snprintf(base, sizeof(base), "%%rd%u", call_buffer.base_reg);
+    else
+        snprintf(base, sizeof(base), "base");
+
+    bool is_masked = !mask->is_literal() || mask->literal != 1,
+         is_bool   = v->type == (uint32_t) VarType::Bool;
+
+    // %rd3 = base + index * tsize (the constant 'header_offset' is folded into
+    // the load's address immediate below).
+    if (tsize == 1)
+        fmt("    cvt.u64.$t %rd3, $v;\n"
+            "    add.u64 %rd3, %rd3, $s;\n", index, index, base);
+    else
+        fmt("    mad.wide.$t %rd3, $v, $a, $s;\n", index, index, v, base);
+
+    if (is_masked) {
+        if (is_bool)
+            fmt("    mov.b16 %w0, 0;\n");
+        else if ((VarType) v->type == VarType::UInt8 || (VarType) v->type == VarType::Int8)
+            // There is no `mov.b8`
+            fmt("    cvt.u8.u16 $v, 0;\n", v);
+        else
+            fmt("    mov.$b $v, 0;\n", v, v);
+        fmt("    @$v ", mask);
+    } else {
+        put("    ");
+    }
+
+    if (is_bool)
+        fmt("ld.global.nc.u8 %w0, [%rd3+$u];\n"
+            "    setp.ne.u16 $v, %w0, 0;\n", header_offset, v);
+    else
+        fmt("ld.global.nc.$b $v, [%rd3+$u];\n", v, v, header_offset);
+}
 
 /// Virtual function call code generation -- CUDA/PTX-specific bits
 void jitc_var_call_assemble_cuda(CallData *call, uint32_t call_reg,

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -158,6 +158,13 @@ void jitc_cuda_assemble(ThreadState *ts, ScheduledGroup group,
         params_type = "global";
     }
 
+    // Load the call-data base pointer once, shared by every call's dispatch in
+    // this kernel.
+    if (call_buffer.base_v)
+        fmt("    ld.$s.u64 %rd$u, [$s+$u];\n", params_type, call_buffer.base_reg,
+            params_base,
+            call_buffer.base_param_index * (uint32_t) sizeof(void *));
+
     for (uint32_t gi = group.start; gi != group.end; ++gi) {
         uint32_t index = schedule[gi].index;
         Variable *v = jitc_var(index);
@@ -300,6 +307,9 @@ void jitc_cuda_assemble_func(const CallData *call, uint32_t inst,
         put(".reg .u32 self, ");
     if (!call->slots.empty())
         put(".reg .u64 data, ");
+    // Callables containing a nested call receive the base pointer.
+    if (call->use_nested)
+        put(".reg .u64 base, ");
     if (in_size)
         fmt(".param .align $u .b8 params[$u], ", in_align, in_size);
     buffer.delete_trailing_commas();
@@ -999,8 +1009,7 @@ static void jitc_cuda_render(Variable *v) {
 
         case VarKind::Call:
             jitc_var_call_assemble((CallData *) v->data, v->reg_index,
-                                   a0->reg_index, a1->reg_index, a2->reg_index,
-                                   a3 ? a3->reg_index : 0);
+                                   a0->reg_index, a1->reg_index);
             break;
 
         case VarKind::CallOutput:
@@ -1508,7 +1517,6 @@ static void jitc_cuda_render_reorder(const Variable *v, const Variable *key) {
 /// Virtual function call code generation -- CUDA/PTX-specific bits
 void jitc_var_call_assemble_cuda(CallData *call, uint32_t call_reg,
                                  uint32_t self_reg, uint32_t mask_reg,
-                                 uint32_t offset_reg, uint32_t data_reg,
                                  uint32_t in_size, uint32_t in_align,
                                  uint32_t out_size, uint32_t out_align) {
     // =====================================================
@@ -1521,17 +1529,35 @@ void jitc_var_call_assemble_cuda(CallData *call, uint32_t call_reg,
         fmt("\n    @!%p$u bra l_masked_$u;\n", mask_reg, call_reg);
     fmt("\n    { // Call: $s\n", call->name.c_str());
 
+    // Name of the base pointer: at the kernel level the register holding the
+    // base pointer parameter, inside a callable the forwarded 'base' argument.
+    // 'has_slots' selects whether the callee reads its own captured data;
+    // 'use_nested' selects whether it must receive the base pointer to forward.
+    char base[32];
+    if (callable_depth == 0)
+        snprintf(base, sizeof(base), "%%rd%u", call_buffer.base_reg);
+    else
+        snprintf(base, sizeof(base), "base");
+
+    bool has_slots  = !call->slots.empty();
+    // The dispatch reads the offset table whenever it must resolve a callable
+    // index (multi-target) or a per-lane data offset (own slots).
+    bool need_entry = call->n_inst != 1 || has_slots;
+
     // =====================================================
-    // 2. Determine unique callable ID
+    // 2. Determine unique callable ID + data offset
     // =====================================================
 
-    // %r3: callable ID
-    // %rd3: (high 32 bit): data offset
-    fmt("\n"
-        "        mad.wide.u32 %rd3, %r$u, 8, %rd$u;\n"
-        "        ld.global.u64 %rd3, [%rd3];\n"
-        "        cvt.u32.u64 %r3, %rd3;\n",
-        self_reg, offset_reg);
+    // %r3: callable ID; %rd3 (high 32 bit): absolute data offset in the buffer.
+    // This call's offset table begins at byte 'offset_base'.
+    if (need_entry) {
+        fmt("\n"
+            "        mad.wide.u32 %rd3, %r$u, 8, $s;\n"
+            "        ld.global.u64 %rd3, [%rd3+$u];\n",
+            self_reg, base, call->offset_base);
+        if (call->n_inst != 1)
+            put("        cvt.u32.u64 %r3, %rd3;\n");
+    }
 
     // =====================================================
     // 3. Turn callable ID into a function pointer
@@ -1549,13 +1575,13 @@ void jitc_var_call_assemble_cuda(CallData *call, uint32_t call_reg,
     }
 
     // =====================================================
-    // 4. Obtain pointer to supplemental call data
+    // 4. Resolve the per-lane call-data pointer (= B + absolute offset)
     // =====================================================
 
-    if (data_reg)
+    if (has_slots)
         fmt("        shr.u64 %rd3, %rd3, 32;\n"
-            "        add.u64 %rd3, %rd3, %rd$u;\n",
-            data_reg);
+            "        add.u64 %rd3, %rd3, $s;\n",
+            base);
 
     // %rd2: function pointer (if applicable)
     // %rd3: call data pointer with offset
@@ -1593,8 +1619,10 @@ void jitc_var_call_assemble_cuda(CallData *call, uint32_t call_reg,
             put(".reg .u32 index, ");
         if (call->use_self)
             put(".reg .u32 self, ");
-        if (data_reg)
+        if (has_slots)
             put(".reg .u64 data, ");
+        if (call->use_nested)
+            put(".reg .u64 base, ");
         if (in_size)
             fmt(".param .align $u .b8 params[$u], ", in_align, in_size);
         buffer.delete_trailing_commas();
@@ -1657,8 +1685,10 @@ void jitc_var_call_assemble_cuda(CallData *call, uint32_t call_reg,
     }
     if (call->use_self)
         fmt("%r$u, ", self_reg);
-    if (data_reg)
+    if (has_slots)
         put("%rd3, ");
+    if (call->use_nested)
+        fmt("$s, ", base);
     if (in_size)
         put("in, ");
     buffer.delete_trailing_commas();

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -325,6 +325,52 @@ void jitc_cuda_assemble_func(const CallData *call, uint32_t inst,
     // Bind this instance's data slots so jitc_call_slot_rel_offset() resolves them O(1)
     jitc_call_bind_slots(call, inst);
 
+    // Issue one or more vector loads to fetch the coalesced part of the call
+    // data (see call.h).
+    const CallData::InstanceLayout &call_layout = call->instance_layout[inst];
+    uint32_t cd_end = call_layout.coalesce_end;
+
+    // Only worth coalescing with >= 2 coalesceable fields.
+    bool cd_coalesce = call_layout.coalesce_count >= 2;
+
+    if (cd_coalesce) {
+        bool supports_256bit =
+            jitc_cuda_supports_256bit(thread_state_cuda, uses_optix);
+
+        // Widest load this device may emit. The last load may cover bytes up
+        // to this boundary beyond ``cd_end``, so reserve that many 32-bit words.
+        uint32_t max_chunk = supports_256bit ? 32u : 16u;
+        uint32_t end    = (cd_end + 3u) & ~3u, // round up to a full word
+                 nwords = ((cd_end + max_chunk - 1u) & ~(max_chunk - 1u)) / 4;
+
+        fmt("    .reg.b32 %cdw<$u>;\n"
+            "    .reg.b64 %cdq;\n"
+            "    .reg.b32 %cdb;\n"
+            "    .reg.b16 %cdh<2>;\n",
+            nwords);
+
+        uint32_t p = 0;
+        while (p < end) {
+            uint32_t w_bytes = jitc_call_pick_word_chunk_size(p, end - p, max_chunk),
+                     first   = p / 4;
+            if (w_bytes == 32)
+                fmt("    ld.global.v8.b32 {%cdw$u, %cdw$u, %cdw$u, %cdw$u, "
+                    "%cdw$u, %cdw$u, %cdw$u, %cdw$u}, [data+$u];\n",
+                    first, first + 1, first + 2, first + 3,
+                    first + 4, first + 5, first + 6, first + 7, p);
+            else if (w_bytes == 16)
+                fmt("    ld.global.v4.b32 {%cdw$u, %cdw$u, %cdw$u, %cdw$u}, [data+$u];\n",
+                    first, first + 1, first + 2, first + 3, p);
+            else if (w_bytes == 8)
+                fmt("    ld.global.v2.b32 {%cdw$u, %cdw$u}, [data+$u];\n",
+                    first, first + 1, p);
+            else
+                fmt("    ld.global.b32 %cdw$u, [data+$u];\n", first, p);
+
+            p += w_bytes;
+        }
+    }
+
     // Warning: do not rewrite this into a range-based for loop.
     // The memory location of 'schedule' may change.
     for (size_t i = 0; i < schedule.size(); ++i) {
@@ -352,7 +398,30 @@ void jitc_cuda_assemble_func(const CallData *call, uint32_t inst,
             }
         } else if (v->is_evaluated() || (vt == VarType::Pointer && kind == VarKind::Literal)) {
             uint32_t offset = jitc_call_slot_rel_offset(call, inst, v, sv.index);
-            if (vt != VarType::Bool)
+            uint32_t tsz = type_size[vti];
+            const CallData::CaptureSlot &capture = call->slots[v->param_offset];
+            if (cd_coalesce && capture.bucket.coalesceable()) {
+                // Reconstruct this field from the coalesced scratch words
+                uint32_t w = offset / 4;
+                if (tsz == 8) // Int64 / UInt64 / Pointer
+                    fmt("    mov.b64 %cdq, {%cdw$u, %cdw$u};\n"
+                        "    mov.b64 $v, %cdq;\n",
+                        w, w + 1, v);
+                else if (tsz == 4)
+                    fmt("    mov.b32 $v, %cdw$u;\n", v, w);
+                else if (tsz == 2) // pick the correct 16-bit half of the word
+                    fmt("    mov.b32 {%cdh0, %cdh1}, %cdw$u;\n"
+                        "    mov.b16 $v, %cdh$u;\n",
+                        w, v, (offset % 4) / 2);
+                else if (vt == VarType::Bool) // tsz == 1: extract the byte
+                    fmt("    bfe.u32 %cdb, %cdw$u, $u, 8;\n"
+                        "    setp.ne.u32 $v, %cdb, 0;\n",
+                        w, (offset % 4) * 8, v);
+                else // tsz == 1: Int8 / UInt8
+                    fmt("    bfe.u32 %cdb, %cdw$u, $u, 8;\n"
+                        "    cvt.u8.u32 $v, %cdb;\n",
+                        w, (offset % 4) * 8, v);
+            } else if (vt != VarType::Bool)
                 fmt("    ld.global.$b $v, [data+$u];\n",
                     v, v, offset);
             else
@@ -1529,17 +1598,16 @@ void jitc_var_call_assemble_cuda(CallData *call, uint32_t call_reg,
         fmt("\n    @!%p$u bra l_masked_$u;\n", mask_reg, call_reg);
     fmt("\n    { // Call: $s\n", call->name.c_str());
 
-    // Name of the base pointer: at the kernel level the register holding the
-    // base pointer parameter, inside a callable the forwarded 'base' argument.
-    // 'has_slots' selects whether the callee reads its own captured data;
-    // 'use_nested' selects whether it must receive the base pointer to forward.
+    // Name of the base pointer holding the kernel's combined call data
     char base[32];
     if (callable_depth == 0)
         snprintf(base, sizeof(base), "%%rd%u", call_buffer.base_reg);
     else
         snprintf(base, sizeof(base), "base");
 
+    // Does the kernel caller read its call data?
     bool has_slots  = !call->slots.empty();
+
     // The dispatch reads the offset table whenever it must resolve a callable
     // index (multi-target) or a per-lane data offset (own slots).
     bool need_entry = call->n_inst != 1 || has_slots;

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -298,7 +298,7 @@ void jitc_cuda_assemble_func(const CallData *call, uint32_t inst,
         put(".reg .u32 index, ");
     if (call->use_self)
         put(".reg .u32 self, ");
-    if (!call->data_map.empty())
+    if (!call->slots.empty())
         put(".reg .u64 data, ");
     if (in_size)
         fmt(".param .align $u .b8 params[$u], ", in_align, in_size);
@@ -311,6 +311,9 @@ void jitc_cuda_assemble_func(const CallData *call, uint32_t inst,
         "    .reg.f64  %d <$u>; .reg.pred %p<$u>;\n",
         call->name.c_str(), n_regs, n_regs, n_regs, n_regs, n_regs, n_regs,
         n_regs, n_regs);
+
+    // Bind this instance's data slots so jitc_call_slot_rel_offset() resolves them O(1)
+    jitc_call_bind_slots(call, inst);
 
     // Warning: do not rewrite this into a range-based for loop.
     // The memory location of 'schedule' may change.
@@ -338,23 +341,7 @@ void jitc_cuda_assemble_func(const CallData *call, uint32_t inst,
                     "    setp.ne.u16 $v, %w0, 0;\n", a, v);
             }
         } else if (v->is_evaluated() || (vt == VarType::Pointer && kind == VarKind::Literal)) {
-            uint64_t key = (uint64_t) sv.index + (((uint64_t) inst) << 32);
-            auto it = call->data_map.find(key);
-
-            if (unlikely(it == call->data_map.end())) {
-                jitc_fail("jitc_cuda_assemble_func(): could not find entry for "
-                          "variable r%u in 'data_map' for function %s", sv.index, call->name.c_str());
-                continue;
-            }
-
-            if (it->second == (uint32_t) -1)
-                jitc_fail(
-                    "jitc_cuda_assemble_func(): variable r%u is referenced by "
-                    "a recorded function call. However, it was evaluated "
-                    "between the recording step and code generation (which "
-                    "is happening now). This is not allowed.", sv.index);
-
-            uint32_t offset = it->second - call->data_offset[inst];
+            uint32_t offset = jitc_call_slot_rel_offset(call, inst, v, sv.index);
             if (vt != VarType::Bool)
                 fmt("    ld.global.$b $v, [data+$u];\n",
                     v, v, offset);

--- a/src/cuda_green.cpp
+++ b/src/cuda_green.cpp
@@ -57,8 +57,7 @@ CUDAGreenContext *jitc_cuda_green_context_make(uint32_t sm_count_requested,
     // Step 2: compute how many SMs we can allocate (respect min/alignment)
     uint32_t total_sm  = sm_resource.sm.smCount;
     uint32_t rounded   = std::max(sm_count_requested, sm_resource.sm.minSmPartitionSize);
-    rounded            = ceil_div(rounded, sm_resource.sm.smCoscheduledAlignment) *
-                         sm_resource.sm.smCoscheduledAlignment;
+    rounded            = align_up(rounded, sm_resource.sm.smCoscheduledAlignment);
 
 
     if (rounded > total_sm)

--- a/src/cuda_packet.cpp
+++ b/src/cuda_packet.cpp
@@ -24,15 +24,8 @@ void jitc_cuda_render_gather_packet(const Variable *v, const Variable *ptr,
              tsize = type_size[v->type],
              total_bytes = count * tsize;
 
-    // Get compute capability for current device
-    const ThreadState *ts = thread_state_cuda;
-    uint32_t compute_capability = state.devices[ts->device].compute_capability;
-
-    // 256-bit operations require CC 12.0+, and for OptiX: CUDA driver 13.2+
-    bool supports_256bit = compute_capability >= 120 &&
-                          (!uses_optix ||
-                           (jitc_cuda_version_major > 13 ||
-                            (jitc_cuda_version_major == 13 && jitc_cuda_version_minor >= 2)));
+    bool supports_256bit =
+        jitc_cuda_supports_256bit(thread_state_cuda, uses_optix);
 
     fmt("    mad.wide.$t %rd3, $v, $u, $v;\n"
         "    .reg.$t $v_out_<$u>;\n",
@@ -326,15 +319,8 @@ void jitc_cuda_render_scatter_packet(const Variable *v, const Variable *ptr,
         return;
     }
 
-    // Get compute capability for current device
-    const ThreadState *ts = thread_state_cuda;
-    uint32_t compute_capability = state.devices[ts->device].compute_capability;
-
-    // 256-bit operations require CC 12.0+, and for OptiX: CUDA driver 13.2+
-    bool supports_256bit = compute_capability >= 120 &&
-                          (!uses_optix ||
-                           (jitc_cuda_version_major > 13 ||
-                            (jitc_cuda_version_major == 13 && jitc_cuda_version_minor >= 2)));
+    bool supports_256bit =
+        jitc_cuda_supports_256bit(thread_state_cuda, uses_optix);
 
     uint32_t count = (uint32_t) values.size(),
              tsize = type_size[v0->type],

--- a/src/cuda_ts.cpp
+++ b/src/cuda_ts.cpp
@@ -246,7 +246,7 @@ void CUDAThreadState::block_reduce(VarType vt, ReduceOp op, uint32_t size,
         // changing the numbers below, the kernel expects this configuration.
 
         // Minimum number of threads needed to finish the work
-        uint32_t min_threads = ceil_div(block_count * chunk_size, 32) * 32;
+        uint32_t min_threads = align_up(block_count * chunk_size, 32);
 
         // In general, schedule >= 4 warps/block to improve occupancy. It's
         // okay to use fewer warps if the input data size is tiny.
@@ -583,7 +583,7 @@ void CUDAThreadState::block_prefix_reduce(VarType vt, ReduceOp op,
         // changing the numbers below, the kernel expects this configuration.
 
         // Minimum number of threads needed to finish the work
-        uint32_t min_threads = ceil_div(block_count * chunk_size, 32) * 32;
+        uint32_t min_threads = align_up(block_count * chunk_size, 32);
 
         // In general, schedule >= 4 warps/block to improve occupancy. It's
         // okay to use fewer warps if the input data size is tiny.

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -305,6 +305,11 @@ static void jitc_var_traverse(uint32_t size, uint32_t index, uint32_t depth = 0)
             }
             break;
 
+        case VarKind::CallGetter:
+            // Only the [index, mask] deps (walked below) are scheduled; the
+            // value table is captured into the buffer at upload, like 'Call'.
+            break;
+
         default:
             break;
     }
@@ -393,7 +398,9 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
 
     // Set while scanning the schedule below if this kernel performs any
     // indirect call (used further down to reserve the call base pointer).
-    bool has_call = false;
+    // 'needs_call_buffer' additionally covers getters, which read from the same
+    // shared buffer but emit no visible function table.
+    bool has_call = false, needs_call_buffer = false;
 
     for (uint32_t group_index = group.start; group_index != group.end; ++group_index) {
         ScheduledVariable &sv = schedule[group_index];
@@ -437,6 +444,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
 
         VarKind kind = (VarKind) v->kind;
         has_call |= (kind == VarKind::Call);
+        needs_call_buffer |= (kind == VarKind::Call || kind == VarKind::CallGetter);
 
         if (unlikely(kind == VarKind::Array ||
                      kind == VarKind::ArrayInit ||
@@ -491,16 +499,14 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
         }
     }
 
-    // If this kernel performs any indirect call, reserve the base pointer: a
-    // single kernel-uniform parameter storing callable offsets and opaque
-    // data accessed by callables. Here, we only reserve its register and
-    // parameter slot.
-    if (has_call) {
-        void *placeholder = jitc_malloc(backend, 1);
+    // If this kernel performs indirect calls or invokes getters, pass a data
+    // buffer containing the call data required by these operations. The code
+    // below reserves a register and parameter slot.
+    if (needs_call_buffer) {
         uint32_t base_src = jitc_var_mem_map(backend, VarType::UInt8,
-                                             placeholder, 1, /*free=*/1);
+                                             nullptr, 1, /*free=*/1);
 
-        uint32_t base_v = jitc_var_pointer(backend, placeholder, base_src,
+        uint32_t base_v = jitc_var_pointer(backend, nullptr, base_src,
                                            /*write=*/0, /*written=*/false,
                                            /*disable_lvn=*/true);
         jitc_var_dec_ref(base_src); // 'base_v' now owns the backing reference
@@ -956,6 +962,11 @@ static void jitc_eval_rollback(size_t callbacks_baseline) {
     for (CallData *call : calls_assembled)
         jitc_var_dec_ref(call->id);
     calls_assembled.clear();
+
+    // Release references taken by jitc_var_call_getter_assemble()
+    for (GetterData *gd : call_buffer.getters)
+        jitc_var_dec_ref(gd->id);
+    call_buffer.getters.clear();
 
     // IR string of a kernel history entry that no launch consumed
     free(kernel_history_entry.ir);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -952,6 +952,11 @@ static void jitc_eval_rollback(size_t callbacks_baseline) {
     // Captured-source references whose aggregate never ran
     call_buffer.data_entries.clear();
 
+    // Release references taken by jitc_var_call_assemble()
+    for (CallData *call : calls_assembled)
+        jitc_var_dec_ref(call->id);
+    calls_assembled.clear();
+
     // IR string of a kernel history entry that no launch consumed
     free(kernel_history_entry.ir);
     kernel_history_entry.ir = nullptr;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -103,6 +103,10 @@ void jitc_visit_new_gen() {
 static std::vector<void *> kernel_params;
 static std::vector<uint32_t> kernel_param_ids;
 
+/// Call-data base pointer variables created during this jit_eval()
+/// (one per kernel that performs calls). Released after the launch barrier.
+static std::vector<uint32_t> call_base_vars;
+
 /// Metadata for kernel parameters
 std::vector<KernelParamInfo> kernel_param_info;
 
@@ -345,6 +349,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
     alloca_size = alloca_align = -1;
     indirect_callable_count = 0;
     indirect_callable_count_unique = 0;
+    call_buffer.reset();
     uses_metal4 = false;
 #if defined(DRJIT_ENABLE_METAL)
     jitc_metal_assemble_reset();
@@ -385,6 +390,10 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
     }
 
     (void) timer();
+
+    // Set while scanning the schedule below if this kernel performs any
+    // indirect call (used further down to reserve the call base pointer).
+    bool has_call = false;
 
     for (uint32_t group_index = group.start; group_index != group.end; ++group_index) {
         ScheduledVariable &sv = schedule[group_index];
@@ -427,6 +436,7 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
         v->reg_index = n_regs++;
 
         VarKind kind = (VarKind) v->kind;
+        has_call |= (kind == VarKind::Call);
 
         if (unlikely(kind == VarKind::Array ||
                      kind == VarKind::ArrayInit ||
@@ -481,19 +491,45 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
         }
     }
 
+    // If this kernel performs any indirect call, reserve the base pointer: a
+    // single kernel-uniform parameter storing callable offsets and opaque
+    // data accessed by callables. Here, we only reserve its register and
+    // parameter slot.
+    if (has_call) {
+        void *placeholder = jitc_malloc(backend, 1);
+        uint32_t base_src = jitc_var_mem_map(backend, VarType::UInt8,
+                                             placeholder, 1, /*free=*/1);
+
+        uint32_t base_v = jitc_var_pointer(backend, placeholder, base_src,
+                                           /*write=*/0, /*written=*/false,
+                                           /*disable_lvn=*/true);
+        jitc_var_dec_ref(base_src); // 'base_v' now owns the backing reference
+
+        uint32_t param_index = (uint32_t) kernel_params.size();
+        Variable *bv = jitc_var(base_v);
+        bv->param_type = ParamType::Input;
+        bv->reg_index = n_regs++;
+        bv->param_offset = param_index * (uint32_t) sizeof(void *);
+
+        call_buffer.base_v = base_v;
+        call_buffer.base_src = base_src;
+        call_buffer.base_reg = bv->reg_index;
+        call_buffer.base_param_index = param_index;
+
+        add_param((void *) (uintptr_t) bv->literal);
+        kernel_param_ids.push_back(base_v);
+
+        // Released after the launch barrier (see jitc_eval_impl).
+        call_base_vars.push_back(base_v);
+    }
+
 #if defined(DRJIT_ENABLE_METAL)
     // If the kernel performs any call, reserve a trailing ``params.args[]`` slot
     // for its visible function table. The slot is not an IR variable, so it stays
     // out of ``kernel_param_ids``.
     metal_vft_arg_index = -1;
-    if (jitc_is_metal(backend)) {
-        for (uint32_t gi = group.start; gi != group.end; ++gi) {
-            if ((VarKind) jitc_var(schedule[gi].index)->kind == VarKind::Call) {
-                metal_vft_arg_index = (int) kernel_params.size() - 1;
-                break;
-            }
-        }
-    }
+    if (jitc_is_metal(backend) && has_call)
+        metal_vft_arg_index = (int) kernel_params.size() - 1;
 #endif
 
     if (unlikely(n_regs > 0xFFFFF))
@@ -555,6 +591,12 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
     else
 #endif
         jitc_llvm_assemble(ts, group);
+
+    // Bind the call-data buffer (built by jitc_call_upload() above and stored in
+    // the base pointer variable) into its reserved parameter slot.
+    if (call_buffer.base_v)
+        kernel_params[call_buffer.base_param_index] =
+            (void *) (uintptr_t) jitc_var(call_buffer.base_v)->literal;
 
     // Replace '^'s in '__raygen__^^^..' or 'drjit_^^^..' with hash.
     // Search for the kernel-name marker rather than the first '^', because
@@ -902,6 +944,14 @@ static void jitc_eval_rollback(size_t callbacks_baseline) {
         eval_callbacks.pop_back();
     }
 
+    // Call-data base pointers created before the failure
+    for (uint32_t index : call_base_vars)
+        jitc_var_dec_ref(index);
+    call_base_vars.clear();
+
+    // Captured-source references whose aggregate never ran
+    call_buffer.data_entries.clear();
+
     // IR string of a kernel history entry that no launch consumed
     free(kernel_history_entry.ir);
     kernel_history_entry.ir = nullptr;
@@ -1078,6 +1128,15 @@ void jitc_eval_impl(ThreadState *ts) {
     // Subsequent kernel launches must be serialized wrt. the launches above.
     // barrier() also drains shared allocations parked for deferred release.
     ts->barrier();
+
+    // Release strong references to opaque objects accessed by vcalls
+    call_buffer.data_entries.clear();
+
+    // Release the call-data base pointers now that every launch that
+    // referenced them has completed; this frees the fused buffers they own.
+    for (uint32_t index : call_base_vars)
+        jitc_var_dec_ref(index);
+    call_base_vars.clear();
 
     /* Variables and their dependencies are now computed, hence internal edges
        between them can be removed. This will cause many variables to expire. */

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -88,9 +88,9 @@ static std::vector<uint32_t> eval_roots;
    variable has scratch == 0, stamps are always >= 2, so the traversal
    correctly treats such a variable as unvisited. On the rare 31-bit wraparound,
    reset all stamps to 0 and restart. */
-static uint32_t visit_gen = 0;
+uint32_t visit_gen = 0;
 
-static void jitc_visit_new_gen() {
+void jitc_visit_new_gen() {
     if (unlikely(visit_gen == 0x7FFFFFFFu)) {
         for (Variable &v : state.variables)
             v.scratch = 0;
@@ -1011,7 +1011,7 @@ void jitc_eval_impl(ThreadState *ts) {
     for (size_t i = 0, n = eval_tasks.size(); i < n; ) {
         uint32_t group_size = eval_tasks[i].size;
 
-        // Advance generation counter per distinct size
+        // Advance the traversal generation counter per distinct size
         jitc_visit_new_gen();
 
         size_t j = i;

--- a/src/eval.h
+++ b/src/eval.h
@@ -105,6 +105,15 @@ extern uint32_t callable_depth;
 /// Ordered list of variables that should be computed
 extern std::vector<ScheduledVariable> schedule;
 
+/* Generation counter used to detect already-visited variables during graph
+   traversal (see the detailed comment in eval.cpp). The same counter is shared
+   by jit_eval() scheduling and jitc_var_call_analyze(); a single monotonic
+   counter guarantees stamps from one phase can never be misread by the other. */
+extern uint32_t visit_gen;
+
+/// Begin a fresh visit generation, invalidating all prior Variable::scratch stamps
+extern void jitc_visit_new_gen();
+
 /// Track kernel parameter metadata (writability, GPU resource kind)
 extern std::vector<KernelParamInfo> kernel_param_info;
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -114,6 +114,9 @@ enum class VarKind : uint32_t {
     // Specialized nodes for calls
     CallMask, CallSelf,
 
+    // Getter implemented as a gather from the shared per-kernel call-data buffer
+    CallGetter,
+
     // Input argument to a function call
     CallInput,
 

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -206,12 +206,20 @@ void jitc_llvm_assemble(ThreadState *ts, ScheduledGroup group) {
 
     /* The program requires extra memory or uses callables. Insert
        setup code the top of the function to accomplish this */
-    if (indirect_callable_count > 0 || alloca_size >= 0) {
+    if (indirect_callable_count > 0 || alloca_size >= 0 || call_buffer.base_v) {
         size_t suffix_start = buffer.size(),
                suffix_target = (char *) strchr(buffer.get(), ':') - buffer.get() + 2;
 
         if (indirect_callable_count > 0)
             fmt("    %callables = load ptr, ptr @callables, align 8\n");
+
+        // Load the call-data base pointer once, shared by every call's
+        // dispatch in this kernel.
+        if (call_buffer.base_v)
+            fmt("    %rd$u_basep = getelementptr inbounds ptr, ptr %params, i32 $u\n"
+                "    %rd$u = load ptr, ptr %rd$u_basep, align 8, !alias.scope !2, !noalias !2, !invariant.load !4\n",
+                call_buffer.base_reg, call_buffer.base_param_index,
+                call_buffer.base_reg, call_buffer.base_reg);
 
         if (alloca_size >= 0)
             fmt("    %buffer = alloca i8, i32 $u, align $u\n",
@@ -342,12 +350,14 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
     if (call->use_thread_id)
         put(", i32 %thread_id");
 
-    if (!call->slots.empty()) {
-        if (callable_depth == 1)
-            fmt(", ptr noalias %data, <$w x i32> %offsets");
-        else
-            fmt(", <$w x ptr> %data, <$w x i32> %offsets");
-    }
+    // The base pointer is kernel-uniform at every nesting level, hence always a
+    // single uniform pointer. A callable receives it if it reads its own
+    // captured data (then also the per-lane offsets) or if it contains a nested
+    // call (then only the base pointer, to forward downward).
+    if (!call->slots.empty())
+        fmt(", ptr noalias %data, <$w x i32> %offsets");
+    else if (call->use_nested)
+        fmt(", ptr noalias %data");
 
     // Name each input argument by slot index
     for (uint32_t i = 0; i < (uint32_t) call->outer_in.size(); ++i) {
@@ -391,15 +401,14 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
             uint32_t offset = jitc_call_slot_rel_offset(call, inst, v, sv.index);
             bool is_pointer_or_bool =
                 (vt == VarType::Pointer) || (vt == VarType::Bool);
-            // Expand $<..$> only when we are compiling a recursive function call
-            callable_depth--;
-            fmt("    $v_p1 = getelementptr inbounds i8, $<ptr$> %data, i32 $u\n"
-                "    $v_p2 = getelementptr inbounds i8, $<ptr$> $v_p1, <$w x i32> %offsets\n"
+            // %data is the kernel-uniform base pointer; %offsets is the per-lane
+            // absolute byte offset of this instance's data block in the buffer.
+            fmt("    $v_p1 = getelementptr inbounds i8, ptr %data, i32 $u\n"
+                "    $v_p2 = getelementptr inbounds i8, ptr $v_p1, <$w x i32> %offsets\n"
                 "    $v$s = call $M @llvm.masked.gather.v$w$h(<$w x ptr> $v_p2, i32 $a, <$w x i1> %mask, $M $z), !alias.scope !2, !noalias !2\n",
                 v, offset,
                 v, v,
                 v, is_pointer_or_bool ? "_p3" : "", v, v, v, v, v);
-            callable_depth++;
 
             if (vt == VarType::Pointer)
                 fmt("    $v = inttoptr <$w x i64> $v_p3 to <$w x ptr>\n",
@@ -1045,8 +1054,7 @@ static void jitc_llvm_render(Variable *v) {
 
         case VarKind::Call:
             jitc_var_call_assemble((CallData *) v->data, v->reg_index,
-                                   a0->reg_index, a1->reg_index, a2->reg_index,
-                                   a3 ? a3->reg_index : 0);
+                                   a0->reg_index, a1->reg_index);
             break;
 
         case VarKind::CallMask:
@@ -1584,10 +1592,25 @@ static void jitc_llvm_render_trace(const Variable *v,
 /// Virtual function call code generation -- LLVM IR-specific bits
 void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
                                  uint32_t self_reg, uint32_t mask_reg,
-                                 uint32_t offset_reg, uint32_t data_reg,
                                  uint32_t buf_size, uint32_t buf_align) {
     const uint32_t width = jitc_llvm_vector_width;
     (void) buf_size; (void) buf_align;
+
+    // Name of the base pointer: at the kernel level the register holding the
+    // base pointer parameter, inside a callable the forwarded '%data' argument.
+    // Both are uniform 'ptr's. 'has_data' is true if the callee reads its own
+    // captured slots (then we also forward the per-lane offsets); a callee with
+    // no data but a nested call still receives the base pointer.
+    char base[32];
+    if (callable_depth == 0)
+        snprintf(base, sizeof(base), "%%rd%u", call_buffer.base_reg);
+    else
+        snprintf(base, sizeof(base), "%%data");
+
+    bool has_data  = !call->slots.empty();
+    // The dispatch reads the offset table whenever it must resolve a callable
+    // index (multi-target) or a per-lane data offset (own slots).
+    bool need_entry = call->n_inst != 1 || has_data;
 
     // =====================================================
     // 1. Declare a few intrinsics that we will use
@@ -1615,13 +1638,17 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
             call_reg, call_reg);
     }
 
-    if (call->n_inst != 1 || data_reg) {
+    if (need_entry) {
         fmt_intrinsic("declare <$w x i64> @llvm.masked.gather.v$wi64(<$w x "
                       "ptr>, i32, <$w x i1>, <$w x i64>)");
 
-        fmt("    %u$u_self_ptr = getelementptr i64, $<ptr$> %rd$u, <$w x i32> %r$u\n"
+        // This call's offset table starts at byte 'offset_base' in the buffer
+        // (= element 'offset_base/8'); index it by 'self'.
+        fmt("    %u$u_obase = getelementptr i64, ptr $s, i64 $u\n"
+            "    %u$u_self_ptr = getelementptr i64, ptr %u$u_obase, <$w x i32> %r$u\n"
              "    %u$u_self_combined = call <$w x i64> @llvm.masked.gather.v$wi64(<$w x ptr> %u$u_self_ptr, i32 8, <$w x i1> %p$u, <$w x i64> $z), !alias.scope !2, !noalias !2\n",
-            call_reg, offset_reg, self_reg,
+            call_reg, base, call->offset_base / (uint32_t) sizeof(uint64_t),
+            call_reg, call_reg, self_reg,
             call_reg, call_reg, mask_reg);
     }
 
@@ -1630,7 +1657,8 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
             call_reg, call_reg);
     }
 
-    if (data_reg) {
+    if (has_data) {
+        // entry.hi is the absolute byte offset of the instance data block
         fmt("    %u$u_offset_1 = lshr <$w x i64> %u$u_self_combined, <",
                  call_reg, call_reg);
         for (uint32_t i = 0; i < width; ++i)
@@ -1657,8 +1685,10 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
             fmt(", i64 %index");
         if (call->use_thread_id)
             fmt(", i32 %thread_id");
-        if (data_reg)
-            fmt(", $<ptr$> %rd$u, <$w x i32> %u$u_offset", data_reg, call_reg);
+        if (has_data)
+            fmt(", ptr $s, <$w x i32> %u$u_offset", base, call_reg);
+        else if (call->use_nested)
+            fmt(", ptr $s", base);
         for (uint32_t i = 0; i < call->n_in; ++i) {
             if (!call->in_active[i])
                 continue;

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -1076,6 +1076,10 @@ static void jitc_llvm_render(Variable *v) {
                                    a0->reg_index, a1->reg_index);
             break;
 
+        case VarKind::CallGetter:
+            jitc_var_call_getter_assemble(v, a0, a1);
+            break;
+
         case VarKind::CallMask:
             fmt("    $v = bitcast <$w x i1> %mask to <$w x i1>\n", v);
             break;
@@ -1606,6 +1610,45 @@ static void jitc_llvm_render_trace(const Variable *v,
     }
 
     put("    ; -------------------\n\n");
+}
+
+/// Getter masked load (LLVM). Like the call offset-table gather, sourcing from
+/// the uniform 'base + header_offset' pointer.
+void jitc_var_call_getter_assemble_llvm(Variable *v, const Variable *index,
+                                        const Variable *mask) {
+    GetterData *gd = (GetterData *) v->data;
+    uint32_t header_offset = gd->header_offset;
+
+    // Name of the base pointer holding the kernel's combined call data. It is
+    // a uniform scalar 'ptr' at every nesting level (see the call signature).
+    char base[32];
+    if (callable_depth == 0)
+        snprintf(base, sizeof(base), "%%rd%u", call_buffer.base_reg);
+    else
+        snprintf(base, sizeof(base), "%%data");
+
+    bool is_bool = v->type == (uint32_t) VarType::Bool;
+    if (is_bool) // Temporary change so the gather renders as i8
+        v->type = (uint32_t) VarType::UInt8;
+
+    fmt_intrinsic(
+        "declare $T @llvm.masked.gather.v$w$h(<$w x ptr>, i32, $T, $T)",
+        v, v, mask, v);
+
+    // Byte-offset the uniform base, then index by the per-lane instance id to
+    // get a vector of pointers. The '_gp' suffix avoids the '_p1'/'_p2'/'_p3'
+    // namespace of the param preamble (a getter result is often a kernel output).
+    fmt("    $v_gp0 = getelementptr inbounds i8, ptr $s, i64 $u\n"
+        "    $v_gp1 = getelementptr inbounds $t, ptr $v_gp0, $V\n"
+        "    $v$s = call $T @llvm.masked.gather.v$w$h(<$w x ptr> $v_gp1, i32 $a, $V, $T $z), !alias.scope !2, !noalias !2\n",
+        v, base, header_offset,
+        v, v, v, index,
+        v, is_bool ? "_2" : "", v, v, v, v, mask, v);
+
+    if (is_bool) { // Restore
+        v->type = (uint32_t) VarType::Bool;
+        fmt("    $v = trunc <$w x i8> %b$u_2 to <$w x i1>\n", v, v->reg_index);
+    }
 }
 
 /// Virtual function call code generation -- LLVM IR-specific bits

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -350,6 +350,7 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
     if (call->use_thread_id)
         put(", i32 %thread_id");
 
+    // Base pointer holding the kernel's combined call data
     // The base pointer is kernel-uniform at every nesting level, hence always a
     // single uniform pointer. A callable receives it if it reads its own
     // captured data (then also the per-lane offsets) or if it contains a nested
@@ -379,6 +380,12 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
     // Bind this instance's data slots so jitc_call_slot_rel_offset() resolves them O(1)
     jitc_call_bind_slots(call, inst);
 
+    // Coalesce the recorded size-class buckets into packet loads up front.
+    // ``packetized_until[c]`` is the first slot past the packetized prefix of
+    // bucket c; the scalar path below validates a slot before consulting it.
+    uint32_t packetized_until[4];
+    jitc_llvm_render_call_data(call, inst, packetized_until);
+
     // Warning: do not rewrite this into a range-based for loop.
     // The memory location of 'schedule' may change.
     for (size_t i = 0; i < schedule.size(); ++i) {
@@ -395,10 +402,22 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
         }
 
         if (v->is_evaluated() || (vt == VarType::Pointer && kind == VarKind::Literal)) {
+            uint32_t offset = jitc_call_slot_rel_offset(call, inst, v, sv.index);
+
+            // Skip fields already emitted by the coalesced packet loads above.
+            uint32_t slot = v->param_offset;
+            const CallData::CaptureSlot &capture = call->slots[slot];
+            if (capture.bucket.coalesceable()) {
+                const CallData::InstanceLayout::Bucket &bucket =
+                    call->instance_layout[inst].bucket[capture.bucket.id()];
+                if (slot >= bucket.slot_start &&
+                    slot < packetized_until[capture.bucket.id()])
+                    continue;
+            }
+
             fmt_intrinsic("declare $M @llvm.masked.gather.v$w$h(<$w x ptr>, i32, <$w x i1>, $M)",
                           v, v, v);
 
-            uint32_t offset = jitc_call_slot_rel_offset(call, inst, v, sv.index);
             bool is_pointer_or_bool =
                 (vt == VarType::Pointer) || (vt == VarType::Bool);
             // %data is the kernel-uniform base pointer; %offsets is the per-lane
@@ -1596,18 +1615,16 @@ void jitc_var_call_assemble_llvm(CallData *call, uint32_t call_reg,
     const uint32_t width = jitc_llvm_vector_width;
     (void) buf_size; (void) buf_align;
 
-    // Name of the base pointer: at the kernel level the register holding the
-    // base pointer parameter, inside a callable the forwarded '%data' argument.
-    // Both are uniform 'ptr's. 'has_data' is true if the callee reads its own
-    // captured slots (then we also forward the per-lane offsets); a callee with
-    // no data but a nested call still receives the base pointer.
+    // Name of the base pointer holding the kernel's combined call data
     char base[32];
     if (callable_depth == 0)
         snprintf(base, sizeof(base), "%%rd%u", call_buffer.base_reg);
     else
         snprintf(base, sizeof(base), "%%data");
 
+    // Does the kernel caller read its call data?
     bool has_data  = !call->slots.empty();
+
     // The dispatch reads the offset table whenever it must resolve a callable
     // index (multi-target) or a per-lane data offset (own slots).
     bool need_entry = call->n_inst != 1 || has_data;

--- a/src/llvm_eval.cpp
+++ b/src/llvm_eval.cpp
@@ -342,7 +342,7 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
     if (call->use_thread_id)
         put(", i32 %thread_id");
 
-    if (!call->data_map.empty()) {
+    if (!call->slots.empty()) {
         if (callable_depth == 1)
             fmt(", ptr noalias %data, <$w x i32> %offsets");
         else
@@ -366,6 +366,9 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
 
     alloca_size = alloca_align = -1;
 
+    // Bind this instance's data slots so jitc_call_slot_rel_offset() resolves them O(1)
+    jitc_call_bind_slots(call, inst);
+
     // Warning: do not rewrite this into a range-based for loop.
     // The memory location of 'schedule' may change.
     for (size_t i = 0; i < schedule.size(); ++i) {
@@ -382,25 +385,10 @@ void jitc_llvm_assemble_func(const CallData *call, uint32_t inst) {
         }
 
         if (v->is_evaluated() || (vt == VarType::Pointer && kind == VarKind::Literal)) {
-            uint64_t key = (uint64_t) sv.index + (((uint64_t) inst) << 32);
-            auto it = call->data_map.find(key);
-            if (unlikely(it == call->data_map.end())) {
-                jitc_fail("jitc_llvm_assemble_func(): could not find entry for "
-                          "variable r%u in 'data_map' for function %s", sv.index, call->name.c_str());
-                continue;
-            }
-
-            if (it->second == (uint32_t) -1)
-                jitc_fail(
-                    "jitc_llvm_assemble_func(): variable r%u is referenced by "
-                    "a recorded function call. However, it was evaluated "
-                    "between the recording step and code generation (which is "
-                    "happening now). This is not allowed.", sv.index);
-
             fmt_intrinsic("declare $M @llvm.masked.gather.v$w$h(<$w x ptr>, i32, <$w x i1>, $M)",
                           v, v, v);
 
-            uint32_t offset = it->second - call->data_offset[inst];
+            uint32_t offset = jitc_call_slot_rel_offset(call, inst, v, sv.index);
             bool is_pointer_or_bool =
                 (vt == VarType::Pointer) || (vt == VarType::Bool);
             // Expand $<..$> only when we are compiling a recursive function call

--- a/src/llvm_packet.cpp
+++ b/src/llvm_packet.cpp
@@ -13,8 +13,10 @@
 #include "var.h"
 #include "llvm_eval.h"
 #include "llvm_packet.h"
+#include "call.h"
 #include "log.h"
 #include "op.h"
+#include <algorithm>
 
 void perm4(const Variable *v, const char *out, const char *arg0, const char *arg1, uint32_t pattern) {
     uint32_t width = jitc_llvm_vector_width;
@@ -119,11 +121,12 @@ void gather_packet_recursive(uint32_t l, uint32_t i, uint32_t n, const Variable 
     }
 }
 
-
-void jitc_llvm_render_gather_packet(const Variable *v, const Variable *ptr,
-                                    const Variable *index, const Variable *mask) {
+/// Emit (and register) the internal helper ``@gather_<n>x<H>`` that reads ``n``
+/// adjacent elements of type ``v`` from each lane's base address and transposes
+/// the result into ``n`` SoA vectors. The per-lane loads are ``type_size * n``
+/// aligned, which both callers guarantee.
+void jitc_llvm_gather_packet_define(const Variable *v, uint32_t n) {
     size_t offset = buffer.size();
-    uint32_t n = (uint32_t) v->literal;
 
     fmt_intrinsic("@zero_$m_$u = private constant [$u x $m] $z, align $u", v, n, n, v,
                   type_size[v->type] * jitc_llvm_vector_width);
@@ -149,6 +152,13 @@ void jitc_llvm_render_gather_packet(const Variable *v, const Variable *ptr,
 
     jitc_register_global(buffer.get() + offset);
     buffer.rewind_to(offset);
+}
+
+void jitc_llvm_render_gather_packet(const Variable *v, const Variable *ptr,
+                                    const Variable *index, const Variable *mask) {
+    uint32_t n = (uint32_t) v->literal;
+
+    jitc_llvm_gather_packet_define(v, n);
 
     const char *ext = "";
     if (v->type == (uint32_t) VarType::Bool)
@@ -172,6 +182,149 @@ void jitc_llvm_render_gather_packet(const Variable *v, const Variable *ptr,
         for (uint32_t i = 0; i < n; ++i)
             fmt("    $v_out_$u = trunc <$w x $m> $v_out_$u_e to <$w x i1>\n",
                 v, i, v, v, i);
+    }
+}
+
+void jitc_llvm_render_call_data(const CallData *call, uint32_t inst,
+                                uint32_t packetized_until[4]) {
+    const CallData::InstanceLayout &layout = call->instance_layout[inst];
+    uint32_t width = jitc_llvm_vector_width,
+             uid   = 0;
+
+    for (uint32_t c = 0; c < 4; ++c)
+        packetized_until[c] = layout.bucket[c].slot_start;
+
+    // A field is loadable iff scheduled (reg_index != 0): only scheduled vars
+    // have an SSA name to bind. This function only iterates coalesceable buckets,
+    // whose membership was classified when slots were captured.
+    //
+    // A coalesceable slot can be unscheduled when it is captured solely by a call
+    // output (or side effect) that the optimizer later eliminated -- the
+    // trace-time layout still reserved its offset, but no codegen references it.
+    // Such "holes" are loaded across (their bytes are contiguous and uploaded)
+    // but bound nowhere; they are dead.
+    auto loadable = [](const Variable *v) {
+        return v && v->reg_index != 0;
+    };
+
+    // The layout pass already grouped coalesceable slots into four homogeneous
+    // size-class buckets. LLVM packet gathers require such homogeneous runs, so
+    // each bucket can be streamed directly rather than rediscovered here.
+    //
+    // A bucket is coalesced on "coalesceable", not "loadable": it may contain
+    // holes -- slots that the optimizer left unscheduled (reg_index 0) and that
+    // are therefore not bound here. Their bytes are contiguous and uploaded like
+    // any other slot, so the packet load reads across them harmlessly and we skip
+    // binding those lanes. Trailing holes are trimmed so the scalar path can pick
+    // up an under-utilized live tail.
+    for (uint32_t c = 0; c < 4; ++c) {
+        const CallData::InstanceLayout::Bucket &bucket = layout.bucket[c];
+        uint32_t k = bucket.slot_start,
+                 kend = bucket.slot_end();
+
+        if (k == kend)
+            continue;
+
+        uint32_t s = CallData::SizeBucket::size_from_id(c),
+                 rel0 = call->slots[k].offset - layout.data_offset,
+                 last_load = (uint32_t) -1;
+
+        for (uint32_t slot = k; slot < kend; ++slot) {
+            const Variable *vk = jitc_var(call->slots[slot].ref);
+            if (loadable(vk))
+                last_load = slot;
+        }
+
+        // Skip a bucket with no loadable fields; otherwise trim trailing holes.
+        if (last_load == (uint32_t) -1)
+            continue;
+        uint32_t run_len = last_load - k + 1;
+
+        // Canonical integer type matching the run's element width.
+        VarType cvt = s == 8 ? VarType::UInt64
+                    : s == 4 ? VarType::UInt32
+                    : s == 2 ? VarType::UInt16
+                             : VarType::UInt8;
+        Variable rep{};
+        rep.type = (uint32_t) cvt;
+
+        uint32_t pos = 0;
+        while (pos < run_len) {
+            uint32_t rem = run_len - pos;
+
+            // Largest packet count (>= 2, <= 8, <= SIMD width) that stays
+            // sufficiently utilized. A return value < 2 falls back to the
+            // per-field gather path below.
+            uint32_t p = jitc_call_pick_llvm_packet_count(
+                rem, width < 8u ? width : 8u);
+            if (p < 2)
+                break;
+
+            uint32_t valid   = std::min(rem, p),
+                     run_off = rel0 + pos * s,
+                     id      = uid++;
+
+            // Each run starts at its size class's packet-aligned boundary (we
+            // coalesce on "coalesceable", the property the layout aligns to) and
+            // advances by whole packets, so ``run_off`` is a multiple of ``p*s`` --
+            // the alignment jitc_llvm_gather_packet_define() bakes into the load.
+            jitc_assert(run_off % (p * s) == 0,
+                        "jitc_llvm_render_call_data(): misaligned packet load "
+                        "(run_off=%u, p=%u, s=%u)", run_off, p, s);
+
+            jitc_llvm_gather_packet_define(&rep, p);
+
+            fmt("    %cd$u_p1 = getelementptr inbounds i8, ptr %data, i32 $u\n"
+                "    %cd$u_p2 = getelementptr inbounds i8, ptr %cd$u_p1, <$w x i32> %offsets\n"
+                "    %cd$u_p3 = getelementptr [$u x $m], ptr @zero_$m_$u, <$w x i32> zeroinitializer\n"
+                "    %cd$u_p4 = select <$w x i1> %mask, <$w x ptr> %cd$u_p2, <$w x ptr> %cd$u_p3\n"
+                "    %cd$u_r = call fastcc [$u x <$w x $m>] @gather_$ux$H(<$w x ptr> %cd$u_p4)\n",
+                id, run_off,
+                id, id,
+                id, p, &rep, &rep, p,
+                id, id, id,
+                id, p, &rep, p, &rep, id);
+
+            for (uint32_t j = 0; j < valid; ++j) {
+                uint32_t slot = k + pos + j;
+                const Variable *vf = jitc_var(call->slots[slot].ref);
+
+                // Skip holes: their lane was loaded but has no SSA value to bind.
+                if (!loadable(vf))
+                    continue;
+
+                VarType ft = (VarType) vf->type;
+
+                // Integers of the run's width are the same LLVM type as the
+                // gathered words and bind directly; floats/bool/pointers convert
+                // from the canonical integer.
+                bool is_int = ft != VarType::Bool && ft != VarType::Pointer &&
+                              ft != VarType::Float16 && ft != VarType::Float32 &&
+                              ft != VarType::Float64;
+
+                if (is_int) {
+                    fmt("    $v = extractvalue [$u x <$w x $m>] %cd$u_r, $u\n",
+                        vf, p, &rep, id, j);
+                } else {
+                    fmt("    %cd$u_o$u = extractvalue [$u x <$w x $m>] %cd$u_r, $u\n",
+                        id, j, p, &rep, id, j);
+                    if (ft == VarType::Bool)
+                        fmt("    $v = trunc <$w x i8> %cd$u_o$u to <$w x i1>\n",
+                            vf, id, j);
+                    else if (ft == VarType::Pointer)
+                        // A pointer's '$T' is '<w x i64>'; the SSA value is the
+                        // '<w x ptr>' produced here (cf. the scalar path).
+                        fmt("    $v = inttoptr <$w x $m> %cd$u_o$u to <$w x ptr>\n",
+                            vf, &rep, id, j);
+                    else // float / half / double
+                        fmt("    $v = bitcast <$w x $m> %cd$u_o$u to $T\n",
+                            vf, &rep, id, j, vf);
+                }
+            }
+
+            pos += valid;
+            packetized_until[c] = k + pos;
+        }
     }
 }
 

--- a/src/llvm_packet.h
+++ b/src/llvm_packet.h
@@ -10,6 +10,14 @@
 
 #include "eval.h"
 
+struct CallData;
+
+/// Coalesce an instance's per-call capture loads into packet (vector) loads,
+/// setting ``packetized_until[c]`` to the first slot past the packetized prefix
+/// of coalesceable size-class bucket ``c`` (0=8B, 1=4B, 2=2B, 3=1B).
+extern void jitc_llvm_render_call_data(const CallData *call, uint32_t inst,
+                                       uint32_t packetized_until[4]);
+
 extern void jitc_llvm_render_gather_packet(const Variable *v,
                                            const Variable *ptr,
                                            const Variable *index,

--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -1291,15 +1291,6 @@ void jitc_metal_assemble_func(const CallData *call, uint32_t inst,
                               uint32_t /*in_size*/, uint32_t /*in_align*/,
                               uint32_t /*out_size*/, uint32_t /*out_align*/,
                               uint32_t /*n_regs*/) {
-    // Callables of one call site share a typed signature: inputs by value,
-    // outputs returned by value in a struct, so they stay in registers across
-    // the indirect call. A multi-target callable is marked ``[[visible]]`` so
-    // it can be reached through the kernel's (single, type-erased) visible
-    // function table, reinterpreted at each site with this site's signature; a
-    // single-target callable is called by name and left inline-able. The
-    // ``call_table`` handle is forwarded for nested calls. (A TraceRay inside
-    // the body reconstructs its accel / IFT from the ``device`` call-data
-    // section, so no per-scene parameters are forwarded.)
     jitc_metal_emit_ret_struct(call);
 
     if (call->n_inst != 1)
@@ -1312,6 +1303,92 @@ void jitc_metal_assemble_func(const CallData *call, uint32_t inst,
 
     // Bind this instance's data slots so jitc_call_slot_rel_offset() resolves them O(1)
     jitc_call_bind_slots(call, inst);
+
+    // Issue one or more vector loads to fetch the coalesced part of the call
+    // data (see call.h).
+    const CallData::InstanceLayout &call_layout = call->instance_layout[inst];
+    uint32_t numeric_end = call_layout.coalesce_end;
+
+    // Only worth coalescing with >= 2 coalesceable fields.
+    bool cd_coalesce = call_layout.coalesce_count >= 2;
+
+    if (cd_coalesce) {
+        uint32_t end = (numeric_end + 3u) & ~3u; // round up to a full word
+
+        uint32_t p = 0, chunk = 0;
+        while (p < end) {
+            uint32_t w_bytes = jitc_call_pick_word_chunk_size(p, end - p, 16u);
+
+            const char *lt = w_bytes == 16 ? "uint4"
+                           : w_bytes == 8  ? "uint2" : "uint";
+            fmt("$s cd_c$u = *(device const $s*)(data + $u);\n",
+                lt, chunk, lt, p);
+
+            ++chunk;
+            p += w_bytes;
+        }
+    }
+
+    // Emit the generated MSL expression holding 32-bit word ``word`` of the
+    // coalesced prefix.
+    auto put_cd_word_expr = [&](uint32_t word) {
+        uint32_t target = word * 4,
+                 end    = (numeric_end + 3u) & ~3u,
+                 p      = 0,
+                 chunk  = 0;
+
+        while (p < end) {
+            uint32_t w_bytes = jitc_call_pick_word_chunk_size(p, end - p, 16u);
+            if (target >= p && target < p + w_bytes) {
+                uint32_t lane = (target - p) / 4;
+                fmt("cd_c$u", chunk);
+                if (w_bytes != 4) {
+                    put('.');
+                    put("xyzw"[lane]);
+                }
+                return;
+            }
+            ++chunk;
+            p += w_bytes;
+        }
+
+        jitc_fail("jitc_metal_assemble_func(): internal call-data word lookup "
+                  "failure.");
+    };
+
+    // Emit a declaration extracting a coalesced field of type ``svt`` at relative
+    // byte offset ``off``. Fields outside the packet-loadable SizeBucket prefix
+    // use the per-field typed load instead.
+    auto put_cd_extract = [&](const Variable *v, uint32_t off, VarType svt) {
+        uint32_t s = type_size[(int) svt], j = off / 4;
+        const char *base = type_name_metal[(int) svt];
+
+        if (svt == VarType::Pointer) {
+            // Buffer pointer: reassemble the 64-bit address and C-cast it back to
+            // a device pointer (MSL forbids 'as_type' to a pointer type, but the
+            // integer-to-device-pointer C cast is well-formed).
+            fmt("device uint8_t* $v = "
+                "(device uint8_t*)(as_type<ulong>(uint2(", v);
+            put_cd_word_expr(j);
+            put(", ");
+            put_cd_word_expr(j + 1);
+            put(")));\n");
+        } else if (s == 8) { // Int64 / UInt64 (Float64 cannot occur on Metal)
+            fmt("$t $v = as_type<$s>(uint2(", v, v, base);
+            put_cd_word_expr(j);
+            put(", ");
+            put_cd_word_expr(j + 1);
+            put("));\n");
+        } else if (s == 4) {
+            fmt("$t $v = as_type<$s>(", v, v, base);
+            put_cd_word_expr(j);
+            put(");\n");
+        } else { // s == 2
+            fmt("$t $v = as_type<$s2>(", v, v, base);
+            put_cd_word_expr(j);
+            fmt(").$s;\n", (off % 4) ? "y" : "x");
+        }
+    };
 
     for (size_t i = 0; i < schedule.size(); ++i) {
         ScheduledVariable &sv = schedule[i];
@@ -1361,7 +1438,13 @@ void jitc_metal_assemble_func(const CallData *call, uint32_t inst,
                     { v->data, ResourceKind::Buffer, false });
             }
 
-            if (vt == VarType::Bool)
+            const CallData::CaptureSlot &capture = call->slots[v->param_offset];
+            if (cd_coalesce && capture.bucket.coalesceable()) {
+                // Extract this field from the coalesced vector loads; the rest
+                // (1-byte fields; opaque handles took the typed path above) fall
+                // through to the plain typed loads below.
+                put_cd_extract(v, offset, vt);
+            } else if (vt == VarType::Bool)
                 fmt("bool $v = *(device uint8_t*)(data + $u) != 0;\n",
                     v, offset);
             else if (vt == VarType::Pointer)
@@ -1447,8 +1530,7 @@ void jitc_var_call_assemble_metal(CallData *call, uint32_t call_reg,
     if (is_masked)
         fmt("if (r$u) {\n", mask_reg);
 
-    // Name of the base pointer: at the kernel level the register holding the
-    // base pointer parameter, inside a callable the forwarded 'base' argument.
+    // Name of the base pointer holding the kernel's combined call data
     char base[32];
     if (callable_depth == 0)
         snprintf(base, sizeof(base), "r%u", call_buffer.base_reg);

--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -1298,6 +1298,9 @@ void jitc_metal_assemble_func(const CallData *call, uint32_t inst,
     put(") {\n");
     fmt("// Call: $s\n", call->name.c_str());
 
+    // Bind this instance's data slots so jitc_call_slot_rel_offset() resolves them O(1)
+    jitc_call_bind_slots(call, inst);
+
     for (size_t i = 0; i < schedule.size(); ++i) {
         ScheduledVariable &sv = schedule[i];
         Variable *v = jitc_var(sv.index);
@@ -1317,24 +1320,7 @@ void jitc_metal_assemble_func(const CallData *call, uint32_t inst,
         } else if (kind == VarKind::CallSelf) {
             fmt("uint $v = self;\n", v);
         } else if (v->is_evaluated() || (vt == VarType::Pointer && kind == VarKind::Literal)) {
-            uint64_t key = (uint64_t) sv.index + (((uint64_t) inst) << 32);
-            auto it = call->data_map.find(key);
-
-            if (unlikely(it == call->data_map.end())) {
-                jitc_fail("jitc_metal_assemble_func(): could not find entry for "
-                          "variable r%u in 'data_map' for function %s",
-                          sv.index, call->name.c_str());
-                continue;
-            }
-
-            if (it->second == (uint32_t) -1)
-                jitc_fail(
-                    "jitc_metal_assemble_func(): variable r%u is referenced by "
-                    "a recorded function call. However, it was evaluated "
-                    "between the recording step and code generation (which is "
-                    "happening now). This is not allowed.", sv.index);
-
-            uint32_t offset = it->second - call->data_offset[inst];
+            uint32_t offset = jitc_call_slot_rel_offset(call, inst, v, sv.index);
 
             // Opaque resource handles (textures, samplers, ray-tracing
             // structures) reconstruct a typed reference directly from the

--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -273,6 +273,13 @@ void jitc_metal_assemble(ThreadState *ts, ScheduledGroup group,
         "    constant Params& params [[buffer(0)]],\n"
         "    uint r0 [[thread_position_in_grid]]) {\n");
 
+    // Load the call-data base pointer once, shared by every call's dispatch in
+    // this kernel. The args index is the parameter index minus one (the leading
+    // 'size' field, see the '$o' convention).
+    if (call_buffer.base_v)
+        fmt("    device uint8_t* r$u = (device uint8_t*) params.args[$u];\n",
+            call_buffer.base_reg, call_buffer.base_param_index - 1);
+
     // -------------------------------------------------------------------
     //   4. Render every variable in the schedule
     // -------------------------------------------------------------------
@@ -1122,12 +1129,9 @@ static void jitc_metal_render(Variable *v) {
 
         case VarKind::Call: {
             Variable *a0 = jitc_var(v->dep[0]),
-                     *a1 = jitc_var(v->dep[1]),
-                     *a2 = jitc_var(v->dep[2]),
-                     *a3 = v->dep[3] ? jitc_var(v->dep[3]) : nullptr;
+                     *a1 = jitc_var(v->dep[1]);
             jitc_var_call_assemble((CallData *) v->data, v->reg_index,
-                                   a0->reg_index, a1->reg_index, a2->reg_index,
-                                   a3 ? a3->reg_index : 0);
+                                   a0->reg_index, a1->reg_index);
             break;
         }
 
@@ -1264,6 +1268,14 @@ static void jitc_metal_callable_signature(const CallData *call, bool with_names)
     else
         put("uint, uint, device uint8_t*, constant void*");
 
+    // Callables containing a nested call also receive the base pointer.
+    if (call->use_nested) {
+        if (with_names)
+            put(", device uint8_t* base");
+        else
+            put(", device uint8_t*");
+    }
+
     for (uint32_t i = 0; i < call->n_in; ++i) {
         if (!call->in_active[i])
             continue;
@@ -1387,7 +1399,6 @@ void jitc_metal_assemble_func(const CallData *call, uint32_t inst,
 
 void jitc_var_call_assemble_metal(CallData *call, uint32_t call_reg,
                                   uint32_t self_reg, uint32_t mask_reg,
-                                  uint32_t offset_reg, uint32_t data_reg,
                                   uint32_t /*in_size*/, uint32_t /*in_align*/,
                                   uint32_t /*out_size*/, uint32_t /*out_align*/) {
     // =====================================================
@@ -1436,16 +1447,32 @@ void jitc_var_call_assemble_metal(CallData *call, uint32_t call_reg,
     if (is_masked)
         fmt("if (r$u) {\n", mask_reg);
 
-    // Load the uint64_t entry: (data_offset << 32) | callable_index
-    fmt("$sulong _oe_$u = ((device const ulong*) r$u)[r$u];\n"
-        "$suint _ci_$u = (uint)(_oe_$u & 0xFFFFFFFFu);\n",
-        indent, call_reg, offset_reg, self_reg,
-        indent, call_reg, call_reg);
+    // Name of the base pointer: at the kernel level the register holding the
+    // base pointer parameter, inside a callable the forwarded 'base' argument.
+    char base[32];
+    if (callable_depth == 0)
+        snprintf(base, sizeof(base), "r%u", call_buffer.base_reg);
+    else
+        snprintf(base, sizeof(base), "base");
 
-    if (data_reg)
+    bool has_slots  = !call->slots.empty();
+    bool need_entry = call->n_inst != 1 || has_slots;
+
+    // Load the uint64_t offset-table entry: (abs_data_offset << 32) |
+    // callable_index. This call's table begins at element 'offset_base/8' of B.
+    if (need_entry) {
+        fmt("$sulong _oe_$u = ((device const ulong*) $s)[$u + r$u];\n",
+            indent, call_reg, base,
+            call->offset_base / (uint32_t) sizeof(uint64_t), self_reg);
+        if (call->n_inst != 1)
+            fmt("$suint _ci_$u = (uint)(_oe_$u & 0xFFFFFFFFu);\n",
+                indent, call_reg, call_reg);
+    }
+
+    if (has_slots)
         fmt("$sdevice uint8_t* _cd_$u = "
-            "(device uint8_t*) r$u + (uint)(_oe_$u >> 32);\n",
-            indent, call_reg, data_reg, call_reg);
+            "(device uint8_t*) $s + (uint)(_oe_$u >> 32);\n",
+            indent, call_reg, base, call_reg);
 
     // =====================================================
     // 4. Dispatch
@@ -1461,7 +1488,7 @@ void jitc_var_call_assemble_metal(CallData *call, uint32_t call_reg,
     // index, self, data, call_table, live inputs (by value).
     auto put_args = [&]() {
         fmt("$s, r$u, ", index_name, self_reg);
-        if (data_reg)
+        if (has_slots)
             fmt("_cd_$u", call_reg);
         else
             put("(device uint8_t*) nullptr");
@@ -1470,6 +1497,9 @@ void jitc_var_call_assemble_metal(CallData *call, uint32_t call_reg,
         else
             fmt(", (constant void*) &params.args[$u]",
                 (uint32_t) metal_vft_arg_index);
+        // Callables containing a nested call receive the base pointer.
+        if (call->use_nested)
+            fmt(", $s", base);
         // Live inputs always have a register: in_active mirrors the packing
         // predicate, which excludes !reg_index inputs.
         for (uint32_t i = 0; i < call->n_in; ++i)

--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -1135,6 +1135,13 @@ static void jitc_metal_render(Variable *v) {
             break;
         }
 
+        case VarKind::CallGetter: {
+            Variable *index = jitc_var(v->dep[0]),
+                     *mask  = jitc_var(v->dep[1]);
+            jitc_var_call_getter_assemble(v, index, mask);
+            break;
+        }
+
         case VarKind::CallOutput:
             break;
 
@@ -1478,6 +1485,30 @@ void jitc_metal_assemble_func(const CallData *call, uint32_t inst,
     }
 
     put("}\n");
+}
+
+/// Getter masked load (Metal/MSL). Mirrors the 'Gather' case, sourcing from
+/// 'base + header_offset'.
+void jitc_var_call_getter_assemble_metal(Variable *v, const Variable *index,
+                                         const Variable *mask) {
+    GetterData *gd = (GetterData *) v->data;
+    uint32_t header_offset = gd->header_offset;
+
+    // Name of the base pointer holding the kernel's combined call data
+    // (a 'device uint8_t*' at every nesting level).
+    char base[32];
+    if (callable_depth == 0)
+        snprintf(base, sizeof(base), "r%u", call_buffer.base_reg);
+    else
+        snprintf(base, sizeof(base), "base");
+
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+    if (is_unmasked)
+        fmt("$t $v = ((device const $t*) ($s + $u))[$v];\n",
+            v, v, v, base, header_offset, index);
+    else
+        fmt("$t $v = ($v) ? ((device const $t*) ($s + $u))[$v] : ($t) 0;\n",
+            v, v, mask, v, base, header_offset, index, v);
 }
 
 void jitc_var_call_assemble_metal(CallData *call, uint32_t call_reg,

--- a/src/metal_ts.mm
+++ b/src/metal_ts.mm
@@ -1221,7 +1221,7 @@ uint32_t MetalThreadState::block_mkperm(const uint32_t *values, uint32_t size,
             gpu_blocks_per_group = std::min(gpu_blocks_per_group, max_sub);
 
             uint32_t size_per_block =
-                ceil_div(ceil_div(block_size, gpu_blocks_per_group), warp) * warp;
+                align_up(ceil_div(block_size, gpu_blocks_per_group), warp);
             uint32_t rows_per_group = gpu_blocks_per_group * warp_count;
             uint32_t seg            = rows_per_group * bucket_count;
             uint32_t total_cells    = n_blocks * seg;

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -2192,7 +2192,7 @@ void jitc_var_gather_packet(size_t n, uint32_t src_, uint32_t index, uint32_t ma
 
         // Find the largest supported packet size i.e. power of two smaller than
         // ``max_packet_size`` that divides ``n``.
-        uint32_t packet_size = std::min(8u, jitc_llvm_vector_width);;
+        uint32_t packet_size = std::min(8u, jitc_llvm_vector_width);
         while ((n & (packet_size - 1)) != 0)
             packet_size /= 2;
 

--- a/src/record_ts.cpp
+++ b/src/record_ts.cpp
@@ -167,22 +167,7 @@ struct ReplayVariable {
     uint32_t index;
     RecordedVarInit init;
 
-    ReplayVariable(RecordedVariable &rv) : index(rv.index), init(rv.init) {
-        if (init == RecordedVarInit::Captured) {
-            // Copy the variable, so that it isn't changed by this recording.
-            // Captured variables are only used for vcall offset buffers, which
-            // are not supposed to change between replay calls.
-
-            Variable *v = jitc_var(index);
-            alloc_size  = v->size * type_size[v->type];
-            data_size   = alloc_size;
-            if (!dry_run) {
-                index = jitc_var_copy(index);
-                v = jitc_var(index); // 'v' may have been invalidated
-                data  = v->data;
-            }
-        }
-    }
+    ReplayVariable(RecordedVariable &rv) : index(rv.index), init(rv.init) { }
 
     /// Initializes the \ref ReplayVariable from a function input.
     void init_from_input(Variable *input_variable) {
@@ -463,17 +448,6 @@ int Recording::replay(const uint32_t *replay_inputs, uint32_t *replay_outputs) {
             uint32_t var_index = replay_inputs[rv.index];
             jitc_var_inc_ref(var_index);
             replay_outputs[i] = var_index;
-        } else if (rv.init == RecordedVarInit::Captured) {
-            if (log_debug)
-                jitc_log(LogLevel::Debug,
-                         "    output %u: from slot s%u = captured r%u", i,
-                         slot, rv.index);
-            jitc_assert(rv.data, "replay(): freed an input variable "
-                                 "that is passed through!");
-
-            jitc_var_inc_ref(rv.index);
-
-            replay_outputs[i] = rv.index;
         } else {
             if (log_debug)
                 jitc_log(LogLevel::Debug, "    output %u: from slot s%u", i,
@@ -495,12 +469,8 @@ int Recording::replay(const uint32_t *replay_inputs, uint32_t *replay_outputs) {
     }
 
     for (ReplayVariable &rv : replay_variables) {
-        if (rv.init == RecordedVarInit::Captured) {
-            jitc_var_dec_ref(rv.index);
-            rv.data = 0;
-        } else if (rv.init == RecordedVarInit::None && rv.data) {
+        if (rv.init == RecordedVarInit::None && rv.data)
             rv.free();
-        }
     }
 
     return true;
@@ -1442,30 +1412,15 @@ void RecordThreadState::memcpy_async(void *dst, const void *src, size_t size) {
     }
     try {
         if (!paused() && !has_var) {
-            // If we did not know the source variable, this memcpy might be
-            // coming from \c jitc_call_upload.
-            // If that is the case, we have to capture the offset buffer.
-            // Since the pointer might be used, for example by an aggregate call
-            // (nested calls), we have to overwrite the RecordedVariable.
-            CallData *call = nullptr;
-            for (CallData *tmp : calls_assembled) {
-                if (tmp->offset_table == dst) {
-                    call = tmp;
-                    break;
-                }
-            }
-            if (call) {
-                capture_call_offset(dst, size);
-                jitc_log(LogLevel::Debug, "    captured call offset");
-            } else {
-                jitc_raise(
-                    "record(): Tried to record a memcpy_async operation, "
-                    "but the source pointer %p is unknown. This can occur if "
-                    "the source of the memcopy was not found during traversal "
-                    "of the function inputs, or did not refer to the start of "
-                    "a variables memory region.",
-                    src);
-            }
+            // Call data is built and tracked through aggregate() operations, so
+            // a memcpy from an untracked source is a genuine error.
+            jitc_raise(
+                "record(): Tried to record a memcpy_async operation, "
+                "but the source pointer %p is unknown. This can occur if "
+                "the source of the memcopy was not found during traversal "
+                "of the function inputs, or did not refer to the start of "
+                "a variables memory region.",
+                src);
         }
     } catch (...) {
         record_exception();
@@ -2131,13 +2086,10 @@ void RecordThreadState::record_aggregate(void *dst, AggregationEntry *agg,
             is_ptr = true;
 
         if ((p.size == 8 && is_ptr) || p.size < 0) {
-            // Pointer or evaluated
-
-            bool has_var = has_variable(p.src);
-
-            // NOTE: Offset buffers of nested calls might be used by this
-            // aggregate call, before the offset buffer is uploaded. We defer
-            // the offset buffer capture to the memcpy_async operation.
+            // Pointer or evaluated. The source is a captured input / registry
+            // member (a texture, scatter target, gather source, ...). If it was
+            // not traversed as a function input, add_variable() leaves the slot
+            // uninitialized and validate() reports it.
             uint32_t slot = add_variable(p.src);
 
             AccessInfo info;
@@ -2149,9 +2101,8 @@ void RecordThreadState::record_aggregate(void *dst, AggregationEntry *agg,
             add_param(info);
 
             jitc_log(LogLevel::Debug,
-                     "    entry: var at slot s%u %s src=%p, size=%i, offset=%u",
-                     slot, has_var ? "" : "deferred capture", p.src, p.size,
-                     p.offset);
+                     "    entry: var at slot s%u src=%p, size=%i, offset=%u",
+                     slot, p.src, p.size, p.offset);
         } else {
             // Literal
             AccessInfo info;
@@ -2202,26 +2153,17 @@ int Recording::replay_aggregate(Operation &op) {
 
     AggregationEntry *p = agg;
 
+    uint32_t data_size = 0;
+
     for (; i < op.dependency_range.second; ++i) {
         const AccessInfo &param = dependencies[i];
 
         if (param.type == ParamType::Input) {
             ReplayVariable &rv = replay_variables[param.slot];
 
-            if (log_debug) {
+            if (log_debug)
                 jitc_log(LogLevel::Debug, " -> s%u is_pointer=%u offset=%u",
                          param.slot, param.pointer_access, param.extra.offset);
-
-                // 'jitc_var_str' forces evaluation of the variable, so this
-                // must stay gated behind the log-level check.
-                if (rv.init == RecordedVarInit::Captured) {
-                    jitc_log(LogLevel::Debug, "    captured");
-                    jitc_log(LogLevel::Debug, "    label=%s",
-                             jitc_var_label(rv.index));
-                    jitc_log(LogLevel::Debug, "    data=%s",
-                             jitc_var_str(rv.index));
-                }
-            }
 
             p->size   = (int16_t) (param.pointer_access
                             ? 8
@@ -2239,12 +2181,13 @@ int Recording::replay_aggregate(Operation &op) {
             p->src    = (void *) param.extra.data;
         }
 
+        // The entries are unordered, keep track of the max. extent
+        int sz = p->size > 0 ? p->size : -p->size;
+        data_size = std::max(data_size, p->offset + (uint32_t) sz);
+
         p++;
     }
 
-    AggregationEntry *last = p - 1;
-    uint32_t data_size =
-        last->offset + (last->size > 0 ? last->size : -last->size);
     // Restore to full alignment
     data_size = (data_size + 7) / 8 * 8;
 
@@ -2386,72 +2329,6 @@ bool Recording::check_kernel_cache() {
 
     kernel_cache_generation = state.kernel_cache_generation;
     return true;
-}
-
-void Recording::destroy() {
-    for (RecordedVariable &rv : this->recorded_variables) {
-        if (rv.init == RecordedVarInit::Captured) {
-            jitc_var_dec_ref(rv.index);
-        }
-    }
-}
-
-/**
- * \brief
- *     This captures the offset buffer of a vcall in a kernel.
- *
- * The offset buffer describes where in the data buffer of that vcall the
- * variables or pointers to variables, for that vcall are stored.
- * It should not change between invocations and we should therefore be able
- * to capture it and reuse it when replaying the kernel.
- *
- * \param dsize
- *     The size of the offset buffer in bytes.
- */
-uint32_t RecordThreadState::capture_call_offset(const void *ptr, size_t dsize) {
-    jitc_log(LogLevel::Debug, "capture_call_offset(ptr=%p, dsize=%zu)", ptr, dsize);
-    uint32_t size = (uint32_t) dsize / type_size[(uint32_t) VarType::UInt64];
-
-    uint64_t *data = (uint64_t *) jitc_malloc(backend, dsize);
-    jitc_memcpy(backend, data, ptr, dsize);
-
-    uint32_t data_var =
-        jitc_var_mem_map(backend, VarType::UInt64, data, size, true);
-
-    RecordedVariable rv;
-#ifndef NDEBUG
-    rv.ptr = ptr;
-#endif
-    rv.state = RecordedVarState::Captured;
-    rv.init  = RecordedVarInit::Captured;
-    rv.index = data_var;
-
-    uint32_t slot;
-    auto it = ptr_to_slot.find(ptr);
-    if (it == ptr_to_slot.end()) {
-        slot = (uint32_t) m_recording.recorded_variables.size();
-
-        m_recording.recorded_variables.push_back(rv);
-
-        ptr_to_slot.insert({ ptr, slot });
-    } else {
-        slot                  = it.value();
-        RecordedVariable &old = m_recording.recorded_variables[slot];
-        if (old.init != RecordedVarInit::None) {
-            // The offset buffer allocation can be reused. If this happens, we
-            // have to capture the new version, while leaving the old one
-            // intact. We therefore evict the old entry in the ``ptr_to_slot``
-            // mapping and insert the new value.
-            uint32_t new_slot = (uint32_t) m_recording.recorded_variables.size();
-            m_recording.recorded_variables.push_back(rv);
-            ptr_to_slot[ptr] = new_slot;
-            return new_slot;
-        }
-
-        m_recording.recorded_variables[slot] = rv;
-    }
-
-    return slot;
 }
 
 void RecordThreadState::coop_vec_pack(uint32_t count, const void *in,
@@ -2926,10 +2803,10 @@ Recording *jitc_freeze_stop(JitBackend backend, const uint32_t *outputs,
             rts->add_output(outputs[i]);
 
         Recording *recording = new Recording(std::move(rts->m_recording));
-        try{
+        try {
             recording->validate(scope);
         } catch (const std::exception &) {
-            recording->destroy();
+            delete recording;
             throw;
         }
 
@@ -2948,8 +2825,6 @@ void jitc_freeze_abort(JitBackend backend) {
             dynamic_cast<RecordThreadState *>(thread_state(backend));
         rts != nullptr) {
         RecordThreadStateGuard guard{ rts };
-
-        rts->m_recording.destroy();
 
         ThreadState *internal = rts->m_internal;
 
@@ -2991,7 +2866,6 @@ void jitc_freeze_abort(JitBackend backend) {
 }
 
 void jitc_freeze_destroy(Recording *recording) {
-    recording->destroy();
     delete recording;
 }
 

--- a/src/record_ts.cpp
+++ b/src/record_ts.cpp
@@ -1449,7 +1449,7 @@ void RecordThreadState::memcpy_async(void *dst, const void *src, size_t size) {
             // (nested calls), we have to overwrite the RecordedVariable.
             CallData *call = nullptr;
             for (CallData *tmp : calls_assembled) {
-                if (tmp->offset == dst) {
+                if (tmp->offset_table == dst) {
                     call = tmp;
                     break;
                 }

--- a/src/record_ts.h
+++ b/src/record_ts.h
@@ -152,15 +152,6 @@ enum class RecordedVarState {
 
     /// This variable is part of the function input
     Input,
-
-    /// This variable has been captured i.e. it is copied and part of the
-    /// recording. For example, the offset buffer of a vcall does not change
-    /// between recording and replay and can be copied. This is currently the
-    /// only case where captured variables are used. Captured variables are
-    /// immutable and copied when replaying, so that they are not changed by the
-    /// replaying kernels. This introduces some memory overhead, but we assume
-    /// that the offset buffers are sufficiently small.
-    Captured,
 };
 
 /// Records how this variable has been initialized. As opposed to \ref
@@ -170,7 +161,6 @@ enum class RecordedVarState {
 /// initialized when replaying and is recorded in the \ref Recording struct.
 enum class RecordedVarInit {
     None,
-    Captured,
     Input,
 };
 
@@ -183,8 +173,7 @@ enum class RecordedVarInit {
  * allocated using `jit_malloc`, otherwise it cannot be tracked.
  */
 struct RecordedVariable {
-    /// Stores index into input array if variable is input or index of captured
-    /// variable
+    /// Stores the index into the input array if this variable is an input.
     uint32_t index = 0;
 
     /// Records how this variable has been initialized
@@ -368,9 +357,6 @@ struct Recording {
     /// occur when calling dr.kernel_cache_flush between recording the function
     /// and replaying it.
     bool check_kernel_cache();
-
-    /// Destroys the recording, and releases all variables owned by it.
-    void destroy();
 };
 
 /**
@@ -668,22 +654,6 @@ public:
     //!                     Utility Functions
     // =============================================================
 protected:
-
-    /**
-     * This captures the offset buffer of a vcall in a kernel. The offset buffer
-     * describes where in the data buffer of that vcall the variables or
-     * pointers to variables, for that vcall are stored. It should not change
-     * between invocations and we should therefore be able to capture it and
-     * reuse it when replaying the kernel.
-     *
-     * \param ptr
-     *      the pointer to the offset buffer
-     *
-     * \param dsize
-     *      the size in bytes of the offset buffer
-     *
-     */
-    uint32_t capture_call_offset(const void *ptr, size_t dsize);
 
     /**
      * This function tries to capture a variable that is not known to the

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -969,7 +969,8 @@ uint32_t jitc_var_u32(JitBackend backend, uint32_t value) {
 }
 
 uint32_t jitc_var_pointer(JitBackend backend, const void *value,
-                          uint32_t dep, int write, bool written) {
+                          uint32_t dep, int write, bool written,
+                          bool disable_lvn) {
     Variable v;
     v.kind = (uint32_t) VarKind::Literal;
     v.type = (uint32_t) VarType::Pointer;
@@ -997,7 +998,7 @@ uint32_t jitc_var_pointer(JitBackend backend, const void *value,
     ThreadState *ts = thread_state(backend);
     uint32_t scope_backup = 1;
     std::swap(scope_backup, ts->scope);
-    uint32_t result = jitc_var_new(v);
+    uint32_t result = jitc_var_new(v, disable_lvn);
     std::swap(scope_backup, ts->scope);
 
     jitc_log(Debug, "jit_var_pointer(): pointer r%u = " DRJIT_PTR " (r%u, write=%i)",

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -257,6 +257,9 @@ const char *var_kind_name[(int) VarKind::Count] {
     // Specialized nodes for calls
     "call_mask", "call_self",
 
+    // Getter implemented as a gather from the shared per-kernel call-data buffer
+    "call_getter",
+
     // Input argument to a function call
     "call_input",
 

--- a/src/var.h
+++ b/src/var.h
@@ -73,7 +73,8 @@ extern uint32_t jitc_var_undefined(JitBackend backend, VarType type, size_t size
 /// the 'write_ptr' and 'written' flags in the Variable class)
 extern uint32_t jitc_var_pointer(JitBackend backend, const void *value,
                                  uint32_t dep, int write,
-                                 bool written = false);
+                                 bool written = false,
+                                 bool disable_lvn = false);
 
 enum class ResourceKind : uint8_t; // defined in internal.h
 


### PR DESCRIPTION
This PR substantially redesigns how Dr.Jit represents and passes state for _callables_ in operations like ``dr.switch()`` and C++ virtual function calls.

When Dr.Jit evaluates such calls, many callables will often end up performing the same calculation, but using different data. Dr.Jit collapses such structurally equivalent code into a single device callable and packs the variable part into a GPU buffer.

For example, the following contrived program generates a single callable parameterized by a data buffer storing the GPU state associated with ``tex_1`` and ``tex_2``.

```py
# Evaluate either tex_1 or tex_2 depending on the array 'index'
tex_1 = Texture2f(...)
tex_2 = Texture2f(...)
index = UInt32([0, 1, 0, 1, ...])
pos = Array2f(...)

def target_1(pos):
    return tex_1.eval(pos)

def target_2(pos):
    return tex_2.eval(pos)

result = dr.switch(index, [target_1, target_2], pos)
```

This overall idea is reasonable, but the specifics of how it was implemented were flawed:

1. Each indirect call generated an offset and a data buffer. Getters also generated a buffer per call. Object-oriented code executing many calls could produce a _vast_ number of buffers that had to be passed to the kernel.

2. Within callables, the buffers were read using individual scalar loads.

3. When using nested calls, pointers to those buffers were themselves packed into a data buffer and then unpeeled within the callables.

This PR switches to a better system with the following properties:

1. There is only one call data buffer per kernel. It contains all of the information needed by any of the calls and getters in the kernel.

2. That single data buffer is passed on to callables when needed by nested calls.

3. Callables efficiently load their data using a small number of vector loads. The host sorts and pads the call data to enable an efficient load sequence.

The data structures used to find and organize the call data were also improved, removing a ``tsl::robin_map`` that was often on the critical path when compiling programs with many indirect calls.