### PR TITLE
Add AMD HIP backend runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,18 @@ option(DRJIT_CORE_ENABLE_TESTS "Build Dr.Jit-Core test suite?" OFF)
 if (NOT APPLE)
   option(DRJIT_ENABLE_CUDA  "Enable the NVIDIA CUDA backend?" ON)
   option(DRJIT_DYNAMIC_CUDA "Resolve CUDA dynamically at run time?" ON)
+  option(DRJIT_ENABLE_AMD   "Enable the AMD/HIP backend?" OFF)
+  set(DRJIT_HIPRT_ROOT "" CACHE PATH "Path to the HIPRT source/include root")
   option(DRJIT_ENABLE_OPTIX "Allow the use of OptiX ray tracing calls in kernels?" ON)
 endif()
 
 if (APPLE)
   option(DRJIT_ENABLE_METAL "Enable the Apple Metal backend?" ON)
+endif()
+
+if (DRJIT_ENABLE_OPTIX AND NOT DRJIT_ENABLE_CUDA)
+  message(STATUS "Dr.Jit-Core: disabling OptiX because CUDA is disabled.")
+  set(DRJIT_ENABLE_OPTIX OFF)
 endif()
 
 if (NOT MSVC)
@@ -71,6 +78,12 @@ if (DRJIT_ENABLE_CUDA)
   else()
     message(STATUS "Dr.Jit-Core: OptiX support disabled.")
   endif()
+endif()
+
+if (DRJIT_ENABLE_AMD)
+  message(STATUS "Dr.Jit-Core: AMD/HIP GPU backend enabled.")
+else()
+  message(STATUS "Dr.Jit-Core: AMD/HIP GPU backend disabled.")
 endif()
 
 if (DRJIT_ENABLE_METAL)
@@ -138,6 +151,18 @@ if (DRJIT_ENABLE_CUDA)
   )
 endif()
 
+if (DRJIT_ENABLE_AMD)
+  set(DRJIT_AMD_FILES
+    include/drjit-core/amd.h
+    src/amd_api.h
+    src/amd_core.cpp
+    src/amd_eval.cpp
+    src/amd_rt.h
+    src/amd_rt.cpp
+    src/amd_ts.h
+    src/amd_ts.cpp)
+endif()
+
 if (DRJIT_ENABLE_OPTIX)
   set(DRJIT_OPTIX_FILES
     src/optix.h
@@ -197,6 +222,9 @@ add_library(
 
   # CUDA backend, if enabled
   ${DRJIT_CUDA_FILES}
+
+  # AMD/HIP backend, if enabled
+  ${DRJIT_AMD_FILES}
 
   # OptiX backend, if enabled
   ${DRJIT_OPTIX_FILES}
@@ -321,6 +349,49 @@ else()
   find_package(CUDA REQUIRED)
   target_include_directories(drjit-core PRIVATE ${CUDA_INCLUDE_DIRS})
   target_link_libraries(drjit-core PRIVATE cuda)
+endif()
+
+if (DRJIT_ENABLE_AMD)
+  if (DEFINED ENV{ROCM_HOME})
+    list(APPEND CMAKE_PREFIX_PATH "$ENV{ROCM_HOME}" "$ENV{ROCM_HOME}/lib/cmake")
+  endif()
+  find_package(hip CONFIG REQUIRED)
+  find_package(hiprtc CONFIG REQUIRED)
+
+  if (NOT DRJIT_HIPRT_ROOT)
+    get_filename_component(DRJIT_HIPRT_ROOT_DEFAULT
+      "${CMAKE_CURRENT_SOURCE_DIR}/../../../hiprt" ABSOLUTE)
+    if (IS_DIRECTORY "${DRJIT_HIPRT_ROOT_DEFAULT}/hiprt")
+      set(DRJIT_HIPRT_ROOT "${DRJIT_HIPRT_ROOT_DEFAULT}" CACHE PATH
+          "Path to the HIPRT source/include root" FORCE)
+    endif()
+  endif()
+
+  target_compile_definitions(drjit-core PRIVATE -DDRJIT_ENABLE_AMD=1)
+  file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/resources" DRJIT_CORE_RESOURCE_DIR_CMAKE)
+  target_compile_definitions(drjit-core PRIVATE
+    "DRJIT_CORE_RESOURCE_DIR=\"${DRJIT_CORE_RESOURCE_DIR_CMAKE}\"")
+  if (DRJIT_HIPRT_ROOT)
+    file(TO_CMAKE_PATH "${DRJIT_HIPRT_ROOT}" DRJIT_HIPRT_ROOT_CMAKE)
+    target_compile_definitions(drjit-core PRIVATE
+      "DRJIT_HIPRT_ROOT=\"${DRJIT_HIPRT_ROOT_CMAKE}\"")
+    target_include_directories(drjit-core PRIVATE "${DRJIT_HIPRT_ROOT}")
+
+    file(GLOB DRJIT_HIPRT_LIB
+      "${DRJIT_HIPRT_ROOT}/dist/bin/Release/hiprt*64.lib")
+    file(GLOB DRJIT_HIPRT_DLL
+      "${DRJIT_HIPRT_ROOT}/dist/bin/Release/hiprt*64.dll")
+    if (DRJIT_HIPRT_LIB AND DRJIT_HIPRT_DLL)
+      list(GET DRJIT_HIPRT_LIB 0 DRJIT_HIPRT_LIB_0)
+      list(GET DRJIT_HIPRT_DLL 0 DRJIT_HIPRT_DLL_0)
+      target_compile_definitions(drjit-core PRIVATE -DDRJIT_ENABLE_HIPRT=1)
+      target_link_libraries(drjit-core PRIVATE "${DRJIT_HIPRT_LIB_0}")
+      add_custom_command(TARGET drjit-core POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+          "${DRJIT_HIPRT_DLL_0}" "$<TARGET_FILE_DIR:drjit-core>")
+    endif()
+  endif()
+  target_link_libraries(drjit-core PRIVATE hip::host hiprtc::hiprtc)
 endif()
 
 if (DRJIT_DYNAMIC_LLVM)

--- a/include/drjit-core/amd.h
+++ b/include/drjit-core/amd.h
@@ -1,0 +1,112 @@
+/*
+    drjit-core/amd.h -- Public API for the AMD/HIP backend.
+
+    Copyright (c) 2026 Wenzel Jakob <wenzel.jakob@epfl.ch>
+
+    All rights reserved. Use of this source code is governed by a BSD-style
+    license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include "jit.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/// Return the no. of available AMD GPU devices that are compatible with Dr.Jit.
+extern JIT_EXPORT int jit_amd_device_count();
+
+/// Set the active AMD GPU device for the calling thread.
+extern JIT_EXPORT void jit_amd_set_device(int device);
+
+/// Return the Dr.Jit AMD device ID associated with the current thread.
+extern JIT_EXPORT int jit_amd_device();
+
+/// Return the raw HIP device ID associated with the current thread.
+extern JIT_EXPORT int jit_amd_device_raw();
+
+/// Return the AMDGPU architecture name, e.g. "gfx1201".
+extern JIT_EXPORT const char *jit_amd_arch();
+
+/// Return the HIP stream associated with the current thread.
+extern JIT_EXPORT void *jit_amd_stream();
+
+/// Return the HIP context associated with the current thread.
+extern JIT_EXPORT void *jit_amd_context();
+
+/// Return the HIP runtime version encoded as reported by hipRuntimeGetVersion().
+extern JIT_EXPORT int jit_amd_runtime_version();
+
+/// Wait for all computation on the current AMD device to finish.
+extern JIT_EXPORT void jit_amd_sync_device();
+
+/// Add HIP event synchronization between Dr.Jit's stream and an external HIP stream.
+extern JIT_EXPORT void jit_amd_sync_stream(uintptr_t stream);
+
+/**
+ * \brief Wrap a HIPRT scene handle in a Dr.Jit scene variable
+ *
+ * The returned variable keeps backend-side bookkeeping alive while pending
+ * kernels or frozen functions reference the scene. The HIPRT scene itself and
+ * all geometry buffers remain owned by the caller.
+ *
+ * \param scene
+ *     Opaque ``hiprtScene`` handle.
+ *
+ * \param geometry_types_mask
+ *     Bit 0: triangle geometry present.
+ *     Bit 3: triangle backface culling required for at least one instance.
+ */
+extern JIT_EXPORT uint32_t jit_amd_configure_scene(
+    void *scene, uint32_t geometry_types_mask);
+
+/**
+ * \brief Wrap a HIPRT scene handle with optional custom intersection functions
+ *
+ * This extended form is used by renderers that build HIPRT AABB-list
+ * geometries or triangle filters. ``intersect_function_names`` and
+ * ``filter_function_names`` contain ``num_geom_types * num_ray_types``
+ * entries, either null or naming device functions defined by ``device_source``.
+ * ``func_table`` is an optional ``hiprtFuncTable`` configured by the caller.
+ */
+extern JIT_EXPORT uint32_t jit_amd_configure_scene_ex(
+    void *scene, void *func_table, uint32_t num_geom_types,
+    uint32_t num_ray_types, const char **intersect_function_names,
+    const char **filter_function_names, const char *device_source,
+    uint32_t geometry_types_mask);
+
+/**
+ * \brief Perform an inline HIPRT ray intersection in an AMD kernel
+ *
+ * Creates a ``VarKind::TraceRay`` IR node that emits HIPRT closest-hit or
+ * any-hit traversal. Inputs and outputs match the Metal backend.
+ *
+ * Inputs ``args`` must contain 8 Float32 variables:
+ * [ox, oy, oz, dx, dy, dz, tmin, tmax].
+ *
+ * Outputs ``out`` receives:
+ * [valid, distance, bary_u, bary_v, instance_id, primitive_id,
+ *  geometry_id, user_instance_id].
+ */
+extern JIT_EXPORT void jit_amd_ray_trace(uint32_t n_args, uint32_t *args,
+                                         uint32_t mask, uint32_t *out,
+                                         uint32_t n_out, uint32_t scene,
+                                         int shadow);
+
+/// Register a cleanup callback that runs when the scene variable dies.
+extern JIT_EXPORT void jit_amd_scene_set_cleanup(uint32_t scene_index,
+                                                 void (*callback)(void *),
+                                                 void *payload);
+
+/// Create an owner-token variable exposing a scene as a frozen-function input.
+extern JIT_EXPORT uint32_t jit_amd_scene_owner_handle(uint32_t scene_index);
+
+/// Create an owner-token variable exposing a scene's HIPRT function table.
+extern JIT_EXPORT uint32_t jit_amd_scene_func_table_handle(
+    uint32_t scene_index);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/include/drjit-core/array.h
+++ b/include/drjit-core/array.h
@@ -508,5 +508,6 @@ Array linspace(typename Array::Value min, typename Array::Value max, size_t size
 template <typename T> using CUDAArray = JitArray<JitBackend::CUDA, T>;
 template <typename T> using LLVMArray = JitArray<JitBackend::LLVM, T>;
 template <typename T> using MetalArray = JitArray<JitBackend::Metal, T>;
+template <typename T> using AMDArray = JitArray<JitBackend::AMD, T>;
 
 NAMESPACE_END(drjit)

--- a/include/drjit-core/jit.h
+++ b/include/drjit-core/jit.h
@@ -56,8 +56,11 @@ enum class JitBackend : uint32_t {
     /// Metal backend (Apple Silicon GPUs, generates MSL source)
     Metal = 3,
 
+    /// AMD GPU backend (generates HIP/AMDGPU code objects)
+    AMD = 4,
+
     /// Sentinel value (not a real backend; equals the number of backends)
-    Count = 4
+    Count = 5
 };
 
 /// Compile-time name of a JIT backend (e.g., to identify registry domains)
@@ -65,14 +68,16 @@ template <JitBackend Backend>
 constexpr const char *jit_backend_name_v =
     Backend == JitBackend::CUDA  ? "cuda"  :
     Backend == JitBackend::LLVM  ? "llvm"  :
-    Backend == JitBackend::Metal ? "metal" : "none";
+    Backend == JitBackend::Metal ? "metal" :
+    Backend == JitBackend::AMD   ? "amd"   : "none";
 #else
 enum JitBackend {
     JitBackendNone = 0,
     JitBackendCUDA = 1,
     JitBackendLLVM = 2,
     JitBackendMetal = 3,
-    JitBackendCount = 4
+    JitBackendAMD = 4,
+    JitBackendCount = 5
 };
 #endif
 
@@ -91,7 +96,8 @@ enum JitBackend {
 extern JIT_EXPORT void
 jit_init(uint32_t backends JIT_DEF((1u << (uint32_t) JitBackend::CUDA) |
                                    (1u << (uint32_t) JitBackend::LLVM) |
-                                   (1u << (uint32_t) JitBackend::Metal)));
+                                   (1u << (uint32_t) JitBackend::Metal) |
+                                   (1u << (uint32_t) JitBackend::AMD)));
 
 /**
  * \brief Launch an asynchronous thread that will execute jit_init() and
@@ -113,7 +119,8 @@ jit_init(uint32_t backends JIT_DEF((1u << (uint32_t) JitBackend::CUDA) |
 extern JIT_EXPORT void
 jit_init_async(uint32_t backends JIT_DEF((1u << (uint32_t) JitBackend::CUDA) |
                                          (1u << (uint32_t) JitBackend::LLVM) |
-                                         (1u << (uint32_t) JitBackend::Metal)));
+                                         (1u << (uint32_t) JitBackend::Metal) |
+                                         (1u << (uint32_t) JitBackend::AMD)));
 
 /// Check whether the LLVM backend was successfully initialized
 extern JIT_EXPORT int jit_has_backend(JIT_ENUM JitBackend backend);
@@ -442,7 +449,7 @@ extern JIT_EXPORT void *jit_malloc(JIT_ENUM JitBackend backend, size_t size,
  * synchronous and behaves like ``free()`` — the buffer is placed back into
  * Dr.Jit's internal allocation cache and is immediately available for reuse.
  *
- * For all other backends (LLVM, CUDA, Metal), pending kernels may still
+ * For all other backends (LLVM, CUDA, AMD, Metal), pending kernels may still
  * reference the buffer. The release is therefore *scheduled*: the buffer is
  * only returned to the allocation cache once the work preceding it has
  * completed.

--- a/include/drjit-core/nanostl.h
+++ b/include/drjit-core/nanostl.h
@@ -22,12 +22,14 @@
 
 #include <cstdlib>
 #include <cstdint>
+#include <cstdio>
 #include <utility>
 #include <type_traits>
 #include <new>
 #include "macros.h"
 #if defined(_MSC_VER)
 #  include <cstring>
+#  include <intrin.h>
 #endif
 
 NAMESPACE_BEGIN(drjit)

--- a/resources/block_reduce.cuh
+++ b/resources/block_reduce.cuh
@@ -194,17 +194,22 @@ __device__ void block_reduce(block_reduce_params params) {
         if ((tid & (WarpSize - 1)) == 0)
             shared[tid / Active] = value;
 
+        __syncthreads();
+
         // Most of the thread block can quit after this step
         if (tid >= BlockDim / Active)
             return;
 
         // Load the data right back
-        __syncthreads();
-
         value = shared[tid];
 
+        constexpr uint32_t ActiveMask =
+            BlockDim / Active >= WarpSize
+                ? WarpMask
+                : (uint32_t) ((1ull << (BlockDim / Active)) - 1ull);
+
         for (uint32_t k = 1; k < ReducedChunkSize; k *= 2)
-            value = red(value, __shfl_xor_sync(WarpMask, value, k, ReducedChunkSize));
+            value = red(value, __shfl_xor_sync(ActiveMask, value, k, ReducedChunkSize));
 
         // Different threads handle different chunks, and we moved their state around
         // Need to update the indices.

--- a/resources/common.h
+++ b/resources/common.h
@@ -3,13 +3,35 @@
 #include <stdint.h>
 #include <type_traits>
 #include <limits>
-#include <cuda_fp16.h>
+
+#if defined(__HIP_PLATFORM_AMD__)
+#  include <hip/hip_runtime.h>
+#  include <hip/hip_fp16.h>
+using half = __half;
+#else
+#  include <cuda_fp16.h>
+#endif
 
 #define KERNEL extern "C" __global__
 #define DEVICE __device__
 #define FINLINE __forceinline__
 #define WarpSize 32
-#define WarpMask 0xffffffff
+#define WarpMask 0xffffffffu
+
+#if defined(__HIP_PLATFORM_AMD__) && !defined(__grid_constant__)
+#  define __grid_constant__
+#endif
+
+#if defined(__HIP_PLATFORM_AMD__)
+#  define __ballot_sync(mask, pred) ((uint32_t) __ballot_sync((uint64_t) (mask), (pred)))
+#  define __any_sync(mask, pred) __any_sync((uint64_t) (mask), (pred))
+#  define __shfl_sync(mask, var, src_lane, ...) \
+    __shfl_sync((uint64_t) (mask), (var), (src_lane), ##__VA_ARGS__)
+#  define __shfl_down_sync(mask, var, delta, ...) \
+    __shfl_down_sync((uint64_t) (mask), (var), (delta), ##__VA_ARGS__)
+#  define __shfl_xor_sync(mask, var, lane_mask, ...) \
+    __shfl_xor_sync((uint64_t) (mask), (var), (lane_mask), ##__VA_ARGS__)
+#endif
 
 template <typename T> struct SharedMemory {
     __device__ inline static T *get() {
@@ -25,6 +47,51 @@ template <> struct SharedMemory<double> {
     }
 };
 
+
+#if defined(__HIP_PLATFORM_AMD__)
+
+DEVICE float fma_(float a, float b, float c) { return fmaf(a, b, c); }
+DEVICE double fma_(double a, double b, double c) { return fma(a, b, c); }
+DEVICE half fma_(half a, half b, half c) {
+    return (half) fmaf((float) a, (float) b, (float) c);
+}
+
+template <typename T> DEVICE T add_(T a, T b) { return a + b; }
+DEVICE half add_(half a, half b) {
+    return (half) ((float) a + (float) b);
+}
+
+template <typename T> DEVICE T mul_(T a, T b) { return a * b; }
+DEVICE half mul_(half a, half b) {
+    return (half) ((float) a * (float) b);
+}
+
+template <typename T> DEVICE T sub_(T a, T b) { return a - b; }
+DEVICE half sub_(half a, half b) {
+    return (half) ((float) a - (float) b);
+}
+
+DEVICE float max_(float a, float b) { return fmaxf(a, b); }
+DEVICE double max_(double a, double b) { return fmax(a, b); }
+DEVICE uint32_t max_(uint32_t a, uint32_t b) { return a > b ? a : b; }
+DEVICE uint64_t max_(uint64_t a, uint64_t b) { return a > b ? a : b; }
+DEVICE int32_t max_(int32_t a, int32_t b) { return a > b ? a : b; }
+DEVICE int64_t max_(int64_t a, int64_t b) { return a > b ? a : b; }
+DEVICE half max_(half a, half b) {
+    return (half) fmaxf((float) a, (float) b);
+}
+
+DEVICE float min_(float a, float b) { return fminf(a, b); }
+DEVICE double min_(double a, double b) { return fmin(a, b); }
+DEVICE uint32_t min_(uint32_t a, uint32_t b) { return a < b ? a : b; }
+DEVICE uint64_t min_(uint64_t a, uint64_t b) { return a < b ? a : b; }
+DEVICE int32_t min_(int32_t a, int32_t b) { return a < b ? a : b; }
+DEVICE int64_t min_(int64_t a, int64_t b) { return a < b ? a : b; }
+DEVICE half min_(half a, half b) {
+    return (half) fminf((float) a, (float) b);
+}
+
+#else
 
 DEVICE float fma_(float a, float b, float c) { return __fmaf_rn(a, b, c); }
 DEVICE double fma_(double a, double b, double c) { return __fma_rn(a, b, c); }
@@ -89,6 +156,8 @@ DEVICE half min_(half a, half b) {
         return (half) fminf((float) a, (float) b);
     #endif
 }
+
+#endif
 
 template <typename T> struct reduction_add {
     using Value = std::conditional_t<std::is_same<half, T>::value, float, T>;
@@ -177,6 +246,57 @@ __device__ Target memcpy_cast(Source source) {
 }
 
 /// Helper routines to write tagged values while bypassing the L1 cache
+#if defined(__HIP_PLATFORM_AMD__)
+
+__device__ void store_with_status(uint16_t *p, uint16_t value, uint32_t status) {
+    uint32_t v = ((uint32_t) value) | (((uint32_t) status) << 16);
+    *((volatile uint32_t *) p) = v;
+    __threadfence();
+}
+
+__device__ void store_with_status(uint32_t *p, uint32_t value, uint32_t status) {
+    uint64_t v = ((uint64_t) value) | (((uint64_t) status) << 32);
+    *((volatile uint64_t *) p) = v;
+    __threadfence();
+}
+
+__device__ void store_with_status(uint64_t *p, uint64_t value, uint32_t status) {
+    uint64_t status_shift = ((uint64_t) status) << 32,
+             v0 = uint32_t(value)  | status_shift,
+             v1 = (value >> 32)    | status_shift;
+    volatile uint64_t *q = (volatile uint64_t *) p;
+    q[0] = v0;
+    q[1] = v1;
+    __threadfence();
+}
+
+__device__ void load_with_status(volatile uint16_t *p, uint16_t &value, uint32_t &status) {
+    uint32_t v = *((volatile uint32_t *) p);
+    value = (uint16_t) v;
+    status = (uint32_t) (v >> 16);
+}
+
+__device__ void load_with_status(volatile uint32_t *p, uint32_t &value, uint32_t &status) {
+    uint64_t v = *((volatile uint64_t *) p);
+    value = (uint32_t) v;
+    status = (uint32_t) (v >> 32);
+}
+
+__device__ void load_with_status(volatile uint64_t *p, uint64_t &value, uint32_t &status) {
+    volatile uint64_t *q = (volatile uint64_t *) p;
+    uint64_t v0 = q[0], v1 = q[1];
+
+    uint32_t v0_lo = (uint32_t) v0,
+             v1_lo = (uint32_t) v1,
+             v0_hi = (uint32_t) (v0 >> 32),
+             v1_hi = (uint32_t) (v1 >> 32);
+
+    value = (uint64_t) v0_lo + (((uint64_t) v1_lo) << 32);
+    status = v0_hi == v1_hi ? v0_hi : 0;
+}
+
+#else
+
 __device__ void store_with_status(uint16_t *p, uint16_t value, uint32_t status) {
     uint32_t v = ((uint32_t) value) | (((uint32_t) status) << 16);
 
@@ -254,6 +374,8 @@ __device__ void load_with_status(volatile uint64_t *p, uint64_t &value, uint32_t
     status = v0_hi == v1_hi ? v0_hi : 0;
 }
 
+#endif
+
 
 // Vectorized types for 128 bit loads
 template <typename T> struct Vec2 {
@@ -291,9 +413,13 @@ struct divisor {
     uint32_t value;
 
     static __device__ uint32_t mulhi(uint32_t a, uint32_t b) {
+#if defined(__HIP_PLATFORM_AMD__)
+        return (uint32_t) (((uint64_t) a * (uint64_t) b) >> 32);
+#else
         uint32_t r;
         asm("mul.hi.u32 %0, %1, %2;" : "=r"(r) : "r"(a), "r"(b));
         return r;
+#endif
     }
 
     __device__ void div_rem(uint32_t input, uint32_t *out_div, uint32_t *out_rem) const {

--- a/resources/compress.cuh
+++ b/resources/compress.cuh
@@ -11,13 +11,22 @@
 #include "common.h"
 
 DEVICE FINLINE void store_cg(volatile uint64_t *ptr, uint64_t val) {
+#if defined(__HIP_PLATFORM_AMD__)
+    *ptr = val;
+    __threadfence();
+#else
     asm volatile("st.cg.u64 [%0], %1;" : : "l"(ptr), "l"(val));
+#endif
 }
 
 DEVICE FINLINE uint64_t load_cg(volatile uint64_t *ptr) {
+#if defined(__HIP_PLATFORM_AMD__)
+    return *ptr;
+#else
     uint64_t retval;
     asm volatile("ld.volatile.global.u64 %0, [%1];" : "=l"(retval) : "l"(ptr) : "memory");
     return retval;
+#endif
 }
 
 KERNEL void compress_small(const uint8_t *in, uint32_t *out, uint32_t size, uint32_t *count_out) {

--- a/resources/mkperm.cuh
+++ b/resources/mkperm.cuh
@@ -58,7 +58,7 @@ inline __device__ uint32_t reduce(uint32_t active, uint32_t value, uint32_t *buc
     offset = __shfl_sync(peers, offset, leader_idx);
 
     // Determine current thread's position within peer group
-    uint32_t rel_pos = __popc(peers << (32 - lane_idx));
+    uint32_t rel_pos = lane_idx ? __popc(peers << (32 - lane_idx)) : 0;
 
     return offset + rel_pos;
 }
@@ -82,7 +82,7 @@ inline __device__ uint32_t reduce_atomic(uint32_t active, uint32_t value, uint32
     offset = __shfl_sync(peers, offset, leader_idx);
 
     // Determine current thread's position within peer group
-    uint32_t rel_pos = __popc(peers << (32 - lane_idx));
+    uint32_t rel_pos = lane_idx ? __popc(peers << (32 - lane_idx)) : 0;
 
     return offset + rel_pos;
 }
@@ -312,7 +312,7 @@ KERNEL void block_mkperm_phase_3(uint32_t *buckets,
             offset = __shfl_sync(peers, offset, leader_idx);
 
             // Determine current thread's position within peer group
-            offset += __popc(peers << (32 - lane_idx));
+            offset += lane_idx ? __popc(peers << (32 - lane_idx)) : 0;
 
             offsets[offset] = make_uint4(i, offset_a, offset_b - offset_a, 0);
         }

--- a/src/amd_api.h
+++ b/src/amd_api.h
@@ -1,0 +1,34 @@
+/*
+    src/amd_api.h -- Low-level helpers for the AMD/HIP backend.
+*/
+
+#pragma once
+
+#include <drjit-core/jit.h>
+
+#if defined(DRJIT_ENABLE_AMD)
+
+#  include <hip/hip_runtime.h>
+#  include <hip/hiprtc.h>
+
+extern int jitc_amd_runtime_version_v;
+
+extern void jitc_amd_check(hipError_t result, const char *expr,
+                           const char *file, int line);
+
+extern void jitc_amd_rtc_check(hiprtcResult result, const char *expr,
+                               const char *file, int line);
+
+extern void jitc_amd_sync_stream(uintptr_t stream);
+
+#  define hip_check(expr)                                                    \
+    do {                                                                     \
+        jitc_amd_check((expr), #expr, __FILE__, __LINE__);                   \
+    } while (0)
+
+#  define hiprtc_check(expr)                                                 \
+    do {                                                                     \
+        jitc_amd_rtc_check((expr), #expr, __FILE__, __LINE__);               \
+    } while (0)
+
+#endif

--- a/src/amd_core.cpp
+++ b/src/amd_core.cpp
@@ -1,0 +1,250 @@
+#include "amd_api.h"
+
+#if defined(DRJIT_ENABLE_AMD)
+
+#include "amd_ts.h"
+#include "internal.h"
+#include "io.h"
+#include "log.h"
+#include "malloc.h"
+#include "strbuf.h"
+
+#include <algorithm>
+#include <cstring>
+
+#if defined(DRJIT_ENABLE_HIPRT)
+#  include <hiprt/hiprt.h>
+#endif
+
+int jitc_amd_runtime_version_v = 0;
+
+static std::string jitc_amd_normalize_arch(const char *gcn_arch_name) {
+    std::string result = gcn_arch_name ? gcn_arch_name : "";
+    size_t suffix = result.find(':');
+    if (suffix != std::string::npos)
+        result.resize(suffix);
+    return result;
+}
+
+void jitc_amd_check(hipError_t result, const char *expr,
+                    const char *file, int line) {
+    if (likely(result == hipSuccess))
+        return;
+
+    jitc_raise("%s:%i: HIP call \"%s\" failed: %s", file, line, expr,
+               hipGetErrorString(result));
+}
+
+void jitc_amd_rtc_check(hiprtcResult result, const char *expr,
+                        const char *file, int line) {
+    if (likely(result == HIPRTC_SUCCESS))
+        return;
+
+    jitc_raise("%s:%i: HIPRTC call \"%s\" failed: %s", file, line, expr,
+               hiprtcGetErrorString(result));
+}
+
+bool jitc_amd_init() {
+    int device_count = 0;
+    hipError_t result = hipGetDeviceCount(&device_count);
+    if (result != hipSuccess) {
+        jitc_log(Warn, "jit_amd_init(): hipGetDeviceCount() failed: %s",
+                 hipGetErrorString(result));
+        return false;
+    }
+
+    if (device_count == 0) {
+        jitc_log(Warn, "jit_amd_init(): no AMD/HIP devices were found.");
+        return false;
+    }
+
+    hip_check(hipRuntimeGetVersion(&jitc_amd_runtime_version_v));
+
+    for (int i = 0; i < device_count; ++i) {
+        hipDeviceProp_t props;
+        result = hipGetDeviceProperties(&props, i);
+        if (result != hipSuccess) {
+            jitc_log(Warn, "jit_amd_init(): hipGetDeviceProperties(%i) "
+                           "failed: %s", i, hipGetErrorString(result));
+            continue;
+        }
+
+        std::string arch = jitc_amd_normalize_arch(props.gcnArchName);
+        if (arch.empty()) {
+            jitc_log(Warn, "jit_amd_init(): skipping device %i because it did "
+                           "not report a GCN architecture name.", i);
+            continue;
+        }
+
+        AMDDevice dev;
+        dev.id = i;
+        dev.name = strdup(props.name);
+        dev.arch = strdup(arch.c_str());
+        dev.multi_processor_count = props.multiProcessorCount;
+        dev.wavefront_size = props.warpSize ? props.warpSize : 32;
+        dev.max_threads_per_block = props.maxThreadsPerBlock;
+        dev.shared_memory_bytes = props.sharedMemPerBlock;
+
+        hip_check(hipDeviceGet(&dev.device, i));
+        hip_check(hipCtxCreate(&dev.context, 0, dev.device));
+        hip_check(hipStreamCreateWithFlags(&dev.stream, hipStreamNonBlocking));
+        hip_check(hipEventCreateWithFlags(&dev.event, hipEventDisableTiming));
+        hip_check(hipEventCreateWithFlags(&dev.sync_stream_event,
+                                          hipEventDisableTiming));
+
+        jitc_log(Info, "jit_amd_init(): found device %i: %s (%s, %u CUs)",
+                 (int) state.amd_devices.size(), props.name, dev.arch,
+                 dev.multi_processor_count);
+
+        state.amd_devices.push_back(dev);
+    }
+
+    return !state.amd_devices.empty();
+}
+
+void jitc_amd_shutdown() {
+    for (AMDDevice &dev : state.amd_devices) {
+        if (dev.context)
+            hipCtxSetCurrent(dev.context);
+
+        for (hipModule_t module : dev.modules)
+            if (module)
+                hipModuleUnload(module);
+
+#if defined(DRJIT_ENABLE_HIPRT)
+        if (dev.hiprt_context)
+            hiprtDestroyContext((hiprtContext) dev.hiprt_context);
+#endif
+
+        if (dev.event)
+            hipEventDestroy(dev.event);
+        if (dev.sync_stream_event)
+            hipEventDestroy(dev.sync_stream_event);
+        if (dev.stream)
+            hipStreamDestroy(dev.stream);
+
+        if (dev.context)
+            hipCtxDestroy(dev.context);
+
+        free(dev.name);
+        free(dev.arch);
+    }
+
+    state.amd_devices.clear();
+}
+
+void jitc_amd_set_device(int device_id) {
+    ThreadState *ts = thread_state(JitBackend::AMD);
+    if (ts->device == device_id && ts->amd_context)
+        return;
+
+    if (device_id < 0 || (size_t) device_id >= state.amd_devices.size())
+        jitc_raise("jit_amd_set_device(%i): must be in the range 0..%i!",
+                   device_id, (int) state.amd_devices.size() - 1);
+
+    jitc_log(Info, "jit_amd_set_device(%i)", device_id);
+
+    AMDDevice &device = state.amd_devices[device_id];
+
+    if (ts->amd_stream)
+        hip_check(hipStreamSynchronize(ts->amd_stream));
+
+    hip_check(hipCtxSetCurrent(device.context));
+
+    ts->device = device_id;
+    ts->amd_raw_device = device.id;
+    ts->amd_device = device.device;
+    ts->amd_context = device.context;
+    ts->amd_stream = device.stream;
+    ts->amd_event = device.event;
+    ts->amd_sync_stream_event = device.sync_stream_event;
+    ts->amd_arch = device.arch;
+    ts->amd_wavefront_size = device.wavefront_size;
+    ts->amd_max_threads = device.max_threads_per_block;
+}
+
+void jitc_amd_sync_thread(ThreadState *ts) {
+    if (!ts)
+        return;
+
+    hipStream_t stream = ts->amd_stream;
+    hip_check(hipCtxSetCurrent(ts->amd_context));
+    unlock_guard guard(state.lock);
+    hip_check(hipStreamSynchronize(stream));
+}
+
+void jitc_amd_sync_stream(uintptr_t stream) {
+    ThreadState *ts = thread_state(JitBackend::AMD);
+    hipEvent_t sync_event = ts->amd_sync_stream_event;
+    hip_check(hipCtxSetCurrent(ts->amd_context));
+    hip_check(hipEventRecord(sync_event, ts->amd_stream));
+    hip_check(hipStreamWaitEvent(stream == 2 ? hipStreamPerThread
+                                             : (hipStream_t) stream,
+                                 sync_event, 0));
+}
+
+void jitc_amd_sync_device(ThreadState *ts) {
+    if (!ts)
+        return;
+
+    hip_check(hipCtxSetCurrent(ts->amd_context));
+    unlock_guard guard(state.lock);
+    hip_check(hipDeviceSynchronize());
+}
+
+JitEvent jitc_amd_event_create(bool enable_timing) {
+    ThreadState *ts = thread_state(JitBackend::AMD);
+    hip_check(hipCtxSetCurrent(ts->amd_context));
+
+    EventData *event = new EventData(JitBackend::AMD, enable_timing);
+    event->ts = ts;
+
+    unsigned flags = enable_timing ? hipEventDefault : hipEventDisableTiming;
+    hip_check(hipEventCreateWithFlags(&event->amd_event, flags));
+    return (JitEvent) event;
+}
+
+void jitc_amd_event_destroy(JitEvent event) {
+    EventData *e = (EventData *) event;
+    hip_check(hipCtxSetCurrent(e->ts->amd_context));
+    hip_check(hipEventDestroy(e->amd_event));
+    delete e;
+}
+
+void jitc_amd_event_record(JitEvent event) {
+    EventData *e = (EventData *) event;
+    hip_check(hipCtxSetCurrent(e->ts->amd_context));
+    hip_check(hipEventRecord(e->amd_event, e->ts->amd_stream));
+}
+
+int jitc_amd_event_query(JitEvent event) {
+    EventData *e = (EventData *) event;
+    hip_check(hipCtxSetCurrent(e->ts->amd_context));
+    hipError_t result = hipEventQuery(e->amd_event);
+    if (result == hipSuccess)
+        return 1;
+    if (result == hipErrorNotReady)
+        return 0;
+    hip_check(result);
+    return 0;
+}
+
+void jitc_amd_event_wait(JitEvent event) {
+    EventData *e = (EventData *) event;
+    hip_check(hipCtxSetCurrent(e->ts->amd_context));
+    hip_check(hipEventSynchronize(e->amd_event));
+}
+
+float jitc_amd_event_elapsed_time(JitEvent start, JitEvent end) {
+    EventData *s = (EventData *) start;
+    EventData *e = (EventData *) end;
+    if (!s->enable_timing || !e->enable_timing)
+        jitc_raise("jit_event_elapsed_time(): both events must have timing enabled");
+
+    hip_check(hipCtxSetCurrent(s->ts->amd_context));
+    float ms;
+    hip_check(hipEventElapsedTime(&ms, s->amd_event, e->amd_event));
+    return ms;
+}
+
+#endif

--- a/src/amd_eval.cpp
+++ b/src/amd_eval.cpp
@@ -1,0 +1,2160 @@
+/*
+    src/amd_eval.cpp -- AMD/HIP source code generation via HIPRTC
+*/
+
+#include "eval.h"
+
+#if defined(DRJIT_ENABLE_AMD)
+
+#include "amd_api.h"
+#include "amd_rt.h"
+#include "array.h"
+#include "call.h"
+#include "cond.h"
+#include "internal.h"
+#include "log.h"
+#include "loop.h"
+#include "op.h"
+#include "trace.h"
+#include "util.h"
+#include "var.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#  include <stdlib.h>
+#endif
+
+#if defined(DRJIT_ENABLE_HIPRT)
+#  include <hiprt/hiprt.h>
+#endif
+
+#if defined(DRJIT_ENABLE_HIPRT)
+static std::vector<hiprtFuncNameSet> amd_kernel_func_name_sets;
+static uint32_t amd_kernel_num_geom_types = 1;
+static uint32_t amd_kernel_num_ray_types = 1;
+static std::string amd_kernel_device_source;
+#endif
+
+static const char *jitc_amd_type(VarType vt) {
+    switch (vt) {
+        case VarType::Void:    return "void";
+        case VarType::Bool:    return "bool";
+        case VarType::Int8:    return "int8_t";
+        case VarType::UInt8:   return "uint8_t";
+        case VarType::Int16:   return "int16_t";
+        case VarType::UInt16:  return "uint16_t";
+        case VarType::Int32:   return "int32_t";
+        case VarType::UInt32:  return "uint32_t";
+        case VarType::Int64:   return "int64_t";
+        case VarType::UInt64:  return "uint64_t";
+        case VarType::Pointer: return "uintptr_t";
+        case VarType::Float16: return "__half";
+        case VarType::Float32: return "float";
+        case VarType::Float64: return "double";
+        default:
+            jitc_fail("jitc_amd_type(): unsupported variable type %u.",
+                      (uint32_t) vt);
+    }
+}
+
+static const char *jitc_amd_type(const Variable *v) {
+    return jitc_amd_type((VarType) v->type);
+}
+
+static const char *jitc_amd_binary_type(uint32_t size) {
+    switch (size) {
+        case 1: return "uint8_t";
+        case 2: return "uint16_t";
+        case 4: return "uint32_t";
+        case 8: return "uint64_t";
+        default:
+            jitc_fail("jitc_amd_binary_type(): unsupported type size %u.",
+                      size);
+    }
+}
+
+static const char *jitc_amd_zero(VarType vt) {
+    switch (vt) {
+        case VarType::Bool:
+            return "false";
+        case VarType::Float16:
+            return "__ushort_as_half((unsigned short) 0)";
+        case VarType::Float32:
+            return "0.0f";
+        case VarType::Float64:
+            return "0.0";
+        default:
+            return "0";
+    }
+}
+
+static uint32_t jitc_amd_param_slot(const Variable *v) {
+    return v->param_offset / (uint32_t) sizeof(void *);
+}
+
+static void jitc_amd_var(const Variable *v) {
+    buffer.fmt("r%u", v->reg_index);
+}
+
+static void jitc_amd_literal(const Variable *v) {
+    VarType vt = (VarType) v->type;
+    switch (vt) {
+        case VarType::Bool:
+            buffer.fmt("%s", v->literal ? "true" : "false");
+            break;
+
+        case VarType::Float16:
+            buffer.fmt("__ushort_as_half((unsigned short) 0x%xu)",
+                       (uint32_t) v->literal & 0xffffu);
+            break;
+
+        case VarType::Float32:
+            buffer.fmt("drjit_bits_to_float(0x%xu)",
+                       (uint32_t) v->literal);
+            break;
+
+        case VarType::Float64:
+            buffer.fmt("drjit_bits_to_double(0x%llxull)",
+                       (unsigned long long) v->literal);
+            break;
+
+        case VarType::Pointer:
+            buffer.fmt("(uintptr_t) 0x%llxull",
+                       (unsigned long long) v->literal);
+            break;
+
+        case VarType::Int8:
+        case VarType::Int16:
+        case VarType::Int32:
+        case VarType::Int64:
+            buffer.fmt("(%s) %lld", jitc_amd_type(v),
+                       (long long) v->literal);
+            break;
+
+        case VarType::UInt8:
+        case VarType::UInt16:
+        case VarType::UInt32:
+        case VarType::UInt64:
+            buffer.fmt("(%s) %lluull", jitc_amd_type(v),
+                       (unsigned long long) v->literal);
+            break;
+
+        default:
+            jitc_fail("jitc_amd_literal(): unsupported literal type %u.",
+                      (uint32_t) vt);
+    }
+}
+
+static void jitc_amd_emit_decl(const Variable *v) {
+    buffer.fmt("%s ", jitc_amd_type(v));
+    jitc_amd_var(v);
+    buffer.put(" = ");
+}
+
+static void jitc_amd_render_binary(Variable *v, const char *op) {
+    Variable *a0 = jitc_var(v->dep[0]),
+             *a1 = jitc_var(v->dep[1]);
+    jitc_amd_emit_decl(v);
+    jitc_amd_var(a0);
+    buffer.fmt(" %s ", op);
+    jitc_amd_var(a1);
+    buffer.put(";\n");
+}
+
+static void jitc_amd_render_unary(Variable *v, const char *op) {
+    Variable *a0 = jitc_var(v->dep[0]);
+    jitc_amd_emit_decl(v);
+    buffer.fmt("%s", op);
+    jitc_amd_var(a0);
+    buffer.put(";\n");
+}
+
+static void jitc_amd_render_call(Variable *v, const char *fn, uint32_t n_args) {
+    jitc_amd_emit_decl(v);
+    buffer.fmt("%s(", fn);
+    for (uint32_t i = 0; i < n_args; ++i) {
+        if (i)
+            buffer.put(", ");
+        jitc_amd_var(jitc_var(v->dep[i]));
+    }
+    buffer.put(");\n");
+}
+
+static void jitc_amd_render_float_call(Variable *v, const char *fn_half,
+                                       const char *fn_float,
+                                       const char *fn_double) {
+    if (jitc_is_half(v))
+        jitc_amd_render_call(v, fn_half, 1);
+    else if (jitc_is_single(v))
+        jitc_amd_render_call(v, fn_float, 1);
+    else
+        jitc_amd_render_call(v, fn_double, 1);
+}
+
+static void jitc_amd_render_round(Variable *v, const char *fn) {
+    Variable *a0 = jitc_var(v->dep[0]);
+    jitc_amd_emit_decl(v);
+    if (jitc_is_half(v)) {
+        const char *fn_half =
+            strcmp(fn, "ceil") == 0  ? "drjit_ceil"  :
+            strcmp(fn, "floor") == 0 ? "drjit_floor" :
+            strcmp(fn, "rint") == 0  ? "drjit_rint"  : "drjit_trunc";
+        buffer.fmt("%s(", fn_half);
+        jitc_amd_var(a0);
+        buffer.put(")");
+    } else if (jitc_is_float(v)) {
+        buffer.fmt("%s(", jitc_is_single(v) ? (strcmp(fn, "ceil") == 0  ? "ceilf"  :
+                                               strcmp(fn, "floor") == 0 ? "floorf" :
+                                               strcmp(fn, "rint") == 0  ? "rintf"  : "truncf")
+                                           : fn);
+        jitc_amd_var(a0);
+        buffer.put(")");
+    } else if ((VarKind) v->kind == VarKind::Trunc) {
+        buffer.fmt("(%s) ", jitc_amd_type(v));
+        jitc_amd_var(a0);
+    } else {
+        buffer.fmt("(%s) %s(", jitc_amd_type(v), fn);
+        jitc_amd_var(a0);
+        buffer.put(")");
+    }
+    buffer.put(";\n");
+}
+
+static void jitc_amd_render_array(Variable *v, Variable *pred) {
+    if (pred && pred->array_state != (uint32_t) ArrayState::Conflicted) {
+        v->reg_index = pred->reg_index;
+        return;
+    }
+
+    buffer.fmt("%s arr_%u[%u];\n", jitc_amd_type(v), v->reg_index,
+               (uint32_t) v->array_length);
+}
+
+static void jitc_amd_render_array_init(Variable *v, Variable *pred,
+                                       Variable *value) {
+    v->reg_index = pred->reg_index;
+
+    buffer.fmt("for (uint32_t _i = 0; _i < %uu; ++_i)\n"
+               "    arr_%u[_i] = r%u;\n",
+               (uint32_t) v->array_length, v->reg_index, value->reg_index);
+}
+
+static void jitc_amd_render_array_read(Variable *v, Variable *source,
+                                       Variable *mask, Variable *offset) {
+    if (!mask->is_literal())
+        buffer.fmt("%s r%u = (%s) (%s);\n", jitc_amd_type(v), v->reg_index,
+                   jitc_amd_type(v), jitc_amd_zero((VarType) v->type));
+
+    if (offset) {
+        if (!mask->is_literal())
+            buffer.fmt("if (r%u) r%u = arr_%u[r%u];\n",
+                       mask->reg_index, v->reg_index, source->reg_index,
+                       offset->reg_index);
+        else
+            buffer.fmt("%s r%u = arr_%u[r%u];\n", jitc_amd_type(v),
+                       v->reg_index, source->reg_index, offset->reg_index);
+    } else {
+        if (!mask->is_literal())
+            buffer.fmt("if (r%u) r%u = arr_%u[%u];\n",
+                       mask->reg_index, v->reg_index, source->reg_index,
+                       (uint32_t) v->literal);
+        else
+            buffer.fmt("%s r%u = arr_%u[%u];\n", jitc_amd_type(v),
+                       v->reg_index, source->reg_index,
+                       (uint32_t) v->literal);
+    }
+}
+
+static void jitc_amd_render_array_write(Variable *v, Variable *target,
+                                        Variable *value, Variable *mask,
+                                        Variable *offset) {
+    if (offset && offset->is_array())
+        offset = nullptr;
+
+    bool copy = target->array_state == (uint32_t) ArrayState::Conflicted;
+    uint32_t target_buffer = target->reg_index;
+
+    if (copy) {
+        target_buffer = jitc_array_buffer(v)->reg_index;
+        buffer.fmt("for (uint32_t _i = 0; _i < %uu; ++_i)\n"
+                   "    arr_%u[_i] = arr_%u[_i];\n",
+                   (uint32_t) v->array_length, target_buffer,
+                   target->reg_index);
+    }
+
+    if (offset) {
+        if (!mask->is_literal())
+            buffer.fmt("if (r%u) arr_%u[r%u] = r%u;\n",
+                       mask->reg_index, target_buffer, offset->reg_index,
+                       value->reg_index);
+        else
+            buffer.fmt("arr_%u[r%u] = r%u;\n", target_buffer,
+                       offset->reg_index, value->reg_index);
+    } else {
+        if (!mask->is_literal())
+            buffer.fmt("if (r%u) arr_%u[%u] = r%u;\n",
+                       mask->reg_index, target_buffer, (uint32_t) v->literal,
+                       value->reg_index);
+        else
+            buffer.fmt("arr_%u[%u] = r%u;\n", target_buffer,
+                       (uint32_t) v->literal, value->reg_index);
+    }
+
+    v->reg_index = target_buffer;
+}
+
+static void jitc_amd_render_array_select(Variable *v, Variable *mask,
+                                         Variable *t, Variable *f) {
+    uint32_t reg_index = jitc_array_buffer(v)->reg_index;
+    buffer.fmt("if (r%u) {\n"
+               "    for (uint32_t _i = 0; _i < %uu; ++_i)\n"
+               "        arr_%u[_i] = arr_%u[_i];\n"
+               "} else {\n"
+               "    for (uint32_t _i = 0; _i < %uu; ++_i)\n"
+               "        arr_%u[_i] = arr_%u[_i];\n"
+               "}\n",
+               mask->reg_index,
+               (uint32_t) f->array_length, reg_index, t->reg_index,
+               (uint32_t) f->array_length, reg_index, f->reg_index);
+
+    v->reg_index = reg_index;
+}
+
+static void jitc_amd_render_array_memcpy_in(const Variable *v,
+                                            uint32_t slot) {
+    buffer.fmt("%s arr_%u[%u];\n", jitc_amd_type(v), v->reg_index,
+               (uint32_t) v->array_length);
+    buffer.fmt("for (uint32_t _i = 0; _i < %uu; ++_i)\n"
+               "    arr_%u[_i] = ((const %s *) params[%u])[_i * size + r0];\n",
+               (uint32_t) v->array_length, v->reg_index, jitc_amd_type(v),
+               slot);
+}
+
+static void jitc_amd_render_array_memcpy_out(const Variable *v,
+                                             uint32_t slot) {
+    buffer.fmt("for (uint32_t _i = 0; _i < %uu; ++_i)\n"
+               "    ((%s *) params[%u])[_i * size + r0] = arr_%u[_i];\n",
+               (uint32_t) v->array_length, jitc_amd_type(v), slot,
+               v->reg_index);
+}
+
+static void jitc_amd_render_bitwise_float_binary(Variable *v,
+                                                 const char *op) {
+    Variable *a0 = jitc_var(v->dep[0]),
+             *a1 = jitc_var(v->dep[1]);
+    const char *bt = type_size[v->type] == 8 ? "uint64_t" :
+                     type_size[v->type] == 4 ? "uint32_t" : "uint16_t";
+    jitc_amd_emit_decl(v);
+    buffer.fmt("drjit_bitcast<%s>((%s) (drjit_bitcast<%s>(", jitc_amd_type(v),
+               bt, bt);
+    jitc_amd_var(a0);
+    buffer.fmt(") %s drjit_bitcast<%s>(", op, bt);
+    jitc_amd_var(a1);
+    buffer.put(")));\n");
+}
+
+static void jitc_amd_render_bitwise_float_unary(Variable *v,
+                                                const char *op) {
+    Variable *a = jitc_var(v->dep[0]);
+    const char *bt = type_size[v->type] == 8 ? "uint64_t" :
+                     type_size[v->type] == 4 ? "uint32_t" : "uint16_t";
+    jitc_amd_emit_decl(v);
+    buffer.fmt("drjit_bitcast<%s>((%s) (%sdrjit_bitcast<%s>(",
+               jitc_amd_type(v), bt, op, bt);
+    jitc_amd_var(a);
+    buffer.put(")));\n");
+}
+
+static void jitc_amd_render_gather(Variable *v) {
+    Variable *src   = jitc_var(v->dep[0]);
+    Variable *index = jitc_var(v->dep[1]);
+    Variable *mask  = jitc_var(v->dep[2]);
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+
+    jitc_amd_emit_decl(v);
+    if (!is_unmasked) {
+        jitc_amd_var(mask);
+        buffer.put(" ? ");
+    }
+    buffer.fmt("((const %s *) (uintptr_t) ", jitc_amd_type(v));
+    jitc_amd_var(src);
+    buffer.put(")[");
+    jitc_amd_var(index);
+    buffer.put("]");
+    if (!is_unmasked) {
+        buffer.fmt(" : (%s) (%s)", jitc_amd_type(v),
+                   jitc_amd_zero((VarType) v->type));
+    }
+    buffer.put(";\n");
+}
+
+static void jitc_amd_render_gather_packet(Variable *v) {
+    Variable *ptr   = jitc_var(v->dep[0]);
+    Variable *index = jitc_var(v->dep[1]);
+    Variable *mask  = jitc_var(v->dep[2]);
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+
+    VarType vt = (VarType) v->type;
+    uint32_t count = (uint32_t) v->literal,
+             tsize = type_size[v->type],
+             total_bytes = count * tsize,
+             id = v->reg_index;
+
+    for (uint32_t i = 0; i < count; ++i) {
+        buffer.fmt("%s r%u_out_%u = (%s) (%s);\n",
+                   jitc_amd_type(v), id, i, jitc_amd_type(v),
+                   jitc_amd_zero(vt));
+    }
+
+    if (!is_unmasked) {
+        buffer.put("if (");
+        jitc_amd_var(mask);
+        buffer.put(") {\n");
+    } else {
+        buffer.put("{\n");
+    }
+
+    buffer.fmt("const uint8_t *_packet_%u = "
+               "(const uint8_t *) (uintptr_t) ", id);
+    jitc_amd_var(ptr);
+    buffer.put(" + (uintptr_t) ");
+    jitc_amd_var(index);
+    buffer.fmt(" * %uu;\n", total_bytes);
+
+    for (uint32_t i = 0; i < count; ++i) {
+        if (vt == VarType::Bool) {
+            buffer.fmt("r%u_out_%u = *((const uint8_t *) "
+                       "(_packet_%u + %uu)) != 0;\n",
+                       id, i, id, i * tsize);
+        } else {
+            buffer.fmt("r%u_out_%u = *((const %s *) "
+                       "(_packet_%u + %uu));\n",
+                       id, i, jitc_amd_type(v), id, i * tsize);
+        }
+    }
+
+    buffer.put("}\n");
+}
+
+static void jitc_amd_render_scatter_packet(Variable *v) {
+    Variable *ptr   = jitc_var(v->dep[0]);
+    Variable *index = jitc_var(v->dep[1]);
+    Variable *mask  = jitc_var(v->dep[2]);
+    PacketScatterData *psd = (PacketScatterData *) v->data;
+    const std::vector<uint32_t> &values = psd->values;
+    Variable *v0 = jitc_var(values[0]);
+
+    if (psd->op != ReduceOp::Identity)
+        jitc_raise("jitc_amd_render_scatter_packet(): packet scatter-reduce "
+                   "nodes should have been lowered to scalar AMD scatters.");
+
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+    VarType vt = (VarType) v0->type;
+    uint32_t count = (uint32_t) values.size(),
+             id = v->reg_index;
+    const char *packet_type =
+        vt == VarType::Bool ? "uint8_t" : jitc_amd_type(v0);
+
+    if (!is_unmasked) {
+        buffer.put("if (");
+        jitc_amd_var(mask);
+        buffer.put(") {\n");
+    } else {
+        buffer.put("{\n");
+    }
+
+    buffer.fmt("%s *_packet_%u = (%s *) (uintptr_t) ",
+               packet_type, id, packet_type);
+    jitc_amd_var(ptr);
+    buffer.put(" + (uintptr_t) ");
+    jitc_amd_var(index);
+    buffer.put(";\n");
+
+    for (uint32_t i = 0; i < count; ++i) {
+        Variable *value = jitc_var(values[i]);
+        if (vt == VarType::Bool) {
+            buffer.fmt("_packet_%u[%u] = (uint8_t) (", id, i);
+            jitc_amd_var(value);
+            buffer.put(" ? 1u : 0u);\n");
+        } else {
+            buffer.fmt("_packet_%u[%u] = ", id, i);
+            jitc_amd_var(value);
+            buffer.put(";\n");
+        }
+    }
+
+    buffer.put("}\n");
+}
+
+static void jitc_amd_render_scatter(Variable *v) {
+    Variable *ptr   = jitc_var(v->dep[0]);
+    Variable *value = jitc_var(v->dep[1]);
+    Variable *index = jitc_var(v->dep[2]);
+    Variable *mask  = jitc_var(v->dep[3]);
+
+    ReduceOp op = (ReduceOp) (uint32_t) v->literal;
+    VarType vt = (VarType) value->type;
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+
+    if (!is_unmasked) {
+        buffer.put("if (");
+        jitc_amd_var(mask);
+        buffer.put(") ");
+    }
+
+    if (op == ReduceOp::Identity) {
+        buffer.fmt("((%s *) (uintptr_t) ", jitc_amd_type(value));
+        jitc_amd_var(ptr);
+        buffer.put(")[");
+        jitc_amd_var(index);
+        buffer.put("] = ");
+        jitc_amd_var(value);
+        buffer.put(";\n");
+        return;
+    }
+
+    if (vt == VarType::Float16) {
+        uint32_t id = v->reg_index;
+        if (op == ReduceOp::Add) {
+            buffer.put("atomicAdd((__half *) (uintptr_t) ");
+            jitc_amd_var(ptr);
+            buffer.put(" + ");
+            jitc_amd_var(index);
+            buffer.put(", ");
+            jitc_amd_var(value);
+            buffer.put(");\n");
+            return;
+        } else if (op == ReduceOp::Min || op == ReduceOp::Max) {
+            const char *fn = op == ReduceOp::Min ? "fminf" : "fmaxf";
+            buffer.fmt("{\n"
+                       "unsigned short *_addr_%u = "
+                       "(unsigned short *) ((__half *) (uintptr_t) ",
+                       id);
+            jitc_amd_var(ptr);
+            buffer.put(" + ");
+            jitc_amd_var(index);
+            buffer.fmt(");\n"
+                       "unsigned short _old_%u = *_addr_%u;\n"
+                       "while (true) {\n"
+                       "    __half _old_h_%u = __ushort_as_half(_old_%u);\n"
+                       "    __half _new_h_%u = (__half) %s((float) _old_h_%u, (float) ",
+                       id, id, id, id, id, fn, id);
+            jitc_amd_var(value);
+            buffer.fmt(");\n"
+                       "    unsigned short _new_%u = __half_as_ushort(_new_h_%u);\n"
+                       "    unsigned short _prev_%u = atomicCAS(_addr_%u, _old_%u, _new_%u);\n"
+                       "    if (_prev_%u == _old_%u)\n"
+                       "        break;\n"
+                       "    _old_%u = _prev_%u;\n"
+                       "}\n"
+                       "}\n",
+                       id, id, id, id, id, id, id, id, id, id);
+            return;
+        }
+    }
+
+    const char *atomic_fn = nullptr,
+               *atomic_type = jitc_amd_type(value);
+    switch (op) {
+        case ReduceOp::Add:
+            atomic_fn = "atomicAdd";
+            if (vt == VarType::Int64)
+                atomic_type = "uint64_t";
+            if (!(vt == VarType::Int32 || vt == VarType::UInt32 ||
+                  vt == VarType::Int64 || vt == VarType::UInt64 ||
+                  vt == VarType::Float32 || vt == VarType::Float64))
+                jitc_raise("jitc_amd_render_scatter(): atomic add for %s is "
+                           "not implemented yet.", type_name[(uint32_t) vt]);
+            break;
+
+        case ReduceOp::Min:
+            atomic_fn = "atomicMin";
+            if (!(vt == VarType::Int32 || vt == VarType::UInt32 ||
+                  vt == VarType::Int64 || vt == VarType::UInt64 ||
+                  vt == VarType::Float32 || vt == VarType::Float64))
+                jitc_raise("jitc_amd_render_scatter(): atomic min for %s is "
+                           "not implemented yet.", type_name[(uint32_t) vt]);
+            break;
+
+        case ReduceOp::Max:
+            atomic_fn = "atomicMax";
+            if (!(vt == VarType::Int32 || vt == VarType::UInt32 ||
+                  vt == VarType::Int64 || vt == VarType::UInt64 ||
+                  vt == VarType::Float32 || vt == VarType::Float64))
+                jitc_raise("jitc_amd_render_scatter(): atomic max for %s is "
+                           "not implemented yet.", type_name[(uint32_t) vt]);
+            break;
+
+        case ReduceOp::And:
+            atomic_fn = "atomicAnd";
+            if (vt == VarType::Int32)
+                atomic_type = "uint32_t";
+            else if (vt == VarType::Int64 || vt == VarType::UInt64)
+                atomic_type = "uint64_t";
+            if (!(vt == VarType::Int32 || vt == VarType::UInt32 ||
+                  vt == VarType::Int64 || vt == VarType::UInt64))
+                jitc_raise("jitc_amd_render_scatter(): atomic and for %s is "
+                           "not implemented yet.", type_name[(uint32_t) vt]);
+            break;
+
+        case ReduceOp::Or:
+            atomic_fn = "atomicOr";
+            if (vt == VarType::Int32)
+                atomic_type = "uint32_t";
+            else if (vt == VarType::Int64 || vt == VarType::UInt64)
+                atomic_type = "uint64_t";
+            if (!(vt == VarType::Int32 || vt == VarType::UInt32 ||
+                  vt == VarType::Int64 || vt == VarType::UInt64))
+                jitc_raise("jitc_amd_render_scatter(): atomic or for %s is "
+                           "not implemented yet.", type_name[(uint32_t) vt]);
+            break;
+
+        default:
+            jitc_raise("jitc_amd_render_scatter(): scatter-reduce operation "
+                       "\"%s\" is not implemented yet.",
+                       red_name[(uint32_t) op]);
+    }
+
+    buffer.fmt("%s((%s *) (uintptr_t) ", atomic_fn, atomic_type);
+    jitc_amd_var(ptr);
+    buffer.put(" + ");
+    jitc_amd_var(index);
+    buffer.fmt(", (%s) ", atomic_type);
+    jitc_amd_var(value);
+    buffer.put(");\n");
+}
+
+static void jitc_amd_render_scatter_inc(Variable *v) {
+    Variable *ptr   = jitc_var(v->dep[0]);
+    Variable *index = jitc_var(v->dep[1]);
+    Variable *mask  = jitc_var(v->dep[2]);
+
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+
+    jitc_amd_emit_decl(v);
+    buffer.put("0u;\n");
+
+    if (!is_unmasked) {
+        buffer.put("if (");
+        jitc_amd_var(mask);
+        buffer.put(") ");
+    }
+
+    jitc_amd_var(v);
+    buffer.put(" = atomicAdd((uint32_t *) (uintptr_t) ");
+    jitc_amd_var(ptr);
+    buffer.put(" + ");
+    jitc_amd_var(index);
+    buffer.put(", 1u);\n");
+
+    v->consumed = 1;
+}
+
+static const char *jitc_amd_atomic_uint_type(VarType vt) {
+    switch (type_size[(int) vt]) {
+        case 2: return "unsigned short";
+        case 4: return "uint32_t";
+        case 8: return "unsigned long long";
+        default:
+            jitc_raise("jitc_amd_atomic_uint_type(): unsupported type %s.",
+                       type_name[(int) vt]);
+    }
+}
+
+static const char *jitc_amd_atomic_value_expr(Variable *v) {
+    VarType vt = (VarType) v->type;
+    if (vt == VarType::Float16)
+        return "__half_as_ushort";
+    else if (vt == VarType::Float32)
+        return "drjit_bitcast<uint32_t>";
+    else if (vt == VarType::Float64)
+        return "drjit_bitcast<unsigned long long>";
+    else
+        return nullptr;
+}
+
+static void jitc_amd_put_atomic_value(Variable *v) {
+    const char *expr = jitc_amd_atomic_value_expr(v);
+    if (expr) {
+        buffer.fmt("%s(", expr);
+        jitc_amd_var(v);
+        buffer.put(")");
+    } else {
+        buffer.fmt("(%s) ", jitc_amd_atomic_uint_type((VarType) v->type));
+        jitc_amd_var(v);
+    }
+}
+
+static void jitc_amd_put_atomic_result_cast(VarType vt, const char *var) {
+    switch (vt) {
+        case VarType::Float16:
+            buffer.fmt("__ushort_as_half((unsigned short) %s)", var);
+            break;
+        case VarType::Float32:
+            buffer.fmt("drjit_bitcast<float>((uint32_t) %s)", var);
+            break;
+        case VarType::Float64:
+            buffer.fmt("drjit_bitcast<double>((uint64_t) %s)", var);
+            break;
+        default:
+            buffer.fmt("(%s) %s", jitc_amd_type(vt), var);
+            break;
+    }
+}
+
+static void jitc_amd_render_scatter_exch(Variable *v) {
+    Variable *ptr   = jitc_var(v->dep[0]);
+    Variable *value = jitc_var(v->dep[1]);
+    Variable *index = jitc_var(v->dep[2]);
+    Variable *mask  = jitc_var(v->dep[3]);
+    VarType vt = (VarType) value->type;
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+    uint32_t id = v->reg_index;
+
+    jitc_amd_emit_decl(v);
+    buffer.fmt("%s", jitc_amd_zero(vt));
+    buffer.put(";\n");
+
+    if (!is_unmasked) {
+        buffer.put("if (");
+        jitc_amd_var(mask);
+        buffer.put(") {\n");
+    } else {
+        buffer.put("{\n");
+    }
+
+    const char *atomic_type = jitc_amd_atomic_uint_type(vt);
+    buffer.fmt("%s *_addr_%u = (%s *) ((%s *) (uintptr_t) ",
+               atomic_type, id, atomic_type, jitc_amd_type(value));
+    jitc_amd_var(ptr);
+    buffer.put(" + ");
+    jitc_amd_var(index);
+    buffer.fmt(");\n%s _old_%u = atomicExch(_addr_%u, ",
+               atomic_type, id, id);
+    jitc_amd_put_atomic_value(value);
+    buffer.put(");\n");
+    jitc_amd_var(v);
+    buffer.put(" = ");
+    char tmp[64];
+    snprintf(tmp, sizeof(tmp), "_old_%u", id);
+    jitc_amd_put_atomic_result_cast(vt, tmp);
+    buffer.put(";\n}\n");
+
+    v->consumed = 1;
+}
+
+static void jitc_amd_render_scatter_cas(Variable *v) {
+    Variable *ptr     = jitc_var(v->dep[0]);
+    Variable *compare = jitc_var(v->dep[1]);
+    Variable *value   = jitc_var(v->dep[2]);
+    Variable *index   = jitc_var(v->dep[3]);
+
+    ScatterCASDData *cas_data = (ScatterCASDData *) v->data;
+    Variable *mask = jitc_var(cas_data->mask);
+    VarType vt = (VarType) value->type;
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+    uint32_t id = v->reg_index;
+
+    buffer.fmt("%s r%u_out_0 = %s;\n"
+               "bool r%u_out_1 = false;\n",
+               jitc_amd_type(value), id, jitc_amd_zero(vt), id);
+
+    if (!is_unmasked) {
+        buffer.put("if (");
+        jitc_amd_var(mask);
+        buffer.put(") {\n");
+    } else {
+        buffer.put("{\n");
+    }
+
+    const char *atomic_type = jitc_amd_atomic_uint_type(vt);
+    buffer.fmt("%s *_addr_%u = (%s *) ((%s *) (uintptr_t) ",
+               atomic_type, id, atomic_type, jitc_amd_type(value));
+    jitc_amd_var(ptr);
+    buffer.put(" + ");
+    jitc_amd_var(index);
+    buffer.fmt(");\n%s _expected_%u = ", atomic_type, id);
+    jitc_amd_put_atomic_value(compare);
+    buffer.fmt(";\n%s _old_%u = atomicCAS(_addr_%u, _expected_%u, ",
+               atomic_type, id, id, id);
+    jitc_amd_put_atomic_value(value);
+    buffer.put(");\n");
+    buffer.fmt("r%u_out_0 = ", id);
+    char tmp[64];
+    snprintf(tmp, sizeof(tmp), "_old_%u", id);
+    jitc_amd_put_atomic_result_cast(vt, tmp);
+    buffer.fmt(";\nr%u_out_1 = _old_%u == _expected_%u;\n}\n",
+               id, id, id);
+
+    v->consumed = 1;
+}
+
+static void jitc_amd_render_trace(Variable *v) {
+    TraceData *td = (TraceData *) v->data;
+    Variable *valid = jitc_var(v->dep[0]);
+    Variable *scene_h = jitc_var(v->dep[2]);
+    Variable *func_h = v->dep[3] ? jitc_var(v->dep[3]) : nullptr;
+    bool is_unmasked = valid->is_literal() && valid->literal == 1;
+    uint32_t id = v->reg_index;
+
+    if (td->shadow) {
+        buffer.fmt("bool r%u_out_0 = false;\n", id);
+    } else {
+        buffer.fmt("bool r%u_out_0 = false;\n"
+                   "float r%u_out_1 = drjit_bits_to_float(0x7f800000u);\n"
+                   "float r%u_out_2 = 0.0f;\n"
+                   "float r%u_out_3 = 0.0f;\n"
+                   "uint32_t r%u_out_4 = 0u;\n"
+                   "uint32_t r%u_out_5 = 0u;\n"
+                   "uint32_t r%u_out_6 = 0u;\n"
+                   "uint32_t r%u_out_7 = 0u;\n",
+                   id, id, id, id, id, id, id, id);
+    }
+
+    if (!is_unmasked) {
+        buffer.put("if (");
+        jitc_amd_var(valid);
+        buffer.put(") {\n");
+    } else {
+        buffer.put("{\n");
+    }
+
+    Variable *ox   = jitc_var(td->indices[0]);
+    Variable *oy   = jitc_var(td->indices[1]);
+    Variable *oz   = jitc_var(td->indices[2]);
+    Variable *dx   = jitc_var(td->indices[3]);
+    Variable *dy   = jitc_var(td->indices[4]);
+    Variable *dz   = jitc_var(td->indices[5]);
+    Variable *tmin = jitc_var(td->indices[6]);
+    Variable *tmax = jitc_var(td->indices[7]);
+
+    buffer.fmt("hiprtRay _ray_%u;\n"
+               "_ray_%u.origin = hiprtFloat3{", id, id);
+    jitc_amd_var(ox);
+    buffer.put(", ");
+    jitc_amd_var(oy);
+    buffer.put(", ");
+    jitc_amd_var(oz);
+    buffer.put("};\n");
+    buffer.fmt("_ray_%u.direction = hiprtFloat3{", id);
+    jitc_amd_var(dx);
+    buffer.put(", ");
+    jitc_amd_var(dy);
+    buffer.put(", ");
+    jitc_amd_var(dz);
+    buffer.put("};\n");
+    buffer.fmt("_ray_%u.minT = ", id);
+    jitc_amd_var(tmin);
+    buffer.put(";\n");
+    buffer.fmt("_ray_%u.maxT = ", id);
+    jitc_amd_var(tmax);
+    buffer.put(";\n");
+
+    buffer.fmt("hiprtScene _scene_%u = (hiprtScene) (uintptr_t) ", id);
+    jitc_amd_var(scene_h);
+    buffer.put(";\n");
+    if (func_h) {
+        buffer.fmt("hiprtFuncTable _func_table_%u = (hiprtFuncTable) "
+                   "(uintptr_t) ", id);
+        jitc_amd_var(func_h);
+        buffer.put(";\n");
+    }
+    std::string func_table_arg =
+        func_h ? ("_func_table_" + std::to_string(id)) : "nullptr";
+
+    if (td->shadow) {
+        buffer.fmt("hiprtSceneTraversalAnyHit _tr_%u(_scene_%u, _ray_%u, "
+                   "hiprtFullRayMask, hiprtTraversalHintShadowRays, nullptr, "
+                   "%s);\n"
+                   "hiprtHit _hit_%u = _tr_%u.getNextHit();\n"
+                   "if (_hit_%u.hasHit())\n"
+                   "    r%u_out_0 = true;\n",
+                   id, id, id,
+                   func_table_arg.c_str(),
+                   id, id, id, id);
+    } else {
+        buffer.fmt("hiprtSceneTraversalClosest _tr_%u(_scene_%u, _ray_%u, "
+                   "hiprtFullRayMask, hiprtTraversalHintDefault, nullptr, "
+                   "%s);\n"
+                   "hiprtHit _hit_%u = _tr_%u.getNextHit();\n"
+                   "if (_hit_%u.hasHit()) {\n"
+                   "    r%u_out_0 = true;\n"
+                   "    r%u_out_1 = _hit_%u.t;\n"
+                   "    r%u_out_2 = _hit_%u.uv.x;\n"
+                   "    r%u_out_3 = _hit_%u.uv.y;\n"
+                   "    r%u_out_4 = _hit_%u.instanceID;\n"
+                   "    r%u_out_5 = _hit_%u.primID;\n"
+                   "    r%u_out_6 = 0u;\n"
+                   "    r%u_out_7 = _hit_%u.instanceID;\n"
+                   "}\n",
+                   id, id, id,
+                   func_table_arg.c_str(),
+                   id, id, id,
+                   id, id, id, id, id, id, id, id,
+                   id, id, id, id, id, id, id, id, id);
+    }
+
+    buffer.put("}\n");
+}
+
+static void jitc_amd_render(Variable *v) {
+    if (v->coop_vec)
+        jitc_raise("jitc_amd_render(): cooperative vectors are not supported "
+                   "by the AMD/HIP backend without an OptiX-like HIPRT "
+                   "cooperative-vector facility.");
+
+    switch ((VarKind) v->kind) {
+        case VarKind::Nop:
+            break;
+
+        case VarKind::Undefined:
+            jitc_amd_emit_decl(v);
+            buffer.fmt("(%s) (%s);\n", jitc_amd_type(v),
+                       jitc_amd_zero((VarType) v->type));
+            break;
+
+        case VarKind::Literal:
+            jitc_amd_emit_decl(v);
+            jitc_amd_literal(v);
+            buffer.put(";\n");
+            break;
+
+        case VarKind::Counter:
+            jitc_amd_emit_decl(v);
+            buffer.fmt("(%s) r0;\n", jitc_amd_type(v));
+            break;
+
+        case VarKind::Add: jitc_amd_render_binary(v, "+"); break;
+        case VarKind::Sub: jitc_amd_render_binary(v, "-"); break;
+        case VarKind::Mul: jitc_amd_render_binary(v, "*"); break;
+        case VarKind::Div:
+        case VarKind::DivApprox:
+            jitc_amd_render_binary(v, "/"); break;
+        case VarKind::Mod: jitc_amd_render_binary(v, "%"); break;
+        case VarKind::Eq:  jitc_amd_render_binary(v, "=="); break;
+        case VarKind::Neq: jitc_amd_render_binary(v, "!="); break;
+        case VarKind::Lt:  jitc_amd_render_binary(v, "<"); break;
+        case VarKind::Le:  jitc_amd_render_binary(v, "<="); break;
+        case VarKind::Gt:  jitc_amd_render_binary(v, ">"); break;
+        case VarKind::Ge:  jitc_amd_render_binary(v, ">="); break;
+        case VarKind::Shl: jitc_amd_render_binary(v, "<<"); break;
+        case VarKind::Shr: jitc_amd_render_binary(v, ">>"); break;
+        case VarKind::MulHi: jitc_amd_render_call(v, "drjit_mul_hi", 2); break;
+
+        case VarKind::MulWide: {
+            Variable *a0 = jitc_var(v->dep[0]),
+                     *a1 = jitc_var(v->dep[1]);
+            jitc_amd_emit_decl(v);
+            buffer.fmt("(%s) ", jitc_amd_type(v));
+            jitc_amd_var(a0);
+            buffer.fmt(" * (%s) ", jitc_amd_type(v));
+            jitc_amd_var(a1);
+            buffer.put(";\n");
+            break;
+        }
+
+        case VarKind::Fma:
+            if (jitc_is_half(v)) {
+                jitc_amd_render_call(v, "drjit_fma", 3);
+            } else if (jitc_is_single(v)) {
+                jitc_amd_render_call(v, "fmaf", 3);
+            } else if (jitc_is_double(v)) {
+                jitc_amd_render_call(v, "fma", 3);
+            } else {
+                Variable *a0 = jitc_var(v->dep[0]),
+                         *a1 = jitc_var(v->dep[1]),
+                         *a2 = jitc_var(v->dep[2]);
+                jitc_amd_emit_decl(v);
+                jitc_amd_var(a0);
+                buffer.put(" * ");
+                jitc_amd_var(a1);
+                buffer.put(" + ");
+                jitc_amd_var(a2);
+                buffer.put(";\n");
+            }
+            break;
+
+        case VarKind::Min: jitc_amd_render_call(v, "drjit_min", 2); break;
+        case VarKind::Max: jitc_amd_render_call(v, "drjit_max", 2); break;
+
+        case VarKind::Ceil:  jitc_amd_render_round(v, "ceil"); break;
+        case VarKind::Floor: jitc_amd_render_round(v, "floor"); break;
+        case VarKind::Round: jitc_amd_render_round(v, "rint"); break;
+        case VarKind::Trunc: jitc_amd_render_round(v, "trunc"); break;
+
+        case VarKind::Select: {
+            Variable *cond = jitc_var(v->dep[0]);
+            Variable *a    = jitc_var(v->dep[1]);
+            Variable *b    = jitc_var(v->dep[2]);
+            jitc_amd_emit_decl(v);
+            jitc_amd_var(cond);
+            buffer.put(" ? ");
+            jitc_amd_var(a);
+            buffer.put(" : ");
+            jitc_amd_var(b);
+            buffer.put(";\n");
+            break;
+        }
+
+        case VarKind::And: {
+            Variable *a0 = jitc_var(v->dep[0]),
+                     *a1 = jitc_var(v->dep[1]);
+            if (a0->type != a1->type) {
+                jitc_amd_emit_decl(v);
+                jitc_amd_var(a1);
+                buffer.put(" ? ");
+                jitc_amd_var(a0);
+                buffer.fmt(" : (%s) (%s);\n", jitc_amd_type(v),
+                           jitc_amd_zero((VarType) v->type));
+            } else if (jitc_is_float(v)) {
+                jitc_amd_render_bitwise_float_binary(v, "&");
+            } else {
+                jitc_amd_render_binary(v, "&");
+            }
+            break;
+        }
+
+        case VarKind::Or: {
+            Variable *a0 = jitc_var(v->dep[0]),
+                     *a1 = jitc_var(v->dep[1]);
+            if (a0->type != a1->type) {
+                jitc_amd_emit_decl(v);
+                buffer.put("drjit_bitcast<");
+                buffer.put(jitc_amd_type(v), strlen(jitc_amd_type(v)));
+                buffer.put(">(");
+                jitc_amd_var(a1);
+                buffer.put(" ? ~drjit_bitcast<");
+                buffer.fmt("%s", jitc_amd_binary_type(type_size[v->type]));
+                buffer.put(">(");
+                jitc_amd_var(a0);
+                buffer.put(") : drjit_bitcast<");
+                buffer.fmt("%s", jitc_amd_binary_type(type_size[v->type]));
+                buffer.put(">(");
+                jitc_amd_var(a0);
+                buffer.put("));\n");
+            } else if (jitc_is_float(v)) {
+                jitc_amd_render_bitwise_float_binary(v, "|");
+            } else {
+                jitc_amd_render_binary(v, "|");
+            }
+            break;
+        }
+
+        case VarKind::Xor:
+            if (jitc_is_float(v))
+                jitc_amd_render_bitwise_float_binary(v, "^");
+            else
+                jitc_amd_render_binary(v, "^");
+            break;
+
+        case VarKind::Neg: jitc_amd_render_unary(v, "-"); break;
+        case VarKind::Not: {
+            Variable *a = jitc_var(v->dep[0]);
+            if ((VarType) v->type == VarType::Bool) {
+                jitc_amd_emit_decl(v);
+                buffer.put("!");
+                jitc_amd_var(a);
+                buffer.put(";\n");
+            } else if (jitc_is_float(v)) {
+                jitc_amd_render_bitwise_float_unary(v, "~");
+            } else {
+                jitc_amd_emit_decl(v);
+                buffer.put("~");
+                jitc_amd_var(a);
+                buffer.put(";\n");
+            }
+            break;
+        }
+
+        case VarKind::Abs: {
+            Variable *a = jitc_var(v->dep[0]);
+            jitc_amd_emit_decl(v);
+            if (jitc_is_uint(v) || (VarType) v->type == VarType::Bool) {
+                jitc_amd_var(a);
+            } else {
+                buffer.put("drjit_abs(");
+                jitc_amd_var(a);
+                buffer.put(")");
+            }
+            buffer.put(";\n");
+            break;
+        }
+
+        case VarKind::Sqrt:
+        case VarKind::SqrtApprox:
+            jitc_amd_render_float_call(v, "drjit_sqrt", "sqrtf", "sqrt"); break;
+        case VarKind::Sin:
+            jitc_amd_render_float_call(v, "drjit_sin", "sinf", "sin"); break;
+        case VarKind::Cos:
+            jitc_amd_render_float_call(v, "drjit_cos", "cosf", "cos"); break;
+        case VarKind::Exp2:
+            jitc_amd_render_float_call(v, "drjit_exp2", "exp2f", "exp2"); break;
+        case VarKind::Log2:
+            jitc_amd_render_float_call(v, "drjit_log2", "log2f", "log2"); break;
+        case VarKind::Tanh:
+            jitc_amd_render_float_call(v, "drjit_tanh", "tanhf", "tanh"); break;
+
+        case VarKind::Rcp:
+        case VarKind::RcpApprox:
+            jitc_amd_emit_decl(v);
+            buffer.fmt("(%s) 1 / ", jitc_amd_type(v));
+            jitc_amd_var(jitc_var(v->dep[0]));
+            buffer.put(";\n");
+            break;
+
+        case VarKind::RSqrtApprox:
+            jitc_amd_render_float_call(v, "drjit_rsqrt", "rsqrtf", "rsqrt");
+            break;
+
+        case VarKind::Popc:
+        case VarKind::Clz:
+        case VarKind::Ctz:
+        case VarKind::Brev: {
+            Variable *a0 = jitc_var(v->dep[0]);
+            bool is_64 = type_size[a0->type] == 8;
+            const char *fn =
+                v->kind == (uint32_t) VarKind::Popc ? (is_64 ? "__popcll" : "__popc") :
+                v->kind == (uint32_t) VarKind::Clz  ? (is_64 ? "__clzll"  : "__clz")  :
+                v->kind == (uint32_t) VarKind::Ctz  ? (is_64 ? "__ffsll"  : "__ffs")  :
+                                                       (is_64 ? "__brevll" : "__brev");
+            const char *cast = is_64 ? "unsigned long long" : "unsigned int";
+            jitc_amd_emit_decl(v);
+            buffer.fmt("(%s) %s((%s) ", jitc_amd_type(v), fn, cast);
+            jitc_amd_var(a0);
+            buffer.put(");\n");
+
+            if (v->kind == (uint32_t) VarKind::Ctz)
+                buffer.fmt("r%u = r%u ? r%u - 1 : %u;\n",
+                           v->reg_index, v->reg_index, v->reg_index,
+                           is_64 ? 64u : 32u);
+            break;
+        }
+
+        case VarKind::Cast: {
+            Variable *a = jitc_var(v->dep[0]);
+            jitc_amd_emit_decl(v);
+            buffer.fmt("(%s) ", jitc_amd_type(v));
+            jitc_amd_var(a);
+            buffer.put(";\n");
+            break;
+        }
+
+        case VarKind::Bitcast: {
+            Variable *a = jitc_var(v->dep[0]);
+            jitc_amd_emit_decl(v);
+            if (v->type == a->type) {
+                jitc_amd_var(a);
+            } else if (type_size[v->type] == type_size[a->type]) {
+                buffer.fmt("drjit_bitcast<%s>(", jitc_amd_type(v));
+                jitc_amd_var(a);
+                buffer.put(")");
+            } else {
+                buffer.fmt("drjit_bitcast<%s>((%s) ",
+                           jitc_amd_type(v),
+                           type_size[v->type] == 8 ? "uint64_t" :
+                           type_size[v->type] == 4 ? "uint32_t" : "uint16_t");
+                jitc_amd_var(a);
+                buffer.put(")");
+            }
+            buffer.put(";\n");
+            break;
+        }
+
+        case VarKind::BoundsCheck: {
+            Variable *index = jitc_var(v->dep[0]);
+            Variable *mask  = jitc_var(v->dep[1]);
+            Variable *buf   = jitc_var(v->dep[2]);
+            jitc_amd_emit_decl(v);
+            jitc_amd_var(mask);
+            buffer.put(" && (");
+            jitc_amd_var(index);
+            buffer.fmt(" < (uint32_t) %u);\n", (uint32_t) v->literal);
+            buffer.put("if (");
+            jitc_amd_var(mask);
+            buffer.put(" && !");
+            jitc_amd_var(v);
+            buffer.put(") *((uint32_t *) (uintptr_t) ");
+            jitc_amd_var(buf);
+            buffer.put(") = ");
+            jitc_amd_var(index);
+            buffer.put(";\n");
+            break;
+        }
+
+        case VarKind::Gather:
+            jitc_amd_render_gather(v);
+            break;
+
+        case VarKind::PacketGather:
+            jitc_amd_render_gather_packet(v);
+            break;
+
+        case VarKind::PacketScatter:
+            jitc_amd_render_scatter_packet(v);
+            break;
+
+        case VarKind::Scatter:
+            jitc_amd_render_scatter(v);
+            break;
+
+        case VarKind::ScatterInc:
+            jitc_amd_render_scatter_inc(v);
+            break;
+
+        case VarKind::ScatterCAS:
+            jitc_amd_render_scatter_cas(v);
+            break;
+
+        case VarKind::ScatterExch:
+            jitc_amd_render_scatter_exch(v);
+            break;
+
+        case VarKind::TraceRay:
+            jitc_amd_render_trace(v);
+            break;
+
+        case VarKind::CoopVecUnpack:
+            jitc_raise("jitc_amd_render(): cooperative vectors are not "
+                       "supported by the AMD/HIP backend.");
+
+        case VarKind::CoopVecAccum:
+            jitc_raise("jitc_amd_render(): cooperative vectors are not "
+                       "supported by the AMD/HIP backend.");
+
+        case VarKind::CoopVecOuterProductAccum:
+            jitc_raise("jitc_amd_render(): cooperative vectors are not "
+                       "supported by the AMD/HIP backend.");
+
+        case VarKind::Call: {
+            Variable *a0 = jitc_var(v->dep[0]),
+                     *a1 = jitc_var(v->dep[1]);
+            jitc_var_call_assemble((CallData *) v->data, v->reg_index,
+                                   a0->reg_index, a1->reg_index);
+            break;
+        }
+
+        case VarKind::CallGetter: {
+            Variable *index = jitc_var(v->dep[0]),
+                     *mask  = jitc_var(v->dep[1]);
+            jitc_var_call_getter_assemble(v, index, mask);
+            break;
+        }
+
+        case VarKind::CallOutput:
+            break;
+
+        case VarKind::CallSelf:
+            buffer.fmt("uint32_t r%u = self;\n", v->reg_index);
+            break;
+
+        case VarKind::CallInput:
+            break;
+
+        case VarKind::Extract: {
+            Variable *src = jitc_var(v->dep[0]);
+            jitc_amd_emit_decl(v);
+            buffer.fmt("r%u_out_%u;\n", src->reg_index,
+                       (uint32_t) v->literal);
+            break;
+        }
+
+        case VarKind::Array:
+            jitc_amd_render_array(v, v->dep[0] ? jitc_var(v->dep[0]) : nullptr);
+            break;
+
+        case VarKind::ArrayInit:
+            jitc_amd_render_array_init(v, jitc_var(v->dep[0]),
+                                       jitc_var(v->dep[1]));
+            break;
+
+        case VarKind::ArrayWrite:
+            jitc_amd_render_array_write(v, jitc_var(v->dep[0]),
+                                        jitc_var(v->dep[1]),
+                                        jitc_var(v->dep[2]),
+                                        v->dep[3] ? jitc_var(v->dep[3]) : nullptr);
+            break;
+
+        case VarKind::ArrayRead:
+            jitc_amd_render_array_read(v, jitc_var(v->dep[0]),
+                                       jitc_var(v->dep[1]),
+                                       v->dep[2] ? jitc_var(v->dep[2]) : nullptr);
+            break;
+
+        case VarKind::ArrayPhi:
+            v->reg_index = jitc_var(v->dep[0])->reg_index;
+            break;
+
+        case VarKind::ArraySelect:
+            jitc_amd_render_array_select(v, jitc_var(v->dep[0]),
+                                         jitc_var(v->dep[1]),
+                                         jitc_var(v->dep[2]));
+            break;
+
+        case VarKind::LoopStart: {
+            const LoopData *ld = (LoopData *) v->data;
+            for (size_t i = 0; i < ld->size; ++i) {
+                Variable *inner_in = jitc_var(ld->inner_in[i]),
+                         *outer_in = jitc_var(ld->outer_in[i]);
+
+                if (inner_in == outer_in || !inner_in->reg_index ||
+                    inner_in->is_array())
+                    continue;
+
+                buffer.fmt("%s r%u = ", jitc_amd_type(inner_in),
+                           inner_in->reg_index);
+                if (outer_in->reg_index)
+                    buffer.fmt("r%u", outer_in->reg_index);
+                else
+                    buffer.fmt("(%s) (%s)", jitc_amd_type(inner_in),
+                               jitc_amd_zero((VarType) inner_in->type));
+                buffer.put(";\n");
+            }
+            buffer.put("while (true) {\n");
+            break;
+        }
+
+        case VarKind::LoopCond: {
+            Variable *cond = jitc_var(v->dep[1]);
+            buffer.put("if (!");
+            jitc_amd_var(cond);
+            buffer.put(") break;\n");
+            break;
+        }
+
+        case VarKind::LoopEnd: {
+            Variable *a0 = jitc_var(v->dep[0]);
+            const LoopData *ld = (LoopData *) a0->data;
+            uint32_t size = (uint32_t) ld->size;
+
+            for (uint32_t i = 0; i < size; ++i) {
+                Variable *in  = jitc_var(ld->inner_in[i]),
+                         *out = jitc_var(ld->inner_out[i]);
+                in->scratch = out->scratch = 0;
+            }
+
+            for (uint32_t i = 0; i < size; ++i) {
+                Variable *in  = jitc_var(ld->inner_in[i]),
+                         *out = jitc_var(ld->inner_out[i]);
+                if (in == out || !in->reg_index || !out->reg_index ||
+                    in->is_array())
+                    continue;
+                in->scratch = 1;
+            }
+
+            for (uint32_t i = 0; i < size; ++i) {
+                Variable *in  = jitc_var(ld->inner_in[i]),
+                         *out = jitc_var(ld->inner_out[i]);
+                if (in == out || !in->reg_index || !out->reg_index ||
+                    in->is_array() || out->scratch != 1)
+                    continue;
+                buffer.fmt("%s r%u_tmp = r%u;\n", jitc_amd_type(out),
+                           out->reg_index, out->reg_index);
+                out->scratch = 2;
+            }
+
+            for (uint32_t i = 0; i < size; ++i) {
+                Variable *in  = jitc_var(ld->inner_in[i]),
+                         *out = jitc_var(ld->inner_out[i]);
+                if (in == out || !in->reg_index || !out->reg_index ||
+                    in->is_array())
+                    continue;
+                if (out->scratch == 2)
+                    buffer.fmt("r%u = r%u_tmp;\n", in->reg_index,
+                               out->reg_index);
+                else
+                    buffer.fmt("r%u = r%u;\n", in->reg_index,
+                               out->reg_index);
+            }
+
+            for (uint32_t i = 0; i < size; ++i) {
+                jitc_var(ld->inner_in[i])->scratch = 0;
+                jitc_var(ld->inner_out[i])->scratch = 0;
+            }
+
+            buffer.put("}\n");
+            break;
+        }
+
+        case VarKind::LoopPhi:
+            if (v->is_array()) {
+                Variable *a3 = jitc_var(v->dep[3]);
+                v->reg_index = a3->reg_index;
+            }
+            break;
+
+        case VarKind::LoopOutput: {
+            Variable *loop_start = jitc_var(v->dep[0]);
+            const LoopData *ld = (LoopData *) loop_start->data;
+            for (size_t i = 0; i < ld->size; ++i) {
+                Variable *outer_out = jitc_var(ld->outer_out[i]);
+                if (outer_out == v) {
+                    Variable *inner_in = jitc_var(ld->inner_in[i]);
+                    if (v->reg_index && inner_in->reg_index)
+                        buffer.fmt("%s r%u = r%u;\n", jitc_amd_type(v),
+                                   v->reg_index, inner_in->reg_index);
+                    break;
+                }
+            }
+            break;
+        }
+
+        case VarKind::CondStart: {
+            const CondData *cd = (CondData *) v->data;
+            Variable *cond = jitc_var(v->dep[0]);
+            for (size_t i = 0; i < cd->indices_out.size(); ++i) {
+                Variable *vo = jitc_var(cd->indices_out[i]);
+                if (vo && vo->reg_index)
+                    buffer.fmt("%s r%u;\n", jitc_amd_type(vo),
+                               vo->reg_index);
+            }
+            buffer.fmt("if (r%u) {\n", cond->reg_index);
+            break;
+        }
+
+        case VarKind::CondMid: {
+            Variable *a0 = jitc_var(v->dep[0]);
+            const CondData *cd = (CondData *) a0->data;
+            for (size_t i = 0; i < cd->indices_out.size(); ++i) {
+                Variable *vt = jitc_var(cd->indices_t[i]),
+                         *vo = jitc_var(cd->indices_out[i]);
+                if (vo && vo->reg_index && vt->reg_index)
+                    buffer.fmt("r%u = r%u;\n", vo->reg_index,
+                               vt->reg_index);
+            }
+            buffer.put("} else {\n");
+            break;
+        }
+
+        case VarKind::CondEnd: {
+            Variable *a0 = jitc_var(v->dep[0]);
+            const CondData *cd = (CondData *) a0->data;
+            for (size_t i = 0; i < cd->indices_out.size(); ++i) {
+                Variable *vf = jitc_var(cd->indices_f[i]),
+                         *vo = jitc_var(cd->indices_out[i]);
+                if (vo && vo->reg_index && vf->reg_index)
+                    buffer.fmt("r%u = r%u;\n", vo->reg_index,
+                               vf->reg_index);
+            }
+            buffer.put("}\n");
+            break;
+        }
+
+        case VarKind::CondOutput:
+            break;
+
+        default:
+            jitc_raise("jitc_amd_render(): node \"%s\" is not implemented yet.",
+                       var_kind_name[v->kind]);
+    }
+}
+
+static bool jitc_amd_call_has_out(const CallData *call) {
+    for (uint32_t i = 0; i < call->n_out; ++i)
+        if (call->out_offset[i] != (uint32_t) -1)
+            return true;
+    return false;
+}
+
+static void jitc_amd_put_ret_type(const CallData *call) {
+    if (!jitc_amd_call_has_out(call)) {
+        buffer.put("void");
+        return;
+    }
+
+    buffer.put("Ret_");
+    for (uint32_t i = 0; i < call->n_out; ++i)
+        if (call->out_offset[i] != (uint32_t) -1)
+            buffer.put(type_mangle[jitc_var(call->inner_out[i])->type]);
+}
+
+static void jitc_amd_emit_ret_struct(const CallData *call) {
+    if (!jitc_amd_call_has_out(call))
+        return;
+
+    size_t off = buffer.size();
+    buffer.put("struct ");
+    jitc_amd_put_ret_type(call);
+    buffer.put(" {\n");
+
+    uint32_t k = 0;
+    for (uint32_t i = 0; i < call->n_out; ++i) {
+        if (call->out_offset[i] == (uint32_t) -1)
+            continue;
+        Variable *v = jitc_var(call->inner_out[i]);
+        buffer.fmt("%s r%u;\n", jitc_amd_type(v), k++);
+    }
+
+    buffer.put("};\n");
+    jitc_register_global(buffer.get() + off);
+    buffer.rewind_to(off);
+}
+
+static void jitc_amd_callable_signature(const CallData *call,
+                                        bool with_names) {
+    if (with_names)
+        buffer.put("uint32_t index, uint32_t self, const uint8_t *data");
+    else
+        buffer.put("uint32_t, uint32_t, const uint8_t *");
+
+    if (call->use_nested) {
+        if (with_names)
+            buffer.put(", uintptr_t base");
+        else
+            buffer.put(", uintptr_t");
+    }
+
+    for (uint32_t i = 0; i < call->n_in; ++i) {
+        if (!call->in_active[i])
+            continue;
+
+        Variable *vo = jitc_var(call->outer_in[i]);
+        if (with_names)
+            buffer.fmt(", %s a%u", jitc_amd_type(vo), i);
+        else
+            buffer.fmt(", %s", jitc_amd_type(vo));
+    }
+}
+
+void jitc_amd_assemble_func(const CallData *call, uint32_t inst,
+                            uint32_t /*in_size*/, uint32_t /*in_align*/,
+                            uint32_t /*out_size*/, uint32_t /*out_align*/,
+                            uint32_t n_regs) {
+    (void) n_regs;
+
+    jitc_amd_emit_ret_struct(call);
+
+    buffer.put("__device__ inline ");
+    jitc_amd_put_ret_type(call);
+    if (call->n_inst == 1)
+        buffer.put(" func_unique_^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^(");
+    else
+        buffer.put(" func_^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^(");
+    jitc_amd_callable_signature(call, /*with_names=*/true);
+    buffer.put(") {\n");
+    buffer.fmt("// Call: %s\n", call->name.c_str());
+
+    jitc_call_bind_slots(call, inst);
+
+    for (size_t i = 0; i < schedule.size(); ++i) {
+        ScheduledVariable &sv = schedule[i];
+        Variable *v = jitc_var(sv.index);
+        VarType vt = (VarType) v->type;
+        VarKind kind = (VarKind) v->kind;
+
+        if (kind == VarKind::Counter) {
+            buffer.fmt("%s r%u = (%s) index;\n",
+                       jitc_amd_type(v), v->reg_index, jitc_amd_type(v));
+        } else if (kind == VarKind::CallInput) {
+            uint32_t in_i = 0;
+            for (; in_i < call->n_in; ++in_i)
+                if (call->inner_in[in_i] == sv.index)
+                    break;
+            buffer.fmt("%s r%u = a%u;\n",
+                       jitc_amd_type(v), v->reg_index, in_i);
+        } else if (kind == VarKind::CallSelf) {
+            buffer.fmt("uint32_t r%u = self;\n", v->reg_index);
+        } else if (v->is_evaluated() ||
+                   (vt == VarType::Pointer && kind == VarKind::Literal)) {
+            uint32_t offset = jitc_call_slot_rel_offset(call, inst, v, sv.index);
+
+            if (vt == VarType::Bool) {
+                buffer.fmt("bool r%u = *((const uint8_t *) (data + %u)) != 0;\n",
+                           v->reg_index, offset);
+            } else {
+                buffer.fmt("%s r%u = *((const %s *) (data + %u));\n",
+                           jitc_amd_type(v), v->reg_index,
+                           jitc_amd_type(v), offset);
+            }
+        } else if (v->is_literal()) {
+            jitc_amd_render(v);
+        } else {
+            jitc_amd_render(v);
+        }
+    }
+
+    if (jitc_amd_call_has_out(call)) {
+        buffer.put("    ");
+        jitc_amd_put_ret_type(call);
+        buffer.put(" ret;\n");
+
+        uint32_t k = 0;
+        for (uint32_t i = 0; i < call->n_out; ++i) {
+            if (call->out_offset[i] == (uint32_t) -1)
+                continue;
+            Variable *v = jitc_var(call->inner_out[inst * call->n_out + i]);
+            buffer.fmt("ret.r%u = r%u;\n", k++, v->reg_index);
+        }
+
+        buffer.put("return ret;\n");
+    }
+
+    buffer.put("}\n");
+}
+
+void jitc_var_call_getter_assemble_amd(Variable *v, const Variable *index,
+                                       const Variable *mask) {
+    GetterData *gd = (GetterData *) v->data;
+    uint32_t header_offset = gd->header_offset;
+
+    char base[32];
+    if (callable_depth == 0)
+        snprintf(base, sizeof(base), "r%u", call_buffer.base_reg);
+    else
+        snprintf(base, sizeof(base), "base");
+
+    bool is_unmasked = mask->is_literal() && mask->literal == 1;
+    jitc_amd_emit_decl(v);
+
+    if (!is_unmasked) {
+        jitc_amd_var(mask);
+        buffer.put(" ? ");
+    }
+
+    if ((VarType) v->type == VarType::Bool) {
+        buffer.fmt("(((const uint8_t *) ((uintptr_t) %s + %u))[",
+                   base, header_offset);
+        jitc_amd_var(index);
+        buffer.put("] != 0)");
+    } else {
+        buffer.fmt("((const %s *) ((uintptr_t) %s + %u))[",
+                   jitc_amd_type(v), base, header_offset);
+        jitc_amd_var(index);
+        buffer.put("]");
+    }
+
+    if (!is_unmasked) {
+        buffer.fmt(" : (%s) (%s)", jitc_amd_type(v),
+                   jitc_amd_zero((VarType) v->type));
+    }
+
+    buffer.put(";\n");
+}
+
+void jitc_var_call_assemble_amd(CallData *call, uint32_t call_reg,
+                                uint32_t self_reg, uint32_t mask_reg,
+                                uint32_t /*in_size*/, uint32_t /*in_align*/,
+                                uint32_t /*out_size*/, uint32_t /*out_align*/) {
+    Variable *mask = jitc_var(jitc_var(call->id)->dep[1]);
+    bool is_masked = !mask->is_literal() || mask->literal != 1;
+
+    buffer.fmt("\n// VCall: %s\n", call->name.c_str());
+
+    std::vector<std::pair<Variable *, uint32_t>> out_regs;
+    out_regs.reserve(call->n_out);
+    for (uint32_t i = 0, k = 0; i < call->n_out; ++i) {
+        if (call->out_offset[i] == (uint32_t) -1)
+            continue;
+        Variable *v = jitc_var(call->outer_out[i]);
+        if (v && v->reg_index && v->param_type != ParamType::Input)
+            out_regs.emplace_back(v, k);
+        k++;
+    }
+
+    for (auto [v, field] : out_regs) {
+        (void) field;
+        buffer.fmt("%s r%u;\n", jitc_amd_type(v), v->reg_index);
+    }
+
+    if (is_masked)
+        buffer.fmt("if (r%u) {\n", mask_reg);
+
+    char base[32];
+    if (callable_depth == 0)
+        snprintf(base, sizeof(base), "r%u", call_buffer.base_reg);
+    else
+        snprintf(base, sizeof(base), "base");
+
+    bool has_slots = !call->slots.empty();
+
+    if (has_slots) {
+        buffer.fmt("uint64_t _oe_%u = ((const uint64_t *) (uintptr_t) %s)[%u + r%u];\n"
+                   "const uint8_t *_cd_%u = (const uint8_t *) ((uintptr_t) %s + "
+                   "(uint32_t) (_oe_%u >> 32));\n",
+                   call_reg, base,
+                   call->offset_base / (uint32_t) sizeof(uint64_t), self_reg,
+                   call_reg, base, call_reg);
+    }
+
+    bool has_out = jitc_amd_call_has_out(call);
+
+    if (has_out) {
+        jitc_amd_put_ret_type(call);
+        if (call->n_inst == 1)
+            buffer.fmt(" ret_%u = ", call_reg);
+        else
+            buffer.fmt(" ret_%u = {};\n", call_reg);
+    }
+
+    auto put_call = [&]() {
+        buffer.put("(");
+
+        if (callable_depth > 0)
+            buffer.put("index");
+        else
+            buffer.put("r0");
+
+        buffer.fmt(", r%u, ", self_reg);
+        if (has_slots)
+            buffer.fmt("_cd_%u", call_reg);
+        else
+            buffer.put("(const uint8_t *) nullptr");
+
+        if (call->use_nested)
+            buffer.fmt(", %s", base);
+
+        for (uint32_t i = 0; i < call->n_in; ++i)
+            if (call->in_active[i])
+                buffer.fmt(", r%u", jitc_var(call->outer_in[i])->reg_index);
+
+        buffer.put(")");
+    };
+
+    auto put_func = [&](XXH128_hash_t hash, bool unique) {
+        if (unique)
+            buffer.put("func_unique_");
+        else
+            buffer.put("func_");
+        buffer.put_q64_unchecked(hash.high64);
+        buffer.put_q64_unchecked(hash.low64);
+        put_call();
+    };
+
+    if (call->n_inst == 1) {
+        put_func(call->inst_hash[0], true);
+        buffer.put(";\n");
+    } else {
+        for (uint32_t i = 0; i < call->n_inst; ++i) {
+            if (i == 0)
+                buffer.fmt("if (r%u == %u) {\n", self_reg, call->inst_id[i]);
+            else
+                buffer.fmt("else if (r%u == %u) {\n", self_reg, call->inst_id[i]);
+
+            if (has_out)
+                buffer.fmt("ret_%u = ", call_reg);
+
+            put_func(call->inst_hash[i], false);
+            buffer.put(";\n}\n");
+        }
+    }
+
+    for (auto [v, field] : out_regs)
+        buffer.fmt("r%u = ret_%u.r%u;\n", v->reg_index, call_reg, field);
+
+    if (is_masked) {
+        if (!out_regs.empty()) {
+            buffer.put("} else {\n");
+            for (auto [v, field] : out_regs) {
+                (void) field;
+                buffer.fmt("r%u = (%s) (%s);\n",
+                           v->reg_index, jitc_amd_type(v),
+                           jitc_amd_zero((VarType) v->type));
+            }
+        }
+        buffer.put("}\n");
+    }
+
+    buffer.put("\n");
+}
+
+void jitc_amd_assemble(ThreadState *ts, ScheduledGroup group,
+                       uint32_t, uint32_t) {
+    bool uses_hiprt = false;
+    AMDScene *hiprt_scene_config = nullptr;
+    for (uint32_t gi = group.start; gi != group.end; ++gi) {
+        Variable *v = jitc_var(schedule[gi].index);
+        if ((VarKind) v->kind == VarKind::TraceRay) {
+            uses_hiprt = true;
+            AMDScene *scene = (AMDScene *) (uintptr_t) jitc_var(v->dep[1])->literal;
+            if (scene && scene->func_table) {
+                if (!hiprt_scene_config) {
+                    hiprt_scene_config = scene;
+                } else if (hiprt_scene_config->num_geom_types != scene->num_geom_types ||
+                           hiprt_scene_config->num_ray_types != scene->num_ray_types ||
+                           hiprt_scene_config->intersect_fns != scene->intersect_fns ||
+                           hiprt_scene_config->filter_fns != scene->filter_fns ||
+                           hiprt_scene_config->device_source != scene->device_source) {
+                    jitc_raise("jitc_amd_assemble(): a single HIPRT kernel "
+                               "cannot mix scenes with different custom "
+                               "function tables.");
+                }
+            }
+        }
+    }
+
+#if defined(DRJIT_ENABLE_HIPRT)
+    amd_kernel_func_name_sets.clear();
+    amd_kernel_device_source.clear();
+    amd_kernel_num_geom_types = 1;
+    amd_kernel_num_ray_types = 1;
+    if (hiprt_scene_config && hiprt_scene_config->num_geom_types &&
+        hiprt_scene_config->num_ray_types) {
+        amd_kernel_num_geom_types = hiprt_scene_config->num_geom_types;
+        amd_kernel_num_ray_types = hiprt_scene_config->num_ray_types;
+        uint32_t count = amd_kernel_num_geom_types * amd_kernel_num_ray_types;
+        amd_kernel_func_name_sets.resize(count);
+        for (uint32_t i = 0; i < count; ++i) {
+            const std::string &isect = hiprt_scene_config->intersect_fns[i];
+            const std::string &filter = hiprt_scene_config->filter_fns[i];
+            amd_kernel_func_name_sets[i].intersectFuncName =
+                isect.empty() ? nullptr : isect.c_str();
+            amd_kernel_func_name_sets[i].filterFuncName =
+                filter.empty() ? nullptr : filter.c_str();
+        }
+        amd_kernel_device_source = hiprt_scene_config->device_source;
+    }
+#endif
+
+    buffer.put(
+        "#include <stdint.h>\n"
+        "#include <hip/hip_runtime.h>\n"
+        "#include <hip/hip_fp16.h>\n"
+    );
+
+    if (uses_hiprt) {
+        buffer.put(
+            "#include <hiprt/hiprt_device.h>\n"
+            "#include <hiprt/hiprt_vec.h>\n"
+            "\n");
+#if defined(DRJIT_ENABLE_HIPRT)
+        if (hiprt_scene_config) {
+            buffer.fmt("// HIPRT scene properties: geom_types=%u ray_types=%u "
+                       "geom_mask=%u\n",
+                       hiprt_scene_config->num_geom_types,
+                       hiprt_scene_config->num_ray_types,
+                       hiprt_scene_config->geometry_types_mask);
+            for (size_t i = 0; i < hiprt_scene_config->intersect_fns.size(); ++i) {
+                buffer.fmt("// HIPRT fn[%u]: intersect=%s filter=%s\n",
+                           (uint32_t) i,
+                           hiprt_scene_config->intersect_fns[i].c_str(),
+                           hiprt_scene_config->filter_fns[i].c_str());
+            }
+            if (!amd_kernel_device_source.empty()) {
+                buffer.put(amd_kernel_device_source.c_str(),
+                           amd_kernel_device_source.size());
+                buffer.put("\n");
+            }
+        }
+#endif
+    } else {
+        buffer.put("\n");
+    }
+
+    buffer.put(
+        "template <typename To, typename From>\n"
+        "__device__ inline To drjit_bitcast(From value) {\n"
+        "    union { From from; To to; } u;\n"
+        "    u.from = value;\n"
+        "    return u.to;\n"
+        "}\n"
+        "\n"
+        "__device__ inline float drjit_bits_to_float(uint32_t value) {\n"
+        "    return drjit_bitcast<float>(value);\n"
+        "}\n"
+        "\n"
+        "__device__ inline double drjit_bits_to_double(uint64_t value) {\n"
+        "    return drjit_bitcast<double>(value);\n"
+        "}\n"
+        "\n"
+        "template <typename T> __device__ inline T drjit_min(T a, T b) { return a < b ? a : b; }\n"
+        "template <typename T> __device__ inline T drjit_max(T a, T b) { return a > b ? a : b; }\n"
+        "template <typename T> __device__ inline T drjit_abs(T a) { return a < (T) 0 ? -a : a; }\n"
+        "__device__ inline __half drjit_fma(__half a, __half b, __half c) { return (__half) fmaf((float) a, (float) b, (float) c); }\n"
+        "__device__ inline __half drjit_sqrt(__half a) { return (__half) sqrtf((float) a); }\n"
+        "__device__ inline __half drjit_sin(__half a) { return (__half) sinf((float) a); }\n"
+        "__device__ inline __half drjit_cos(__half a) { return (__half) cosf((float) a); }\n"
+        "__device__ inline __half drjit_exp2(__half a) { return (__half) exp2f((float) a); }\n"
+        "__device__ inline __half drjit_log2(__half a) { return (__half) log2f((float) a); }\n"
+        "__device__ inline __half drjit_tanh(__half a) { return (__half) tanhf((float) a); }\n"
+        "__device__ inline __half drjit_rsqrt(__half a) { return (__half) (1.0f / sqrtf((float) a)); }\n"
+        "__device__ inline __half drjit_ceil(__half a) { return (__half) ceilf((float) a); }\n"
+        "__device__ inline __half drjit_floor(__half a) { return (__half) floorf((float) a); }\n"
+        "__device__ inline __half drjit_rint(__half a) { return (__half) rintf((float) a); }\n"
+        "__device__ inline __half drjit_trunc(__half a) { return (__half) truncf((float) a); }\n"
+        "\n"
+        "__device__ inline uint8_t drjit_mul_hi(uint8_t a, uint8_t b) { return (uint8_t) (((uint16_t) a * (uint16_t) b) >> 8); }\n"
+        "__device__ inline int8_t drjit_mul_hi(int8_t a, int8_t b) { return (int8_t) (((int16_t) a * (int16_t) b) >> 8); }\n"
+        "__device__ inline uint16_t drjit_mul_hi(uint16_t a, uint16_t b) { return (uint16_t) (((uint32_t) a * (uint32_t) b) >> 16); }\n"
+        "__device__ inline int16_t drjit_mul_hi(int16_t a, int16_t b) { return (int16_t) (((int32_t) a * (int32_t) b) >> 16); }\n"
+        "__device__ inline uint32_t drjit_mul_hi(uint32_t a, uint32_t b) { return (uint32_t) (((uint64_t) a * (uint64_t) b) >> 32); }\n"
+        "__device__ inline int32_t drjit_mul_hi(int32_t a, int32_t b) { return (int32_t) (((int64_t) a * (int64_t) b) >> 32); }\n"
+        "__device__ inline uint64_t drjit_mul_hi(uint64_t a, uint64_t b) { return (uint64_t) (((unsigned __int128) a * (unsigned __int128) b) >> 64); }\n"
+        "__device__ inline int64_t drjit_mul_hi(int64_t a, int64_t b) { return (int64_t) (((__int128) a * (__int128) b) >> 64); }\n"
+        "\n");
+
+    size_t kernel_start = buffer.size();
+
+    buffer.put(
+        "extern \"C\" __global__ void drjit_^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^(void **params) {\n"
+        "uint32_t r0 = (uint32_t) (blockIdx.x * blockDim.x + threadIdx.x);\n"
+        "uint32_t size = (uint32_t) (uintptr_t) params[0];\n"
+        "if (r0 >= size) return;\n");
+    if (call_buffer.base_v)
+        buffer.fmt("uintptr_t r%u = (uintptr_t) params[%u];\n",
+                   call_buffer.base_reg, call_buffer.base_param_index);
+    buffer.put("\nbody:\n");
+
+    for (uint32_t gi = group.start; gi != group.end; ++gi) {
+        uint32_t index = schedule[gi].index;
+        Variable *v = jitc_var(index);
+        ParamType ptype = (ParamType) v->param_type;
+
+        if (ptype == ParamType::Input) {
+            uint32_t slot = jitc_amd_param_slot(v);
+
+            if (v->is_literal()) {
+                jitc_amd_emit_decl(v);
+                if ((VarType) v->type == VarType::Pointer)
+                    buffer.fmt("(uintptr_t) params[%u]", slot);
+                else
+                    jitc_amd_literal(v);
+                buffer.put(";\n");
+                continue;
+            }
+
+            if (v->is_array()) {
+                jitc_amd_render_array_memcpy_in(v, slot);
+                continue;
+            }
+
+            jitc_amd_emit_decl(v);
+            if (v->size > 1) {
+                buffer.fmt("((const %s *) params[%u])[r0]",
+                           jitc_amd_type(v), slot);
+            } else {
+                buffer.fmt("*((const %s *) params[%u])",
+                           jitc_amd_type(v), slot);
+            }
+            buffer.put(";\n");
+            continue;
+        }
+
+        jitc_amd_render(v);
+
+        if (ptype == ParamType::Output) {
+            if (v->is_array()) {
+                jitc_amd_render_array_memcpy_out(v, jitc_amd_param_slot(v));
+                continue;
+            }
+
+            buffer.fmt("((%s *) params[%u])[r0] = ",
+                       jitc_amd_type(v), jitc_amd_param_slot(v));
+            jitc_amd_var(v);
+            buffer.put(";\n");
+        }
+    }
+
+    buffer.put("}\n");
+
+    if (!globals_map.empty()) {
+        size_t suffix_start = buffer.size();
+
+        auto emit_globals = [](GlobalType type) {
+            for (auto &it : globals_map) {
+                if (it.first.type != type)
+                    continue;
+                buffer.put('\n');
+                buffer.put(globals.get() + it.second.start, it.second.length);
+                buffer.put('\n');
+            }
+        };
+
+        auto emit_callable_decls = [](GlobalType type) {
+            for (auto &it : globals_map) {
+                if (it.first.type != type)
+                    continue;
+
+                const char *sig = globals.get() + it.second.start;
+                const char *brace =
+                    (const char *) memchr(sig, '{', it.second.length);
+                if (!brace)
+                    continue;
+
+                size_t sig_len = (size_t) (brace - sig);
+                while (sig_len > 0 &&
+                       (sig[sig_len - 1] == ' ' ||
+                        sig[sig_len - 1] == '\n' ||
+                        sig[sig_len - 1] == '\r' ||
+                        sig[sig_len - 1] == '\t'))
+                    --sig_len;
+
+                buffer.put(sig, sig_len);
+                buffer.put(";\n");
+            }
+        };
+
+        emit_globals(GlobalType::Type);
+        emit_globals(GlobalType::Global);
+        emit_callable_decls(GlobalType::IndirectCallable);
+        emit_callable_decls(GlobalType::Callable);
+        emit_globals(GlobalType::IndirectCallable);
+        emit_globals(GlobalType::Callable);
+
+        if (suffix_start != buffer.size())
+            buffer.move_suffix(suffix_start, kernel_start);
+    }
+
+    jitc_call_upload(ts);
+}
+
+bool jitc_amd_compile(ThreadState *ts, const char *source,
+                      size_t source_size, const char *kernel_name,
+                      Kernel &kernel) {
+    if (!ts->amd_arch || !*ts->amd_arch)
+        jitc_raise("jitc_amd_compile(): the active HIP device does not report "
+                   "an AMDGPU architecture.");
+
+    auto normalize_path = [](std::string value) {
+        for (char &c : value)
+            if (c == '\\')
+                c = '/';
+        return value;
+    };
+
+    std::vector<std::string> option_storage;
+    option_storage.push_back(std::string("--gpu-architecture=") +
+                             ts->amd_arch);
+
+    auto add_include = [&](const char *path) {
+        if (path && *path)
+            option_storage.push_back(std::string("-I") + normalize_path(path));
+    };
+
+    if (const char *rocm_home = getenv("ROCM_HOME"))
+        add_include((std::string(rocm_home) + "/include").c_str());
+    else if (const char *hip_path = getenv("HIP_PATH"))
+        add_include((std::string(hip_path) + "/include").c_str());
+
+#if defined(DRJIT_HIPRT_ROOT)
+    add_include(DRJIT_HIPRT_ROOT);
+#endif
+#if defined(DRJIT_CORE_RESOURCE_DIR)
+    add_include(DRJIT_CORE_RESOURCE_DIR);
+#endif
+    add_include(getenv("HIPRT_ROOT"));
+
+    std::vector<const char *> options {
+        "-std=c++17",
+        "-O3"
+    };
+    for (const std::string &option : option_storage)
+        options.push_back(option.c_str());
+
+    hip_check(hipCtxSetCurrent(ts->amd_context));
+
+    bool uses_hiprt = strstr(source, "hiprtSceneTraversal") != nullptr;
+    size_t code_size = source_size;
+
+    if (uses_hiprt) {
+#if defined(DRJIT_ENABLE_HIPRT)
+#if defined(DRJIT_HIPRT_ROOT)
+        if (!getenv("HIPRT_PATH")) {
+#  if defined(_WIN32)
+            _putenv_s("HIPRT_PATH", DRJIT_HIPRT_ROOT);
+#  else
+            setenv("HIPRT_PATH", DRJIT_HIPRT_ROOT, 0);
+#  endif
+        }
+#endif
+
+        AMDDevice &device = state.amd_devices[(size_t) ts->device];
+
+        if (!device.hiprt_context) {
+            hiprtContextCreationInput input {};
+            input.ctxt = (hiprtApiCtx) ts->amd_context;
+            input.device = (hiprtApiDevice) ts->amd_raw_device;
+            input.deviceType = hiprtDeviceAMD;
+
+            hiprtContext context = nullptr;
+            hiprtError err =
+                hiprtCreateContext(HIPRT_API_VERSION, input, context);
+            if (err != hiprtSuccess)
+                jitc_raise("jitc_amd_compile(): hiprtCreateContext() failed "
+                           "with error %u.", (uint32_t) err);
+            hiprtSetLogLevel(context, hiprtLogLevelError);
+            device.hiprt_context = context;
+        }
+
+        const char *func_name = kernel_name;
+        std::string hiprt_module_name = std::string(kernel_name) + ".hip";
+        hiprtApiFunction function = nullptr;
+        hiprtApiModule module = nullptr;
+        hiprtError err = hiprtBuildTraceKernels(
+            (hiprtContext) device.hiprt_context,
+            1, &func_name,
+            source, hiprt_module_name.c_str(),
+            0, nullptr, nullptr,
+            (uint32_t) options.size(), options.data(),
+            amd_kernel_num_geom_types, amd_kernel_num_ray_types,
+            amd_kernel_func_name_sets.empty()
+                ? nullptr
+                : amd_kernel_func_name_sets.data(),
+            &function, &module,
+            true);
+
+        if (err != hiprtSuccess)
+            jitc_raise("jitc_amd_compile(): hiprtBuildTraceKernels() failed "
+                       "with error %u.", (uint32_t) err);
+
+        kernel.amd.mod = (hipModule_t) module;
+        kernel.amd.func = (hipFunction_t) function;
+        kernel.amd.hiprt_owned = true;
+#else
+        jitc_raise("jitc_amd_compile(): this Dr.Jit build was configured "
+                   "without HIPRT support.");
+#endif
+    } else {
+        hiprtcProgram program = nullptr;
+        hiprtc_check(hiprtcCreateProgram(&program, source, "drjit_amd.hip", 0,
+                                         nullptr, nullptr));
+
+        hiprtcResult result =
+            hiprtcCompileProgram(program, (int) options.size(), options.data());
+
+        size_t log_size = 0;
+        hiprtc_check(hiprtcGetProgramLogSize(program, &log_size));
+        std::vector<char> compile_log;
+        if (log_size > 1) {
+            compile_log.resize(log_size);
+            hiprtc_check(hiprtcGetProgramLog(program, compile_log.data()));
+        }
+
+        if (result != HIPRTC_SUCCESS) {
+            std::string log = compile_log.empty() ? "" : compile_log.data();
+            hiprtcDestroyProgram(&program);
+            jitc_raise("jitc_amd_compile(): HIPRTC compilation failed: %s\n%s",
+                       hiprtcGetErrorString(result), log.c_str());
+        } else if (!compile_log.empty()) {
+            jitc_log(Debug, "jitc_amd_compile(): HIPRTC log:\n%s",
+                     compile_log.data());
+        }
+
+        hiprtc_check(hiprtcGetCodeSize(program, &code_size));
+        std::vector<char> code(code_size);
+        hiprtc_check(hiprtcGetCode(program, code.data()));
+        hiprtc_check(hiprtcDestroyProgram(&program));
+
+        hip_check(hipModuleLoadData(&kernel.amd.mod, code.data()));
+        hip_check(hipModuleGetFunction(&kernel.amd.func, kernel.amd.mod,
+                                       kernel_name));
+        kernel.amd.hiprt_owned = false;
+    }
+
+    int unused = 0, block_size = 0;
+    hipError_t occ = hipModuleOccupancyMaxPotentialBlockSize(
+        &unused, &block_size, kernel.amd.func, 0, 0);
+    if (occ == hipSuccess && block_size > 0)
+        kernel.amd.block_size = (uint32_t) block_size;
+    else
+        kernel.amd.block_size = ts->amd_max_threads ? ts->amd_max_threads : 256;
+
+    kernel.data = nullptr;
+    kernel.size = (uint32_t) code_size;
+    (void) source_size;
+    return false;
+}
+
+#endif

--- a/src/amd_gemm.h
+++ b/src/amd_gemm.h
@@ -1,0 +1,5 @@
+#pragma once
+
+static const char *jitc_amd_gemm_source = R"drjit_amd_gemm(
+#include "gemm.cuh"
+)drjit_amd_gemm";

--- a/src/amd_misc.h
+++ b/src/amd_misc.h
@@ -1,0 +1,8 @@
+#pragma once
+
+static const char *jitc_amd_misc_source = R"drjit_amd_misc(
+// amd-misc-resource-version: hip-shared-runtime-kernels-1
+#include "misc.cuh"
+#include "compress.cuh"
+#include "mkperm.cuh"
+)drjit_amd_misc";

--- a/src/amd_reduce.h
+++ b/src/amd_reduce.h
@@ -1,0 +1,8 @@
+#pragma once
+
+static const char *jitc_amd_reduce_source = R"drjit_amd_reduce(
+// amd-reduce-resource-version: reduced-stage-active-mask
+#include "block_reduce.cuh"
+#include "block_prefix_reduce.cuh"
+#include "reduce_2.cuh"
+)drjit_amd_reduce";

--- a/src/amd_rt.cpp
+++ b/src/amd_rt.cpp
@@ -1,0 +1,246 @@
+/*
+    src/amd_rt.cpp -- HIPRT scene and TraceRay plumbing for the AMD backend
+*/
+
+#include "amd_rt.h"
+
+#if defined(DRJIT_ENABLE_AMD)
+
+#include "internal.h"
+#include "log.h"
+#include "trace.h"
+#include "var.h"
+
+#include <algorithm>
+#include <array>
+
+uint32_t jitc_amd_configure_scene_ex(
+        void *scene_handle, void *func_table, uint32_t num_geom_types,
+        uint32_t num_ray_types, const char **intersect_function_names,
+        const char **filter_function_names, const char *device_source,
+        uint32_t geometry_types_mask) {
+    jitc_log(InfoSym,
+             "jit_amd_configure_scene(scene=" DRJIT_PTR ", func_table="
+             DRJIT_PTR ", geom_types=%u, ray_types=%u, geom_mask=%u)",
+             (uintptr_t) scene_handle, (uintptr_t) func_table,
+             num_geom_types, num_ray_types, geometry_types_mask);
+
+    AMDScene *scene = new AMDScene();
+    scene->scene = scene_handle;
+    scene->func_table = func_table;
+    scene->geometry_types_mask = geometry_types_mask;
+    scene->num_geom_types = num_geom_types;
+    scene->num_ray_types = num_ray_types;
+
+    uint32_t fn_count = num_geom_types * num_ray_types;
+    scene->intersect_fns.reserve(fn_count);
+    scene->filter_fns.reserve(fn_count);
+    for (uint32_t i = 0; i < fn_count; ++i) {
+        scene->intersect_fns.emplace_back(
+            intersect_function_names && intersect_function_names[i]
+                ? intersect_function_names[i] : "");
+        scene->filter_fns.emplace_back(
+            filter_function_names && filter_function_names[i]
+                ? filter_function_names[i] : "");
+    }
+    if (device_source)
+        scene->device_source = device_source;
+
+    uint32_t index =
+        jitc_var_new_node_0(JitBackend::AMD, VarKind::Nop, VarType::Void,
+                            1, 0, (uintptr_t) scene);
+
+    auto callback = [](uint32_t, int free, void *ptr) {
+        if (!free)
+            return;
+
+        AMDScene *scene = (AMDScene *) ptr;
+        jitc_log(InfoSym,
+                 "jit_amd_configure_scene(): freeing AMDScene(scene="
+                 DRJIT_PTR ")",
+                 (uintptr_t) scene->scene);
+
+        if (scene->scene_handle)
+            jitc_var_dec_ref(scene->scene_handle);
+        if (scene->func_table_handle)
+            jitc_var_dec_ref(scene->func_table_handle);
+
+        void (*cleanup)(void *) = scene->cleanup;
+        void *cleanup_payload = scene->cleanup_payload;
+        delete scene;
+
+        if (cleanup)
+            cleanup(cleanup_payload);
+    };
+
+    jitc_var_set_callback(index, callback, scene, true);
+    return index;
+}
+
+uint32_t jitc_amd_configure_scene(void *scene_handle,
+                                  uint32_t geometry_types_mask) {
+    return jitc_amd_configure_scene_ex(scene_handle, nullptr, 0, 0,
+                                       nullptr, nullptr, nullptr,
+                                       geometry_types_mask);
+}
+
+AMDScene *jitc_amd_get_scene(uint32_t scene_index) {
+    Variable *v = scene_index ? jitc_var(scene_index) : nullptr;
+    if (!v || (VarKind) v->kind != VarKind::Nop ||
+        (VarType) v->type != VarType::Void)
+        jitc_fail("jitc_amd_get_scene(): r%u does not wrap a HIPRT scene.",
+                  scene_index);
+    return (AMDScene *) v->literal;
+}
+
+uint32_t jitc_amd_scene_resource_handle(AMDScene *scene) {
+    if (!scene || !scene->scene)
+        return 0;
+
+    if (!scene->scene_handle) {
+        uint32_t backing =
+            jitc_var_mem_map(JitBackend::AMD, VarType::UInt64,
+                             (void *) scene, 1, /* free = */ 0);
+        scene->scene_handle =
+            jitc_var_resource_pointer(backing, ResourceKind::Accel);
+        jitc_var_dec_ref(backing);
+    }
+
+    jitc_var_inc_ref(scene->scene_handle);
+    return scene->scene_handle;
+}
+
+static uint32_t jitc_amd_scene_func_table_resource_handle(AMDScene *scene) {
+    if (!scene || !scene->func_table)
+        return 0;
+
+    if (!scene->func_table_handle) {
+        uint32_t backing =
+            jitc_var_mem_map(JitBackend::AMD, VarType::UInt64,
+                             (void *) scene, 1, /* free = */ 0);
+        scene->func_table_handle =
+            jitc_var_resource_pointer(backing, ResourceKind::IFT);
+        jitc_var_dec_ref(backing);
+    }
+
+    jitc_var_inc_ref(scene->func_table_handle);
+    return scene->func_table_handle;
+}
+
+uint32_t jitc_amd_scene_owner_handle(uint32_t scene_index) {
+    AMDScene *scene = jitc_amd_get_scene(scene_index);
+    return jitc_var_mem_map(JitBackend::AMD, VarType::UInt64,
+                            (void *) scene, 1, /* free = */ 0);
+}
+
+uint32_t jitc_amd_scene_func_table_handle(uint32_t scene_index) {
+    AMDScene *scene = jitc_amd_get_scene(scene_index);
+    if (!scene->func_table)
+        return 0;
+    return jitc_var_mem_map(JitBackend::AMD, VarType::UInt64,
+                            scene->func_table, 1, /* free = */ 0);
+}
+
+void jitc_amd_ray_trace(uint32_t n_args, uint32_t *args,
+                        uint32_t mask, uint32_t *out,
+                        uint32_t n_out, uint32_t scene, int shadow) {
+    if (n_args != 8)
+        jitc_raise("jit_amd_ray_trace(): expected 8 ray arguments, got %u.",
+                   n_args);
+    if (n_out != 8)
+        jitc_raise("jit_amd_ray_trace(): expected 8 outputs, got %u.", n_out);
+    if (!scene)
+        jitc_raise("jit_amd_ray_trace(): a valid scene_index "
+                   "(returned by jit_amd_configure_scene) is required.");
+
+    if (jitc_var_type(scene) != VarType::Void)
+        jitc_raise("jit_amd_ray_trace(): type mismatch for scene argument!");
+
+    std::array<Ref, 8> promoted_literals;
+    uint32_t trace_args[8];
+
+    uint32_t size = 0;
+    bool symbolic = false;
+    for (uint32_t i = 0; i < n_args; ++i) {
+        const Variable *vi = jitc_var(args[i]);
+        if ((VarType) vi->type != VarType::Float32)
+            jitc_raise("jit_amd_ray_trace(): type mismatch for arg. %u "
+                       "(got %s, expected Float32).", i,
+                       type_name[vi->type]);
+
+        trace_args[i] = args[i];
+        if (vi->is_literal() && vi->size == 1) {
+            promoted_literals[i] =
+                steal(jitc_var_literal(JitBackend::AMD, VarType::Float32,
+                                        &vi->literal, 1, /* eval = */ 1));
+            trace_args[i] = promoted_literals[i];
+            vi = jitc_var(trace_args[i]);
+        }
+
+        size = std::max(size, vi->size);
+        symbolic |= (bool) vi->symbolic;
+    }
+
+    const Variable *vm = jitc_var(mask);
+    size = std::max(size, vm->size);
+    symbolic |= (bool) vm->symbolic;
+
+    if (size == 0)
+        size = 1;
+
+    Ref valid = steal(jitc_var_mask_apply(mask, size));
+
+    TraceData *td = new TraceData();
+    td->shadow = shadow != 0;
+    td->indices.reserve(n_args);
+    for (uint32_t i = 0; i < n_args; ++i) {
+        td->indices.push_back(trace_args[i]);
+        jitc_var_inc_ref(trace_args[i]);
+    }
+
+    AMDScene *scene_obj = jitc_amd_get_scene(scene);
+    Ref scene_h = steal(jitc_amd_scene_resource_handle(scene_obj));
+    if (!scene_h)
+        jitc_raise("jit_amd_ray_trace(): scene has no HIPRT handle.");
+    Ref func_h = steal(jitc_amd_scene_func_table_resource_handle(scene_obj));
+
+    Ref trace;
+    if (func_h) {
+        trace = steal(jitc_var_new_node_4(
+            JitBackend::AMD, VarKind::TraceRay, VarType::Void, size, symbolic,
+            valid, jitc_var(valid), scene, jitc_var(scene),
+            scene_h, jitc_var(scene_h), func_h, jitc_var(func_h),
+            (uintptr_t) td));
+    } else {
+        trace = steal(jitc_var_new_node_3(
+            JitBackend::AMD, VarKind::TraceRay, VarType::Void, size, symbolic,
+            valid, jitc_var(valid), scene, jitc_var(scene),
+            scene_h, jitc_var(scene_h), (uintptr_t) td));
+    }
+
+    jitc_var_set_callback(
+        trace,
+        [](uint32_t, int free, void *ptr) {
+            if (free)
+                delete (TraceData *) ptr;
+        },
+        td, true);
+
+    VarType out_types[8] = {
+        VarType::Bool,    // valid
+        VarType::Float32, // distance
+        VarType::Float32, // bary_u
+        VarType::Float32, // bary_v
+        VarType::UInt32,  // instance_id
+        VarType::UInt32,  // primitive_id
+        VarType::UInt32,  // geometry_id
+        VarType::UInt32   // user_instance_id
+    };
+
+    for (uint32_t i = 0; i < (td->shadow ? 1u : 8u); ++i)
+        out[i] = jitc_var_new_node_1(
+            JitBackend::AMD, VarKind::Extract, out_types[i],
+            size, symbolic, trace, jitc_var(trace), (uint64_t) i);
+}
+
+#endif // defined(DRJIT_ENABLE_AMD)

--- a/src/amd_rt.h
+++ b/src/amd_rt.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "common.h"
+
+#if defined(DRJIT_ENABLE_AMD)
+
+#include <string>
+#include <vector>
+
+/// Per-scene HIPRT state. One instance is allocated by
+/// ``jit_amd_configure_scene`` and wrapped in a Void JIT variable so that
+/// pending/frozen trace nodes keep the application-owned HIPRT scene alive.
+struct AMDScene {
+    /// hiprtScene handle. Not retained by Dr.Jit; the caller owns it.
+    void *scene = nullptr;
+
+    /// Bit 0 = triangles, bit 3 = triangle backface culling. Other bits are
+    /// reserved to match the Metal scene mask and rejected by the first pass.
+    uint32_t geometry_types_mask = 0;
+
+    /// Cached resource-handle variable for ``scene``.
+    uint32_t scene_handle = 0;
+
+    /// Optional hiprtFuncTable handle plus cached resource variable.
+    void *func_table = nullptr;
+    uint32_t func_table_handle = 0;
+
+    /// Custom function-table layout used by hiprtBuildTraceKernels().
+    uint32_t num_geom_types = 0;
+    uint32_t num_ray_types = 0;
+    std::vector<std::string> intersect_fns;
+    std::vector<std::string> filter_fns;
+    std::string device_source;
+
+    /// Invoked once after this wrapper is destroyed, letting the application
+    /// release the HIPRT scene and associated geometry buffers.
+    void (*cleanup)(void *) = nullptr;
+    void *cleanup_payload = nullptr;
+};
+
+extern uint32_t jitc_amd_configure_scene(void *scene,
+                                         uint32_t geometry_types_mask);
+extern uint32_t jitc_amd_configure_scene_ex(
+    void *scene, void *func_table, uint32_t num_geom_types,
+    uint32_t num_ray_types, const char **intersect_function_names,
+    const char **filter_function_names, const char *device_source,
+    uint32_t geometry_types_mask);
+extern AMDScene *jitc_amd_get_scene(uint32_t scene_index);
+extern uint32_t jitc_amd_scene_resource_handle(AMDScene *scene);
+extern uint32_t jitc_amd_scene_func_table_handle(uint32_t scene_index);
+extern uint32_t jitc_amd_scene_owner_handle(uint32_t scene_index);
+extern void jitc_amd_ray_trace(uint32_t n_args, uint32_t *args,
+                               uint32_t mask, uint32_t *out,
+                               uint32_t n_out, uint32_t scene, int shadow);
+
+#endif // defined(DRJIT_ENABLE_AMD)

--- a/src/amd_ts.cpp
+++ b/src/amd_ts.cpp
@@ -1,0 +1,1054 @@
+#include "amd_ts.h"
+
+#if defined(DRJIT_ENABLE_AMD)
+
+#include "amd_api.h"
+#include "amd_gemm.h"
+#include "amd_misc.h"
+#include "amd_reduce.h"
+#include "amd_rt.h"
+#include "eval.h"
+#include "internal.h"
+#include "log.h"
+#include "malloc.h"
+#include "util.h"
+#include "var.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
+#include <vector>
+
+static hipFunction_t jitc_amd_builtin_function(AMDThreadState *ts,
+                                               const char *source,
+                                               std::vector<hipModule_t> &modules,
+                                               const char *name) {
+    size_t device_count = state.amd_devices.size();
+    if (modules.size() < device_count)
+        modules.resize(device_count, nullptr);
+
+    hipModule_t &module = modules[(size_t) ts->device];
+    if (!module) {
+        Kernel kernel;
+        memset(&kernel, 0, sizeof(Kernel));
+
+        jitc_amd_compile(ts, source, strlen(source), name, kernel);
+
+        AMDDevice &dev = state.amd_devices[(size_t) ts->device];
+        module = kernel.amd.mod;
+        dev.modules.push_back(module);
+        return kernel.amd.func;
+    }
+
+    hipFunction_t result = nullptr;
+    hip_check(hipModuleGetFunction(&result, module, name));
+    return result;
+}
+
+static std::vector<hipFunction_t>
+    jitc_amd_gemm[(int) VarType::Count][4][3];
+static std::vector<hipModule_t> jitc_amd_gemm_module;
+static std::vector<hipModule_t> jitc_amd_misc_module;
+static std::vector<hipModule_t> jitc_amd_reduce_module;
+
+static hipFunction_t jitc_amd_gemm_function(AMDThreadState *ts, VarType vt,
+                                            int tile, int transpose) {
+    if (vt != VarType::Float16 && vt != VarType::Float32 &&
+        vt != VarType::Float64)
+        return nullptr;
+
+    std::vector<hipFunction_t> &functions =
+        jitc_amd_gemm[(int) vt][tile][transpose];
+    size_t device_count = state.amd_devices.size();
+    if (functions.size() < device_count)
+        functions.resize(device_count, nullptr);
+
+    hipFunction_t &slot = functions[(size_t) ts->device];
+    if (slot)
+        return slot;
+
+    static const char *gemm_suffix[3] = { "nn", "nt", "tn" };
+    char name[128];
+    snprintf(name, sizeof(name), "gemm_%s_%u_%s",
+             type_name_short[(int) vt], 8u << tile,
+             gemm_suffix[transpose]);
+
+    slot = jitc_amd_builtin_function(ts, jitc_amd_gemm_source,
+                                     jitc_amd_gemm_module, name);
+
+    return slot;
+}
+
+static VarType amd_make_int_type_unsigned(VarType type) {
+    switch (type) {
+        case VarType::Int8:  return VarType::UInt8;
+        case VarType::Int16: return VarType::UInt16;
+        case VarType::Int32: return VarType::UInt32;
+        case VarType::Int64: return VarType::UInt64;
+        default: return type;
+    }
+}
+
+static hipFunction_t jitc_amd_reduce_function(AMDThreadState *ts,
+                                              const char *name) {
+    return jitc_amd_builtin_function(ts, jitc_amd_reduce_source,
+                                     jitc_amd_reduce_module, name);
+}
+
+static hipFunction_t jitc_amd_block_reduce_function(AMDThreadState *ts,
+                                                    ReduceOp op, VarType vt,
+                                                    int kernel_id) {
+    char name[128];
+    snprintf(name, sizeof(name), "block_reduce_%s_%s_%u",
+             red_name[(int) op], type_name_short[(int) vt],
+             1u << (kernel_id + 1));
+    return jitc_amd_reduce_function(ts, name);
+}
+
+static hipFunction_t jitc_amd_block_reduce_vec_function(AMDThreadState *ts,
+                                                        ReduceOp op,
+                                                        VarType vt) {
+    char name[128];
+    snprintf(name, sizeof(name), "block_reduce_%s_%s_vec_1024",
+             red_name[(int) op], type_name_short[(int) vt]);
+    return jitc_amd_reduce_function(ts, name);
+}
+
+static hipFunction_t jitc_amd_block_prefix_reduce_function(AMDThreadState *ts,
+                                                           ReduceOp op,
+                                                           VarType vt,
+                                                           int kernel_id) {
+    char name[128];
+    snprintf(name, sizeof(name), "block_prefix_reduce_%s_%s_%u",
+             red_name[(int) op], type_name_short[(int) vt],
+             1u << (kernel_id + 1));
+    return jitc_amd_reduce_function(ts, name);
+}
+
+static hipFunction_t jitc_amd_reduce_dot_function(AMDThreadState *ts,
+                                                  VarType vt) {
+    char name[128];
+    snprintf(name, sizeof(name), "reduce_dot_%s", type_name_short[(int) vt]);
+    return jitc_amd_reduce_function(ts, name);
+}
+
+static hipFunction_t jitc_amd_misc_function(AMDThreadState *ts,
+                                            const char *name) {
+    return jitc_amd_builtin_function(ts, jitc_amd_misc_source,
+                                     jitc_amd_misc_module, name);
+}
+
+static hipFunction_t jitc_amd_poke_function(AMDThreadState *ts, VarType vt) {
+    char name[128];
+    snprintf(name, sizeof(name), "poke_%s", type_name_short[(int) vt]);
+    return jitc_amd_misc_function(ts, name);
+}
+
+static void amd_submit_gpu(AMDThreadState *ts, KernelType type,
+                           hipFunction_t kernel, uint32_t block_count_x,
+                           uint32_t thread_count,
+                           uint32_t shared_mem_bytes, void **args,
+                           uint32_t width, uint32_t block_count_y = 1,
+                           uint32_t block_count_z = 1) {
+    KernelHistoryEntry entry = {};
+    uint32_t flags = jit_flags();
+
+    hip_check(hipCtxSetCurrent(ts->amd_context));
+
+    if (unlikely(flags & (uint32_t) JitFlag::KernelHistory)) {
+        hip_check(hipEventCreate((hipEvent_t *) &entry.event_start));
+        hip_check(hipEventCreate((hipEvent_t *) &entry.event_end));
+        hip_check(hipEventRecord((hipEvent_t) entry.event_start,
+                                 ts->amd_stream));
+    }
+
+    hip_check(hipModuleLaunchKernel(kernel, block_count_x, block_count_y,
+                                    block_count_z, thread_count, 1, 1,
+                                    shared_mem_bytes, ts->amd_stream, args,
+                                    nullptr));
+
+    if (unlikely(flags & (uint32_t) JitFlag::LaunchBlocking))
+        hip_check(hipStreamSynchronize(ts->amd_stream));
+
+    if (unlikely(flags & (uint32_t) JitFlag::KernelHistory)) {
+        entry.backend = JitBackend::AMD;
+        entry.type = type;
+        entry.recording_mode = ts->recording_mode;
+        entry.size = width;
+        entry.input_count = 1;
+        entry.output_count = 1;
+        hip_check(hipEventRecord((hipEvent_t) entry.event_end,
+                                 ts->amd_stream));
+        state.kernel_history.append(entry);
+    }
+}
+
+Task *AMDThreadState::launch(Kernel kernel, KernelKey &, XXH128_hash_t,
+                             uint32_t size, std::vector<void *> &kernel_params,
+                             const std::vector<uint32_t> &,
+                             KernelHistoryEntry *kernel_history_entry) {
+    if (kernel_history_entry) {
+        auto &e = *kernel_history_entry;
+        hip_check(hipEventCreate((hipEvent_t *) &e.event_start));
+        hip_check(hipEventCreate((hipEvent_t *) &e.event_end));
+        hip_check(hipEventRecord((hipEvent_t) e.event_start, amd_stream));
+    }
+
+    uint32_t kernel_param_count = (uint32_t) kernel_params.size();
+    size_t param_size = (size_t) kernel_param_count * sizeof(void *);
+
+    const KernelParamInfo *info = kernel.param_info;
+    if (info) {
+        for (uint32_t i = 1; i < kernel_param_count; ++i) {
+            AMDScene *scene = (AMDScene *) kernel_params[i];
+            switch ((ResourceKind) info[i].kind) {
+                case ResourceKind::Accel:
+                    kernel_params[i] = scene ? scene->scene : nullptr;
+                    break;
+
+                case ResourceKind::IFT:
+                    kernel_params[i] = scene ? scene->func_table : nullptr;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
+
+    uint8_t *params_global =
+        (uint8_t *) jitc_malloc(JitBackend::AMD, param_size);
+
+    hip_check(hipCtxSetCurrent(amd_context));
+    hip_check(hipMemcpy(params_global, kernel_params.data(), param_size,
+                        hipMemcpyHostToDevice));
+
+    uint32_t block_count = 0, thread_count = 0;
+    const AMDDevice &device_ = state.amd_devices[this->device];
+    device_.get_launch_config(&block_count, &thread_count, size,
+                              kernel.amd.block_size
+                                  ? kernel.amd.block_size
+                                  : amd_max_threads);
+
+    void *args[] = { &params_global };
+    hip_check(hipModuleLaunchKernel(kernel.amd.func,
+                                    block_count, 1, 1,
+                                    thread_count, 1, 1,
+                                    0, amd_stream, args, nullptr));
+
+    jitc_trace("jit_run(): launching %u thread%s in %u block%s ..",
+               thread_count, thread_count == 1 ? "" : "s", block_count,
+               block_count == 1 ? "" : "s");
+
+    if (unlikely(jit_flag(JitFlag::LaunchBlocking)))
+        hip_check(hipStreamSynchronize(amd_stream));
+
+    hip_check(hipLaunchHostFunc(
+        amd_stream,
+        [](void *payload) { jitc_free(payload); },
+        params_global));
+
+    if (kernel_history_entry) {
+        hip_check(hipEventRecord((hipEvent_t) kernel_history_entry->event_end,
+                                 amd_stream));
+        state.kernel_history.append(*kernel_history_entry);
+    }
+
+    return nullptr;
+}
+
+void AMDThreadState::memset_async(void *ptr, uint32_t size_, uint32_t isize,
+                                  const void *src) {
+    if (isize != 1 && isize != 2 && isize != 4 && isize != 8)
+        jitc_raise("jit_memset_async(): invalid element size (must be 1, 2, "
+                   "4, or 8)!");
+
+    jitc_trace("jit_memset_async(" DRJIT_PTR ", isize=%u, size=%u)",
+               (uintptr_t) ptr, isize, size_);
+
+    if (size_ == 0)
+        return;
+
+    size_t size = size_;
+    uint64_t zero = 0;
+    if (std::memcmp(src, &zero, isize) == 0) {
+        hip_check(hipMemsetAsync(ptr, 0, size * isize, amd_stream));
+        return;
+    }
+
+    hip_check(hipCtxSetCurrent(amd_context));
+
+    switch (isize) {
+        case 1:
+            hip_check(hipMemsetD8Async((hipDeviceptr_t) ptr,
+                                       ((const uint8_t *) src)[0], size,
+                                       amd_stream));
+            break;
+
+        case 2:
+            hip_check(hipMemsetD16Async((hipDeviceptr_t) ptr,
+                                        ((const uint16_t *) src)[0], size,
+                                        amd_stream));
+            break;
+
+        case 4:
+            hip_check(hipMemsetD32Async((hipDeviceptr_t) ptr,
+                                        (int) ((const uint32_t *) src)[0],
+                                        size, amd_stream));
+            break;
+
+        case 8: {
+            const AMDDevice &dev = state.amd_devices[(size_t) device];
+            uint32_t block_count, thread_count;
+            dev.get_launch_config(&block_count, &thread_count, size_);
+            hipFunction_t func = jitc_amd_misc_function(this, "fill_64");
+            void *args[] = { &ptr, &size_, (void *) src };
+            amd_submit_gpu(this, KernelType::Memset, func, block_count,
+                           thread_count, 0, args, size_);
+            break;
+        }
+    }
+}
+
+void AMDThreadState::block_reduce(VarType vt, ReduceOp op, uint32_t size,
+                                  uint32_t block_size, const void *in,
+                                  void *out) {
+    if (size == 0) {
+        return;
+    } else if (block_size == 0 || block_size > size) {
+        jitc_raise("jit_block_reduce(): invalid block size "
+                   "(size=%u, block_size=%u)!", size, block_size);
+    }
+
+    uint32_t tsize = type_size[(int) vt];
+    if (block_size == 1) {
+        memcpy_async(out, in, (size_t) size * tsize);
+        return;
+    }
+
+    VarType vts = vt;
+    if (op == ReduceOp::Add || op == ReduceOp::Mul ||
+        op == ReduceOp::Or || op == ReduceOp::And) {
+        vt = amd_make_int_type_unsigned(vt);
+        if (vt == VarType::Float16)
+            vts = VarType::Float32;
+    }
+
+    uint32_t block_count = ceil_div(size, block_size);
+    uint32_t chunk_size = round_pow2(block_size);
+
+    uint32_t thread_count, grid_dim_x, grid_dim_y, chunk_count;
+    uint32_t chunks_per_block, chunks_per_thread_block;
+    bool x_is_block_id = true;
+    uint32_t vector_width = 1;
+
+    if (chunk_size < 1024) {
+        uint32_t min_threads = align_up(block_count * chunk_size, 32);
+        thread_count = std::min(std::max(chunk_size, 128u), min_threads);
+
+        chunk_count = block_count;
+        chunks_per_block = 1;
+        chunks_per_thread_block = thread_count / chunk_size;
+
+        grid_dim_x = ceil_div(block_count, chunks_per_thread_block);
+        grid_dim_y = 1;
+    } else {
+        if ((block_size * tsize) % 16 == 0 && (size * tsize) % 16 == 0 &&
+            ((uintptr_t) in) % 16 == 0)
+            vector_width = 16 / tsize;
+
+        chunk_size = 1024;
+        thread_count = chunk_size / vector_width;
+
+        chunks_per_block = ceil_div(block_size, chunk_size);
+        chunks_per_thread_block = 1;
+
+        grid_dim_x = block_count;
+        grid_dim_y = chunks_per_block;
+        chunk_count = block_count * chunks_per_block;
+
+        if (grid_dim_y > grid_dim_x) {
+            std::swap(grid_dim_x, grid_dim_y);
+            x_is_block_id = false;
+        }
+    }
+
+    uint32_t after_stage_1 =
+        chunk_size / (std::min(chunk_size, 32u) * vector_width);
+    uint32_t smem_per_chunk =
+        (after_stage_1 == 1 ? 0 : after_stage_1) * type_size[(int) vts],
+        smem_bytes = smem_per_chunk * chunks_per_thread_block;
+
+    jitc_log(Debug,
+             "jit_amd_block_reduce(" DRJIT_PTR " -> " DRJIT_PTR
+             ", type=%s, op=%s, size=%u, block_size=%u, block_count=%u, "
+             "chunk_size=%u, chunks_per_block=%u, vector_width=%u): "
+             "launching a %u x %u grid with %u threads and %u bytes of "
+             "shared memory per thread block.",
+             (uintptr_t) in, (uintptr_t) out, type_name[(int) vt],
+             red_name[(int) op], size, block_size, block_count, chunk_size,
+             chunks_per_block, vector_width, grid_dim_x, grid_dim_y,
+             thread_count, smem_bytes);
+
+    hipFunction_t func = nullptr;
+    if (vector_width != 1) {
+        func = jitc_amd_block_reduce_vec_function(this, op, vt);
+    } else {
+        int kernel_id = log2i_ceil(chunk_size) - 1;
+        func = jitc_amd_block_reduce_function(this, op, vt, kernel_id);
+    }
+
+    if (!func)
+        jitc_raise("jit_block_reduce(): no existing kernel for type=%s, "
+                   "op=%s, vector_width=%u!",
+                   type_name[(int) vt], red_name[(int) op], vector_width);
+
+    struct {
+        const void *in;
+        void *out;
+        uint32_t size;
+        uint32_t block_size;
+        uint32_t chunks_per_block;
+        uint32_t chunk_count;
+        uint8_t x_is_block_id;
+    } params;
+
+    params.in = in;
+    params.size = size / vector_width;
+    params.block_size = block_size / vector_width;
+    params.chunks_per_block = chunks_per_block;
+    params.chunk_count = chunk_count;
+    params.x_is_block_id = (uint8_t) x_is_block_id;
+
+    if (chunks_per_block == 1)
+        params.out = out;
+    else
+        params.out = jitc_malloc(JitBackend::AMD, chunk_count * tsize);
+
+    void *args[] = { &params };
+    amd_submit_gpu(this, KernelType::BlockReduce, func, grid_dim_x,
+                   thread_count, smem_bytes, args, size, grid_dim_y);
+
+    if (chunks_per_block > 1) {
+        block_reduce(vt, op, chunk_count, chunks_per_block, params.out, out);
+        jitc_free(params.out);
+    }
+}
+
+void AMDThreadState::block_prefix_reduce(VarType vt, ReduceOp op, uint32_t size,
+                                         uint32_t block_size, bool exclusive,
+                                         bool reverse, const void *in,
+                                         void *out) {
+    uint32_t tsize = type_size[(int) vt];
+    if (size == 0) {
+        return;
+    } else if (block_size == 0 || block_size > size) {
+        jitc_raise("jit_block_prefix_reduce(): invalid block size "
+                   "(size=%u, block_size=%u)!", size, block_size);
+    } else if (block_size == 1) {
+        if (exclusive) {
+            uint64_t ident = jitc_reduce_identity(vt, op);
+            memset_async(out, size, tsize, &ident);
+        } else if (in != out) {
+            memcpy_async(out, in, (size_t) size * tsize);
+        }
+        return;
+    }
+
+    VarType vts = vt;
+    if (op == ReduceOp::Add || op == ReduceOp::Mul ||
+        op == ReduceOp::Or || op == ReduceOp::And) {
+        vt = amd_make_int_type_unsigned(vt);
+        if (vt == VarType::Float16)
+            vts = VarType::Float32;
+    }
+
+    uint32_t block_count = ceil_div(size, block_size);
+    uint32_t chunk_size = round_pow2(block_size);
+
+    uint32_t thread_count, grid_dim_x, grid_dim_y, chunk_count;
+    uint32_t chunks_per_block, chunks_per_thread_block;
+    bool x_is_block_id = true;
+
+    if (chunk_size < 1024) {
+        uint32_t min_threads = align_up(block_count * chunk_size, 32);
+        thread_count = std::min(std::max(chunk_size, 128u), min_threads);
+
+        chunk_count = block_count;
+        chunks_per_block = 1;
+        chunks_per_thread_block = thread_count / chunk_size;
+
+        grid_dim_x = ceil_div(block_count, chunks_per_thread_block);
+        grid_dim_y = 1;
+    } else {
+        chunk_size = thread_count = 1024;
+        chunks_per_block = ceil_div(block_size, chunk_size);
+        chunks_per_thread_block = 1;
+
+        grid_dim_x = block_count;
+        grid_dim_y = chunks_per_block;
+        chunk_count = block_count * chunks_per_block;
+
+        if (grid_dim_y > grid_dim_x) {
+            std::swap(grid_dim_x, grid_dim_y);
+            x_is_block_id = false;
+        }
+    }
+
+    uint32_t smem_bytes = thread_count * type_size[(int) vts];
+
+    jitc_log(Debug,
+             "jit_amd_block_prefix_reduce(" DRJIT_PTR " -> " DRJIT_PTR
+             ", type=%s, op=%s, size=%u, block_size=%u, exclusive=%i, "
+             "reverse=%i, block_count=%u, chunk_size=%u, "
+             "chunks_per_block=%u): launching a %u x %u grid with %u "
+             "threads and %u bytes of shared memory per thread block.",
+             (uintptr_t) in, (uintptr_t) out, type_name[(int) vt],
+             red_name[(int) op], size, block_size, exclusive, reverse,
+             block_count, chunk_size, chunks_per_block, grid_dim_x,
+             grid_dim_y, thread_count, smem_bytes);
+
+    int kernel_id = log2i_ceil(chunk_size) - 1;
+    hipFunction_t func =
+        jitc_amd_block_prefix_reduce_function(this, op, vt, kernel_id);
+
+    if (!func)
+        jitc_raise("jit_block_prefix_reduce(): no existing kernel for "
+                   "type=%s, op=%s!",
+                   type_name[(int) vt], red_name[(int) op]);
+
+    struct {
+        const void *in;
+        void *scratch;
+        void *out;
+        uint32_t size;
+        uint32_t block_size;
+        uint32_t chunks_per_block;
+        uint8_t x_is_block_id;
+        uint8_t exclusive;
+        uint8_t reverse;
+    } params;
+
+    params.in = in;
+    params.out = out;
+    params.size = size;
+    params.block_size = block_size;
+    params.chunks_per_block = chunks_per_block;
+    params.x_is_block_id = (uint8_t) x_is_block_id;
+    params.exclusive = (uint8_t) exclusive;
+    params.reverse = (uint8_t) reverse;
+
+    if (chunks_per_block > 1) {
+        uint32_t scratch_size = chunk_count * 2,
+                 vsize = type_size[(int) vts];
+        params.scratch = jitc_malloc(JitBackend::AMD, scratch_size * vsize);
+        uint64_t z = 0;
+        memset_async(params.scratch, scratch_size, vsize, &z);
+    } else {
+        params.scratch = nullptr;
+    }
+
+    void *args[] = { &params };
+    amd_submit_gpu(this, KernelType::BlockPrefixReduce, func, grid_dim_x,
+                   thread_count, smem_bytes, args, size, grid_dim_y);
+
+    if (chunks_per_block > 1)
+        jitc_free(params.scratch);
+}
+
+void AMDThreadState::reduce_dot(VarType vt, const void *ptr_1,
+                                const void *ptr_2, uint32_t size, void *out) {
+    if (size == 0)
+        return;
+
+    const AMDDevice &dev = state.amd_devices[(size_t) device];
+    hipFunction_t red_dot = jitc_amd_reduce_dot_function(this, vt);
+
+    if (!red_dot)
+        jitc_raise("jit_reduce_dot(): no existing kernel for type=%s!",
+                   type_name[(int) vt]);
+
+    uint32_t thread_count = 1024,
+             tsize = type_size[(int) vt],
+             shared_size = thread_count * tsize,
+             block_count = (size + thread_count * 2 - 1) / (thread_count * 2);
+
+    block_count = std::min(dev.multi_processor_count * 4, block_count);
+
+    jitc_log(Debug, "jit_amd_reduce_dot(" DRJIT_PTR ", " DRJIT_PTR
+             ", type=%s, size=%u, smem=%u, blocks=%u)",
+             (uintptr_t) ptr_1, (uintptr_t) ptr_2, type_name[(int) vt],
+             size, shared_size, block_count);
+
+    if (block_count == 1) {
+        void *args[] = { (void *) &ptr_1, (void *) &ptr_2, &size, &out };
+        amd_submit_gpu(this, KernelType::Dot, red_dot, 1, thread_count,
+                       shared_size, args, size);
+    } else {
+        void *temp = jitc_malloc(JitBackend::AMD,
+                                 block_count * (size_t) tsize);
+
+        void *args[] = { (void *) &ptr_1, (void *) &ptr_2, &size, &temp };
+        amd_submit_gpu(this, KernelType::Dot, red_dot, block_count,
+                       thread_count, shared_size, args, size);
+
+        block_reduce(vt, ReduceOp::Add, block_count, block_count, temp, out);
+        jitc_free(temp);
+    }
+}
+
+void AMDThreadState::batched_gemm(VarType vt, bool At, bool Bt, uint32_t M,
+                                  uint32_t N, uint32_t K,
+                                  const GemmBatch *batch, const void *A,
+                                  const void *B, void *C) {
+    if (At && Bt)
+        jitc_raise("jit_batched_gemm(): internal error -- At=Bt=True "
+                   "should have been rewritten by the caller.");
+
+    uint32_t grid_count, reduce_count;
+    if (!jitc_gemm_batch_counts(batch, grid_count, reduce_count))
+        return;
+    if (M == 0 || N == 0 || K == 0)
+        return;
+
+    GemmBatch batch_eff = batch ? *batch : GemmBatch{};
+    uint32_t tsize = type_size[(int) vt];
+
+    auto vec_width = [tsize](uint32_t bm) -> uint32_t {
+        uint32_t tm   = bm / 8;
+        uint32_t vmax = 16u / tsize;
+        return tm < vmax ? tm : vmax;
+    };
+
+    uint32_t a_inner = At ? M : K,
+             b_inner = Bt ? K : N;
+
+    const AMDDevice &dev = state.amd_devices[(size_t) device];
+    constexpr uint32_t grid_y_cap = 65535u;
+
+    uint32_t small_dim = M < N ? M : N;
+    int t_idx = At ? 2 : (Bt ? 1 : 0);
+    uint32_t bm = 0;
+    hipFunction_t func = nullptr;
+
+    for (int l = 0; l <= 3; ++l) {
+        uint32_t bm_try = 8u << l;
+        uint32_t v      = vec_width(bm_try);
+
+        if (a_inner % v || b_inner % v || (N % v))
+            continue;
+        if (ceil_div(M, bm_try) > grid_y_cap)
+            continue;
+
+        hipFunction_t f = jitc_amd_gemm_function(this, vt, l, t_idx);
+        if (!f)
+            continue;
+
+        if (bm == 0) {
+            bm = bm_try;
+            func = f;
+        }
+
+        if (bm_try >= 2 * small_dim)
+            continue;
+
+        uint64_t grid = (uint64_t) ceil_div(M, bm_try) *
+                        ceil_div(N, bm_try) * grid_count;
+        uint64_t min_grid = (bm_try == 64)
+                                ? 3u * dev.multi_processor_count
+                                : dev.multi_processor_count;
+        if (grid >= min_grid) {
+            bm = bm_try;
+            func = f;
+        }
+    }
+
+    if (bm == 0)
+        jitc_raise("jit_batched_gemm(): no compatible tile for M=%u, N=%u: "
+                   "alignment or gridDim.y cap (%u) cannot be satisfied.",
+                   M, N, grid_y_cap);
+
+    uint32_t grid_x = ceil_div(N, bm),
+             grid_y = ceil_div(M, bm);
+
+    if (grid_count > 65535u)
+        jitc_raise("jit_batched_gemm(): grid batch count %u exceeds the "
+                   "current AMD GEMM gridDim.z limit of 65535.", grid_count);
+
+    jitc_log(Debug,
+             "jit_amd_batched_gemm(" DRJIT_PTR ", " DRJIT_PTR " -> "
+             DRJIT_PTR ", type=%s, At=%i, Bt=%i, M=%u, N=%u, K=%u, "
+             "grid=%u, reduce=%u, tile=%ux%u, launch=%ux%ux%u).",
+             (uintptr_t) A, (uintptr_t) B, (uintptr_t) C,
+             type_name[(int) vt], (int) At, (int) Bt, M, N, K, grid_count,
+             reduce_count, bm, bm, grid_x, grid_y, grid_count);
+
+    void *args[] = { (void *) &A, (void *) &B, &C,
+                     &M, &N, &K, (void *) &batch_eff };
+
+    amd_submit_gpu(this, KernelType::BatchedGemm, func, grid_x,
+                   /* thread_count */ 64, /* shared_mem_bytes */ 0, args,
+                   /* width */ grid_count * M * N, grid_y, grid_count);
+}
+
+uint32_t AMDThreadState::compress(const uint8_t *in, uint32_t size,
+                                  uint32_t *out) {
+    if (size == 0)
+        return 0;
+
+    const AMDDevice &dev = state.amd_devices[(size_t) device];
+    hip_check(hipCtxSetCurrent(amd_context));
+
+    uint32_t *count_out = (uint32_t *) jitc_malloc(
+        JitBackend::AMD, sizeof(uint32_t), /*shared=*/true);
+
+    if (size <= 4096) {
+        uint32_t items_per_thread = 4,
+                 thread_count =
+                     round_pow2((size + items_per_thread - 1) /
+                                items_per_thread),
+                 shared_size = thread_count * 2 * sizeof(uint32_t),
+                 trailer = thread_count * items_per_thread - size;
+
+        jitc_log(Debug,
+                 "jit_amd_compress(" DRJIT_PTR " -> " DRJIT_PTR
+                 ", size=%u, type=small, threads=%u, shared=%u)",
+                 (uintptr_t) in, (uintptr_t) out, size, thread_count,
+                 shared_size);
+
+        if (trailer > 0)
+            hip_check(hipMemsetAsync((void *) (in + size), 0, trailer,
+                                     amd_stream));
+
+        hipFunction_t func = jitc_amd_misc_function(this, "compress_small");
+        void *args[] = { (void *) &in, &out, &size, &count_out };
+        amd_submit_gpu(this, KernelType::Compress, func, 1, thread_count,
+                       shared_size, args, size);
+    } else {
+        uint32_t items_per_thread = 16,
+                 thread_count = 128,
+                 items_per_block = items_per_thread * thread_count,
+                 block_count = (size + items_per_block - 1) / items_per_block,
+                 shared_size = items_per_block * sizeof(uint32_t),
+                 scratch_items = block_count + 32,
+                 trailer = items_per_block * block_count - size;
+
+        jitc_log(Debug,
+                 "jit_amd_compress(" DRJIT_PTR " -> " DRJIT_PTR
+                 ", size=%u, type=large, blocks=%u, threads=%u, shared=%u, "
+                 "scratch=%u)",
+                 (uintptr_t) in, (uintptr_t) out, size, block_count,
+                 thread_count, shared_size, scratch_items * 4);
+
+        uint64_t *scratch = (uint64_t *) jitc_malloc(
+            JitBackend::AMD, scratch_items * sizeof(uint64_t));
+
+        uint32_t block_count_init, thread_count_init;
+        dev.get_launch_config(&block_count_init, &thread_count_init,
+                              scratch_items);
+
+        hipFunction_t init =
+            jitc_amd_misc_function(this, "compress_large_init");
+        void *args[] = { &scratch, &scratch_items };
+        amd_submit_gpu(this, KernelType::Compress, init, block_count_init,
+                       thread_count_init, 0, args, scratch_items);
+
+        if (trailer > 0)
+            hip_check(hipMemsetAsync((void *) (in + size), 0, trailer,
+                                     amd_stream));
+
+        scratch += 32;
+        hipFunction_t func = jitc_amd_misc_function(this, "compress_large");
+        void *args_2[] = { (void *) &in, &out, &scratch, &count_out };
+        amd_submit_gpu(this, KernelType::Compress, func, block_count,
+                       thread_count, shared_size, args_2, scratch_items);
+        scratch -= 32;
+
+        jitc_free(scratch);
+    }
+
+    jitc_sync_thread(this);
+    uint32_t count_out_v = *count_out;
+    jitc_free(count_out);
+    return count_out_v;
+}
+
+static void amd_transpose(AMDThreadState *ts, const uint32_t *in,
+                          uint32_t *out, uint32_t rows, uint32_t cols,
+                          uint32_t num_batches = 1,
+                          uint32_t batch_stride = 0) {
+    uint16_t blocks_x = (uint16_t) ((cols + 15u) / 16u),
+             blocks_y = (uint16_t) ((rows + 15u) / 16u);
+
+    jitc_log(Debug,
+             "jit_amd_transpose(" DRJIT_PTR " -> " DRJIT_PTR
+             ", rows=%u, cols=%u, blocks=%ux%u, batches=%u)",
+             (uintptr_t) in, (uintptr_t) out, rows, cols, blocks_x, blocks_y,
+             num_batches);
+
+    hipFunction_t func = jitc_amd_misc_function(ts, "transpose");
+    void *args[] = { (void *) &in, &out, &rows, &cols, &batch_stride };
+    hip_check(hipCtxSetCurrent(ts->amd_context));
+    hip_check(hipModuleLaunchKernel(func, blocks_x, blocks_y, num_batches,
+                                    16, 16, 1,
+                                    16 * 17 * sizeof(uint32_t),
+                                    ts->amd_stream, args, nullptr));
+}
+
+uint32_t AMDThreadState::block_mkperm(const uint32_t *values, uint32_t size,
+                                      uint32_t block_size,
+                                      uint32_t bucket_count, uint32_t *perm,
+                                      uint32_t *offsets) {
+    if (size == 0)
+        return 0;
+    else if (unlikely(bucket_count == 0))
+        jitc_fail("jit_block_mkperm(): bucket_count cannot be zero!");
+
+    hip_check(hipCtxSetCurrent(amd_context));
+    const AMDDevice &dev = state.amd_devices[(size_t) device];
+
+    const uint32_t warp_size = 32;
+
+    uint32_t n_blocks = ceil_div(size, block_size);
+
+    uint32_t gpu_blocks_per_group, thread_count;
+    dev.get_launch_config(&gpu_blocks_per_group, &thread_count, block_size,
+                          1024, 1);
+
+    uint32_t warp_count = (thread_count + warp_size - 1) / warp_size;
+    thread_count = warp_count * warp_size;
+
+    uint32_t gpu_block_count = n_blocks * gpu_blocks_per_group;
+
+    uint32_t bucket_size_1 = bucket_count * sizeof(uint32_t),
+             bucket_size_all = bucket_size_1 * gpu_block_count;
+
+    uint32_t shared_size = 0;
+    const char *variant = nullptr;
+    hipFunction_t phase_1 = nullptr, phase_4 = nullptr;
+    bool initialize_buckets = false, is_tiny = false;
+
+    if (bucket_size_1 * warp_count <= dev.shared_memory_bytes) {
+        phase_1 = jitc_amd_misc_function(this, "block_mkperm_phase_1_tiny");
+        phase_4 = jitc_amd_misc_function(this, "block_mkperm_phase_4_tiny");
+        shared_size = bucket_size_1 * warp_count;
+        bucket_size_all *= warp_count;
+        variant = "tiny";
+        is_tiny = true;
+    } else if (bucket_size_1 <= dev.shared_memory_bytes) {
+        phase_1 = jitc_amd_misc_function(this, "block_mkperm_phase_1_small");
+        phase_4 = jitc_amd_misc_function(this, "block_mkperm_phase_4_small");
+        shared_size = bucket_size_1;
+        variant = "small";
+    } else {
+        phase_1 = jitc_amd_misc_function(this, "block_mkperm_phase_1_large");
+        phase_4 = jitc_amd_misc_function(this, "block_mkperm_phase_4_large");
+        variant = "large";
+        initialize_buckets = true;
+    }
+
+    uint32_t rows_per_group =
+        is_tiny ? gpu_blocks_per_group * warp_count : gpu_blocks_per_group;
+
+    bool needs_transpose = rows_per_group > 1;
+    uint32_t *buckets_1, *buckets_2, *counter = nullptr;
+    buckets_1 = buckets_2 =
+        (uint32_t *) jitc_malloc(JitBackend::AMD, bucket_size_all);
+
+    if (needs_transpose)
+        buckets_2 = (uint32_t *) jitc_malloc(JitBackend::AMD, bucket_size_all);
+
+    if (offsets) {
+        counter = (uint32_t *) jitc_malloc(JitBackend::AMD, sizeof(uint32_t));
+        hip_check(hipMemsetAsync(counter, 0, sizeof(uint32_t), amd_stream));
+    }
+
+    if (initialize_buckets)
+        hip_check(hipMemsetAsync(buckets_1, 0, bucket_size_all, amd_stream));
+
+    uint32_t size_per_gpu_block =
+        (block_size + gpu_blocks_per_group - 1) / gpu_blocks_per_group;
+
+    jitc_log(Debug,
+             "jit_amd_block_mkperm(" DRJIT_PTR
+             ", size=%u, block_size=%u, bucket_count=%u, gpu_block_count=%u, "
+             "thread_count=%u, size_per_gpu_block=%u, variant=%s, "
+             "shared_size=%u)",
+             (uintptr_t) values, size, block_size, bucket_count,
+             gpu_block_count, thread_count, size_per_gpu_block, variant,
+             shared_size);
+
+    void *args_1[] = { (void *) &values, &buckets_1, &size,
+                       &size_per_gpu_block, &bucket_count, &block_size };
+
+    amd_submit_gpu(this, KernelType::MkPerm, phase_1, gpu_blocks_per_group,
+                   thread_count, shared_size, args_1, size, n_blocks);
+
+    if (needs_transpose) {
+        uint32_t batch_stride = rows_per_group * bucket_count;
+        amd_transpose(this, buckets_1, buckets_2, rows_per_group,
+                      bucket_count, n_blocks, batch_stride);
+    }
+
+    uint32_t psum_count = bucket_size_all / sizeof(uint32_t);
+    uint32_t psum_block_size = rows_per_group * bucket_count;
+    block_prefix_reduce(VarType::UInt32, ReduceOp::Add, psum_count,
+                        psum_block_size, true, false, buckets_2, buckets_2);
+
+    if (needs_transpose) {
+        uint32_t batch_stride = rows_per_group * bucket_count;
+        amd_transpose(this, buckets_2, buckets_1, bucket_count,
+                      rows_per_group, n_blocks, batch_stride);
+    }
+
+    if (likely(offsets) && n_blocks == 1) {
+        uint32_t gpu_block_count_3, thread_count_3;
+        dev.get_launch_config(&gpu_block_count_3, &thread_count_3,
+                              bucket_count * gpu_block_count);
+
+        uint32_t bucket_count_rounded =
+            (bucket_count + thread_count_3 - 1) / thread_count_3 *
+            thread_count_3;
+
+        hipFunction_t phase_3 =
+            jitc_amd_misc_function(this, "block_mkperm_phase_3");
+        void *args_3[] = { &buckets_1, &bucket_count, &bucket_count_rounded,
+                           &size, &counter, &offsets };
+
+        amd_submit_gpu(this, KernelType::MkPerm, phase_3, gpu_block_count_3,
+                       thread_count_3, sizeof(uint32_t) * thread_count_3,
+                       args_3, size);
+
+        hip_check(hipMemcpyAsync(offsets + 4 * (size_t) bucket_count, counter,
+                                 sizeof(uint32_t), hipMemcpyDefault,
+                                 amd_stream));
+
+        hip_check(hipEventRecord(amd_event, amd_stream));
+    }
+
+    void *args_4[] = { (void *) &values, &buckets_1, &perm, &size,
+                       &size_per_gpu_block, &bucket_count, &block_size };
+
+    amd_submit_gpu(this, KernelType::MkPerm, phase_4, gpu_blocks_per_group,
+                   thread_count, shared_size, args_4, size, n_blocks);
+
+    if (likely(offsets) && n_blocks == 1) {
+        unlock_guard guard(state.lock);
+        hip_check(hipEventSynchronize(amd_event));
+    }
+
+    jitc_free(buckets_1);
+    if (needs_transpose)
+        jitc_free(buckets_2);
+    jitc_free(counter);
+
+    return (offsets && n_blocks == 1) ? offsets[4 * bucket_count] : 0u;
+}
+
+void AMDThreadState::memcpy(void *dst, const void *src, size_t size) {
+    hip_check(hipCtxSetCurrent(amd_context));
+    hip_check(hipStreamSynchronize(amd_stream));
+    hip_check(hipMemcpy(dst, src, size, hipMemcpyDefault));
+}
+
+void AMDThreadState::memcpy_async(void *dst, const void *src, size_t size) {
+    hip_check(hipCtxSetCurrent(amd_context));
+    hip_check(hipMemcpyAsync(dst, src, size, hipMemcpyDefault, amd_stream));
+}
+
+void AMDThreadState::poke(void *dst, const void *src, uint32_t size) {
+    jitc_log(Debug, "jit_poke(" DRJIT_PTR ", size=%u)", (uintptr_t) dst,
+             size);
+
+    VarType type;
+    switch (size) {
+        case 1: type = VarType::UInt8; break;
+        case 2: type = VarType::UInt16; break;
+        case 4: type = VarType::UInt32; break;
+        case 8: type = VarType::UInt64; break;
+        default:
+            jitc_raise("jit_poke(): only size=1, 2, 4 or 8 are supported!");
+    }
+
+    hip_check(hipCtxSetCurrent(amd_context));
+    hipFunction_t func = jitc_amd_poke_function(this, type);
+    void *args[] = { &dst, (void *) src };
+    amd_submit_gpu(this, KernelType::Poke, func, 1, 1, 0, args, 1);
+}
+
+void AMDThreadState::aggregate(void *dst, AggregationEntry *agg,
+                               uint32_t size) {
+    hip_check(hipCtxSetCurrent(amd_context));
+    const AMDDevice &dev = state.amd_devices[(size_t) device];
+    hipFunction_t func = jitc_amd_misc_function(this, "aggregate");
+
+    for (uint32_t i = 0; i < size; ++i) {
+        AggregationEntry &e = agg[i];
+        if (e.size != 8)
+            continue;
+
+        AMDScene *scene = (AMDScene *) e.src;
+        switch ((ResourceKind) e.resource_kind) {
+            case ResourceKind::Accel:
+                e.src = scene ? scene->scene : nullptr;
+                break;
+
+            case ResourceKind::IFT:
+                e.src = scene ? scene->func_table : nullptr;
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    void *args[] = { &dst, &agg, &size };
+
+    uint32_t block_count, thread_count;
+    dev.get_launch_config(&block_count, &thread_count, size);
+
+    jitc_log(InfoSym,
+             "jit_amd_aggregate(" DRJIT_PTR " -> " DRJIT_PTR
+             ", size=%u, blocks=%u, threads=%u)",
+             (uintptr_t) agg, (uintptr_t) dst, size, block_count,
+             thread_count);
+
+    amd_submit_gpu(this, KernelType::Aggregate, func, block_count,
+                   thread_count, 0, args, 1);
+}
+
+void AMDThreadState::enqueue_host_func(void (*callback)(void *), void *payload) {
+    hip_check(hipLaunchHostFunc(amd_stream, callback, payload));
+}
+
+void AMDThreadState::barrier() {
+    if (!free_next.empty()) {
+        free_later.insert(free_later.end(),
+                          std::make_move_iterator(free_next.begin()),
+                          std::make_move_iterator(free_next.end()));
+        free_next.clear();
+    }
+    flush_deferred_free();
+}
+
+void AMDThreadState::flush_deferred_free() {
+    if (void *batch = take_deferred_free())
+        hip_check(hipLaunchHostFunc(
+            amd_stream,
+            [](void *payload) { jitc_malloc_release_batch(payload); },
+            batch));
+}
+
+void AMDThreadState::coop_vec_pack(uint32_t count, const void *in_,
+                                   const MatrixDescr *in_d, void *out_,
+                                   const MatrixDescr *out_d) {
+    (void) count; (void) in_; (void) in_d; (void) out_; (void) out_d;
+    jitc_raise("AMDThreadState::coop_vec_pack(): cooperative vectors are not "
+               "supported by the AMD/HIP backend without an OptiX-like HIPRT "
+               "cooperative-vector facility.");
+}
+
+#endif

--- a/src/amd_ts.h
+++ b/src/amd_ts.h
@@ -1,0 +1,54 @@
+#include "internal.h"
+
+#if defined(DRJIT_ENABLE_AMD)
+
+struct AMDThreadState final : ThreadState {
+    Task *launch(Kernel kernel, KernelKey &key, XXH128_hash_t hash,
+                 uint32_t size, std::vector<void *> &kernel_params,
+                 const std::vector<uint32_t> &kernel_param_ids,
+                 KernelHistoryEntry *kernel_history_entry) override;
+
+    void memset_async(void *ptr, uint32_t size, uint32_t isize,
+                      const void *src) override;
+
+    void block_reduce(VarType vt, ReduceOp op, uint32_t size,
+                      uint32_t block_size, const void *in, void *out) override;
+
+    void block_prefix_reduce(VarType vt, ReduceOp op, uint32_t size,
+                             uint32_t block_size, bool exclusive, bool reverse,
+                             const void *in, void *out) override;
+
+    void reduce_dot(VarType type, const void *ptr_1, const void *ptr_2,
+                    uint32_t size, void *out) override;
+
+    void batched_gemm(VarType vt, bool At, bool Bt,
+                      uint32_t M, uint32_t N, uint32_t K,
+                      const GemmBatch *batch,
+                      const void *A, const void *B, void *C) override;
+
+    uint32_t compress(const uint8_t *in, uint32_t size, uint32_t *out) override;
+
+    uint32_t block_mkperm(const uint32_t *values, uint32_t size,
+                          uint32_t block_size, uint32_t bucket_count,
+                          uint32_t *perm, uint32_t *offsets) override;
+
+    void memcpy(void *dst, const void *src, size_t size) override;
+
+    void memcpy_async(void *dst, const void *src, size_t size) override;
+
+    void poke(void *dst, const void *src, uint32_t size) override;
+
+    void aggregate(void *dst, AggregationEntry *agg, uint32_t size) override;
+
+    void enqueue_host_func(void (*callback)(void *), void *payload) override;
+
+    void barrier() override;
+
+    void flush_deferred_free() override;
+
+    void coop_vec_pack(uint32_t count, const void *in,
+                       const MatrixDescr *in_d, void *out,
+                       const MatrixDescr *out_d) override;
+};
+
+#endif

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -19,6 +19,11 @@
 #  include "cuda_tex.h"
 #  include "cuda_green.h"
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+#  include <drjit-core/amd.h>
+#  include "amd_api.h"
+#  include "amd_rt.h"
+#endif
 #include "op.h"
 #include "call.h"
 #include "loop.h"
@@ -89,6 +94,15 @@ int jit_has_backend(JitBackend backend) {
 #if defined(DRJIT_ENABLE_CUDA)
             result = (state.backends & (1u << (uint32_t) JitBackend::CUDA))
                 && !state.devices.empty();
+#else
+            result = false;
+#endif
+            break;
+
+        case JitBackend::AMD:
+#if defined(DRJIT_ENABLE_AMD)
+            result = (state.backends & (1u << (uint32_t) JitBackend::AMD))
+                && !state.amd_devices.empty();
 #else
             result = false;
 #endif
@@ -371,6 +385,180 @@ void jit_cuda_set_target(uint32_t, uint32_t) { jit_cuda_unavailable(); }
 void *jit_cuda_lookup(const char *) { jit_cuda_unavailable(); return nullptr; }
 void jit_cuda_sync_stream(uintptr_t) { jit_cuda_unavailable(); }
 #endif
+
+// ==========================================================================
+//                          AMD-specific API
+// ==========================================================================
+
+int jit_amd_device_count() {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    return (int) state.amd_devices.size();
+#else
+    return 0;
+#endif
+}
+
+void jit_amd_set_device(int device) {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    jitc_amd_set_device(device);
+#else
+    (void) device;
+    jit_raise("jit_amd_set_device(): the AMD backend is not enabled in this "
+              "build of Dr.Jit.");
+#endif
+}
+
+int jit_amd_device() {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    return thread_state(JitBackend::AMD)->device;
+#else
+    return -1;
+#endif
+}
+
+int jit_amd_device_raw() {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    return thread_state(JitBackend::AMD)->amd_raw_device;
+#else
+    return -1;
+#endif
+}
+
+const char *jit_amd_arch() {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    return thread_state(JitBackend::AMD)->amd_arch;
+#else
+    return nullptr;
+#endif
+}
+
+void *jit_amd_stream() {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    return (void *) thread_state(JitBackend::AMD)->amd_stream;
+#else
+    return nullptr;
+#endif
+}
+
+void *jit_amd_context() {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    return (void *) thread_state(JitBackend::AMD)->amd_context;
+#else
+    return nullptr;
+#endif
+}
+
+int jit_amd_runtime_version() {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    return jitc_amd_runtime_version_v;
+#else
+    return 0;
+#endif
+}
+
+void jit_amd_sync_device() {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    jitc_amd_sync_device(thread_state(JitBackend::AMD));
+#endif
+}
+
+void jit_amd_sync_stream(uintptr_t stream) {
+#if defined(DRJIT_ENABLE_AMD)
+    return jitc_amd_sync_stream(stream);
+#else
+    (void) stream;
+    jit_raise("jit_amd_sync_stream(): the AMD backend is not enabled in this "
+              "build of Dr.Jit.");
+#endif
+}
+
+uint32_t jit_amd_configure_scene(void *scene, uint32_t geometry_types_mask) {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    return jitc_amd_configure_scene(scene, geometry_types_mask);
+#else
+    (void) scene; (void) geometry_types_mask;
+    jit_raise("jit_amd_configure_scene(): AMD backend not enabled.");
+    return 0;
+#endif
+}
+
+uint32_t jit_amd_configure_scene_ex(
+        void *scene, void *func_table, uint32_t num_geom_types,
+        uint32_t num_ray_types, const char **intersect_function_names,
+        const char **filter_function_names, const char *device_source,
+        uint32_t geometry_types_mask) {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    return jitc_amd_configure_scene_ex(
+        scene, func_table, num_geom_types, num_ray_types,
+        intersect_function_names, filter_function_names, device_source,
+        geometry_types_mask);
+#else
+    (void) scene; (void) func_table; (void) num_geom_types;
+    (void) num_ray_types; (void) intersect_function_names;
+    (void) filter_function_names; (void) device_source;
+    (void) geometry_types_mask;
+    jit_raise("jit_amd_configure_scene_ex(): AMD backend not enabled.");
+    return 0;
+#endif
+}
+
+void jit_amd_ray_trace(uint32_t n_args, uint32_t *args,
+                       uint32_t mask, uint32_t *out, uint32_t n_out,
+                       uint32_t scene, int shadow) {
+    lock_guard guard(state.lock);
+#if defined(DRJIT_ENABLE_AMD)
+    jitc_amd_ray_trace(n_args, args, mask, out, n_out, scene, shadow);
+#else
+    (void) n_args; (void) args; (void) mask; (void) out; (void) n_out;
+    (void) scene; (void) shadow;
+    jit_raise("jit_amd_ray_trace(): AMD backend not enabled.");
+#endif
+}
+
+uint32_t jit_amd_scene_owner_handle(uint32_t scene_index) {
+#if defined(DRJIT_ENABLE_AMD)
+    lock_guard guard(state.lock);
+    return jitc_amd_scene_owner_handle(scene_index);
+#else
+    (void) scene_index;
+    jit_raise("jit_amd_scene_owner_handle(): AMD backend not enabled.");
+    return 0;
+#endif
+}
+
+uint32_t jit_amd_scene_func_table_handle(uint32_t scene_index) {
+#if defined(DRJIT_ENABLE_AMD)
+    lock_guard guard(state.lock);
+    return jitc_amd_scene_func_table_handle(scene_index);
+#else
+    (void) scene_index;
+    jit_raise("jit_amd_scene_func_table_handle(): AMD backend not enabled.");
+    return 0;
+#endif
+}
+
+void jit_amd_scene_set_cleanup(uint32_t scene_index,
+                               void (*callback)(void *), void *payload) {
+#if defined(DRJIT_ENABLE_AMD)
+    lock_guard guard(state.lock);
+    AMDScene *scene = jitc_amd_get_scene(scene_index);
+    scene->cleanup = callback;
+    scene->cleanup_payload = payload;
+#else
+    (void) scene_index; (void) callback; (void) payload;
+#endif
+}
 
 void jit_llvm_set_thread_count(uint32_t size) {
     pool_set_size(nullptr, size);
@@ -675,8 +863,10 @@ int jit_var_device(uint32_t index) {
 }
 
 uint32_t jit_var_literal(JitBackend backend, VarType type, const void *value,
-                             size_t size, int eval) {
+                         size_t size, int eval) {
     lock_guard guard(state.lock);
+    if (backend != JitBackend::None)
+        default_backend = backend;
     return jitc_var_literal(backend, type, value, size, eval);
 }
 
@@ -1201,6 +1391,10 @@ void jit_eval() {
 #if defined(DRJIT_ENABLE_CUDA)
     if (tl.ts_cuda)
         jitc_eval(tl.ts_cuda);
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+    if (tl.ts_amd)
+        jitc_eval(tl.ts_amd);
 #endif
     if (tl.ts_llvm)
         jitc_eval(tl.ts_llvm);
@@ -2253,6 +2447,11 @@ JitEvent jit_event_create(JitBackend backend, int enable_timing) {
             return jitc_cuda_event_create(enable_timing);
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:
+            return jitc_amd_event_create(enable_timing);
+#endif
+
 #if defined(DRJIT_ENABLE_METAL)
         case JitBackend::Metal:
             return jitc_metal_event_create(enable_timing);
@@ -2278,6 +2477,12 @@ void jit_event_destroy(JitEvent event) {
 #if defined(DRJIT_ENABLE_CUDA)
         case JitBackend::CUDA:
             jitc_cuda_event_destroy(event);
+            break;
+#endif
+
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:
+            jitc_amd_event_destroy(event);
             break;
 #endif
 
@@ -2311,6 +2516,12 @@ void jit_event_record(JitEvent event) {
             break;
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:
+            jitc_amd_event_record(event);
+            break;
+#endif
+
 #if defined(DRJIT_ENABLE_METAL)
         case JitBackend::Metal:
             jitc_metal_event_record(event);
@@ -2339,6 +2550,11 @@ int jit_event_query(JitEvent event) {
             return jitc_cuda_event_query(event);
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:
+            return jitc_amd_event_query(event);
+#endif
+
 #if defined(DRJIT_ENABLE_METAL)
         case JitBackend::Metal:
             return jitc_metal_event_query(event);
@@ -2364,6 +2580,12 @@ void jit_event_wait(JitEvent event) {
 #if defined(DRJIT_ENABLE_CUDA)
         case JitBackend::CUDA:
             jitc_cuda_event_wait(event);
+            break;
+#endif
+
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:
+            jitc_amd_event_wait(event);
             break;
 #endif
 
@@ -2400,6 +2622,11 @@ float jit_event_elapsed_time(JitEvent start, JitEvent end) {
             return jitc_cuda_event_elapsed_time(start, end);
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:
+            return jitc_amd_event_elapsed_time(start, end);
+#endif
+
 #if defined(DRJIT_ENABLE_METAL)
         case JitBackend::Metal:
             jitc_raise("jit_event_elapsed_time(): event timing is not "
@@ -2425,6 +2652,11 @@ void* jit_event_handle(JitEvent event) {
 #if defined(DRJIT_ENABLE_CUDA)
         case JitBackend::CUDA:
             return (void*)e->cuda_event;
+#endif
+
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:
+            return (void*) e->amd_event;
 #endif
 
 #if defined(DRJIT_ENABLE_METAL)

--- a/src/call.cpp
+++ b/src/call.cpp
@@ -755,6 +755,10 @@ void jitc_var_call_getter_assemble(Variable *v, const Variable *index,
     else if (jitc_is_cuda(backend))
         jitc_var_call_getter_assemble_cuda(v, index, mask);
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+    else if (jitc_is_amd(backend))
+        jitc_var_call_getter_assemble_amd(v, index, mask);
+#endif
     else
         jitc_fail("jitc_var_call_getter_assemble(): unsupported backend!");
 }
@@ -958,6 +962,13 @@ void jitc_var_call_assemble(CallData *call, uint32_t call_reg,
         jitc_var_call_assemble_cuda(call, call_reg, self_reg, mask_reg,
                                     in_size, in_align,
                                     out_size, out_align);
+#endif
+
+#if defined(DRJIT_ENABLE_AMD)
+    else if (jitc_is_amd(call->backend))
+        jitc_var_call_assemble_amd(call, call_reg, self_reg, mask_reg,
+                                   in_size, in_align,
+                                   out_size, out_align);
 #endif
 
     else

--- a/src/call.h
+++ b/src/call.h
@@ -291,6 +291,11 @@ extern void jitc_var_call_assemble_metal(CallData *call, uint32_t call_reg,
                                          uint32_t in_size, uint32_t in_align,
                                          uint32_t out_size, uint32_t out_align);
 
+extern void jitc_var_call_assemble_amd(CallData *call, uint32_t call_reg,
+                                       uint32_t self_reg, uint32_t mask_reg,
+                                       uint32_t in_size, uint32_t in_align,
+                                       uint32_t out_size, uint32_t out_align);
+
 extern void jitc_var_call(const char *domain, bool symbolic, uint32_t self,
                           uint32_t mask, uint32_t n_inst, uint32_t max_inst_id,
                           const uint32_t *inst_id, uint32_t n_in,
@@ -314,3 +319,5 @@ extern void jitc_var_call_getter_assemble_llvm(Variable *v, const Variable *inde
                                                const Variable *mask);
 extern void jitc_var_call_getter_assemble_metal(Variable *v, const Variable *index,
                                                 const Variable *mask);
+extern void jitc_var_call_getter_assemble_amd(Variable *v, const Variable *index,
+                                              const Variable *mask);

--- a/src/coop_vec.cpp
+++ b/src/coop_vec.cpp
@@ -48,6 +48,10 @@ bool jitc_coop_vec_supported(JitBackend backend) {
 #else
     (void) backend;
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+    if (jitc_is_amd(backend))
+        return false;
+#endif
     return true;
 }
 
@@ -64,9 +68,10 @@ uint32_t jitc_coop_vec_pack(uint32_t n, const uint32_t *in) {
 
     const Variable *arg_v = jitc_var(in[0]);
     if (!jitc_coop_vec_supported((JitBackend) arg_v->backend))
-        jitc_raise("jit_coop_vec_pack(): The use of cooperative vectors on "
-                   "the CUDA/OptiX backend requires CUDA 12.8 or newer "
-                   "(which corresponds to driver version R570+).");
+        jitc_raise("jit_coop_vec_pack(): cooperative vectors are not "
+                   "supported on this backend. CUDA requires CUDA 12.8 or "
+                   "newer via OptiX cooperative vectors; the AMD/HIP backend "
+                   "does not currently expose an equivalent HIPRT facility.");
 
     Variable v;
     v.kind = (uint32_t) VarKind::CoopVecPack;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -591,6 +591,11 @@ void jitc_assemble(ThreadState *ts, ScheduledGroup group) {
         jitc_cuda_assemble(ts, group, n_regs, (uint32_t) kernel_params.size());
     else
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+    if (jitc_is_amd(backend))
+        jitc_amd_assemble(ts, group, n_regs, (uint32_t) kernel_params.size());
+    else
+#endif
 #if defined(DRJIT_ENABLE_METAL)
     if (jitc_is_metal(backend))
         jitc_metal_assemble(ts, group, n_regs, (uint32_t) kernel_params.size());
@@ -746,6 +751,13 @@ Task *jitc_run(ThreadState *ts, ScheduledGroup group) {
                         ts, buffer.get(), buffer.size(), kernel_name, kernel);
                 #endif
             }
+        } else
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        if (jitc_is_amd(ts->backend)) {
+            ProfilerPhase profiler(profiler_region_backend_compile);
+            cache_hit = jitc_amd_compile(ts, buffer.get(), buffer.size(),
+                                         kernel_name, kernel);
         } else
 #endif
 #if defined(DRJIT_ENABLE_METAL)
@@ -1286,6 +1298,13 @@ XXH128_hash_t jitc_assemble_func(const CallData *call, uint32_t inst,
         case JitBackend::CUDA:
             jitc_cuda_assemble_func(call, inst, in_size, in_align, out_size,
                                     out_align, n_regs);
+            break;
+#endif
+
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:
+            jitc_amd_assemble_func(call, inst, in_size, in_align, out_size,
+                                   out_align, n_regs);
             break;
 #endif
 

--- a/src/eval.h
+++ b/src/eval.h
@@ -142,6 +142,25 @@ extern void jitc_cuda_assemble_func(const CallData *call, uint32_t inst,
                                     uint32_t out_size, uint32_t out_align,
                                     uint32_t n_regs);
 
+#if defined(DRJIT_ENABLE_AMD)
+struct Kernel;
+
+/// Used by jitc_eval() to generate AMD HIP source code
+extern void jitc_amd_assemble(ThreadState *ts, ScheduledGroup group,
+                              uint32_t n_regs, uint32_t n_params);
+
+/// Used by jitc_call() to generate HIP source code for callables
+extern void jitc_amd_assemble_func(const CallData *call, uint32_t inst,
+                                   uint32_t in_size, uint32_t in_align,
+                                   uint32_t out_size, uint32_t out_align,
+                                   uint32_t n_regs);
+
+/// Compile a HIP source string to a module and locate the kernel entry point
+extern bool jitc_amd_compile(ThreadState *ts, const char *source,
+                             size_t source_size, const char *kernel_name,
+                             Kernel &kernel);
+#endif
+
 #if defined(DRJIT_ENABLE_METAL)
 struct Kernel;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -12,6 +12,9 @@
 #if defined(DRJIT_ENABLE_CUDA)
 #  include "cuda_ts.h"
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+#  include "amd_ts.h"
+#endif
 #if defined(DRJIT_ENABLE_METAL)
 #  include "metal.h"
 #endif
@@ -84,6 +87,7 @@ void jitc_init(uint32_t backends) {
 
 #if defined(__APPLE__)
     backends &= ~(1u << (uint32_t) JitBackend::CUDA);
+    backends &= ~(1u << (uint32_t) JitBackend::AMD);
 #else
     backends &= ~(1u << (uint32_t) JitBackend::Metal);
 #endif
@@ -138,6 +142,11 @@ void jitc_init(uint32_t backends) {
         state.backends |= 1u << (uint32_t) JitBackend::CUDA;
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+    if ((backends & (1u << (uint32_t) JitBackend::AMD)) && jitc_amd_init())
+        state.backends |= 1u << (uint32_t) JitBackend::AMD;
+#endif
+
 #if defined(DRJIT_ENABLE_METAL)
     if ((backends & (1u << (uint32_t) JitBackend::Metal)) && jitc_metal_init())
         state.backends |= 1u << (uint32_t) JitBackend::Metal;
@@ -182,6 +191,11 @@ void jitc_shutdown(int light) {
 #if defined(DRJIT_ENABLE_METAL)
         if (jitc_is_metal(ts->backend)) {
             jitc_metal_sync(ts);
+        }
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        if (jitc_is_amd(ts->backend)) {
+            jitc_amd_sync_thread(ts);
         }
 #endif
         if (!ts->mask_stack.empty() && state.leak_warnings)
@@ -258,6 +272,10 @@ void jitc_shutdown(int light) {
                 cuda_check(cuStreamSynchronize(ts->stream));
             }
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+            if (jitc_is_amd(ts->backend) && ts->amd_stream)
+                jitc_amd_sync_thread(ts);
+#endif
 
             if (!ts->prefix_stack.empty()) {
                 for (char *s : ts->prefix_stack)
@@ -295,6 +313,9 @@ void jitc_shutdown(int light) {
     tl.ts_llvm = nullptr;
 #if defined(DRJIT_ENABLE_CUDA)
     tl.ts_cuda = nullptr;
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+    tl.ts_amd = nullptr;
 #endif
 #if defined(DRJIT_ENABLE_METAL)
     tl.ts_metal = nullptr;
@@ -357,6 +378,9 @@ void jitc_shutdown(int light) {
 #if defined(DRJIT_ENABLE_CUDA)
         jitc_cuda_shutdown();
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+        jitc_amd_shutdown();
+#endif
 #if defined(DRJIT_ENABLE_OPTIX)
         jitc_optix_api_shutdown();
 #endif
@@ -373,6 +397,10 @@ void jitc_shutdown(int light) {
 
 
 ThreadState *jitc_init_thread_state(JitBackend backend) {
+    if (unlikely(backend == JitBackend::None &&
+                 default_backend != JitBackend::None))
+        backend = default_backend;
+
     ThreadState *ts = nullptr;
 
 #if defined(DRJIT_ENABLE_METAL)
@@ -408,6 +436,38 @@ ThreadState *jitc_init_thread_state(JitBackend backend) {
     }
 #endif
 
+    if (jitc_is_amd(backend)) {
+#if defined(DRJIT_ENABLE_AMD)
+        ts = new AMDThreadState();
+        if ((state.backends & (1u << (uint32_t) JitBackend::AMD)) == 0) {
+            delete ts;
+            jitc_raise(
+                "jit_init_thread_state(): the AMD backend has not been "
+                "initialized. Make sure to call jit_init(JitBackend::AMD) "
+                "first.");
+        }
+
+        if (state.amd_devices.empty()) {
+            delete ts;
+            jitc_raise("jit_init_thread_state(): the AMD backend is inactive "
+                       "because no compatible AMD/HIP devices were found on "
+                       "your system.");
+        }
+
+        AMDDevice &device = state.amd_devices[0];
+        ts->device = 0;
+        ts->amd_raw_device = device.id;
+        ts->amd_device = device.device;
+        ts->amd_context = device.context;
+        ts->amd_stream = device.stream;
+        ts->amd_event = device.event;
+        ts->amd_sync_stream_event = device.sync_stream_event;
+        ts->amd_arch = device.arch;
+        ts->amd_wavefront_size = device.wavefront_size;
+        ts->amd_max_threads = device.max_threads_per_block;
+        thread_state_amd = ts;
+#endif
+    } else
     if (jitc_is_cuda(backend)) {
 #if defined(DRJIT_ENABLE_CUDA)
         ts = new CUDAThreadState();
@@ -555,6 +615,12 @@ void jitc_sync_thread(ThreadState *ts) {
         return;
     }
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+    if (jitc_is_amd(backend)) {
+        jitc_amd_sync_thread(ts);
+        return;
+    }
+#endif
 #if defined(DRJIT_ENABLE_METAL)
     if (jitc_is_metal(backend)) {
         unlock_guard guard(state.lock);
@@ -594,6 +660,9 @@ void jitc_sync_thread() {
 #if defined(DRJIT_ENABLE_CUDA)
     jitc_sync_thread(tl.ts_cuda);
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+    jitc_sync_thread(tl.ts_amd);
+#endif
     jitc_sync_thread(tl.ts_llvm);
 #if defined(DRJIT_ENABLE_METAL)
     jitc_sync_thread(tl.ts_metal);
@@ -601,19 +670,30 @@ void jitc_sync_thread() {
 }
 
 void jitc_flush_thread(ThreadState *ts) {
+#if defined(DRJIT_ENABLE_AMD)
+    if (ts && jitc_is_amd(ts->backend)) {
+        jitc_amd_sync_thread(ts);
+        return;
+    }
+#endif
 #if defined(DRJIT_ENABLE_METAL)
     if (ts && jitc_is_metal(ts->backend)) {
         jitc_metal_flush(ts);
         return;
     }
-#else
+#endif
+#if !defined(DRJIT_ENABLE_AMD) && !defined(DRJIT_ENABLE_METAL)
     (void) ts;
 #endif
 }
 
 void jitc_flush_thread() {
+    ThreadLocal &tl = jitc_thread_local();
+#if defined(DRJIT_ENABLE_AMD)
+    jitc_flush_thread(tl.ts_amd);
+#endif
 #if defined(DRJIT_ENABLE_METAL)
-    jitc_flush_thread(jitc_thread_local().ts_metal);
+    jitc_flush_thread(tl.ts_metal);
 #endif
 }
 
@@ -629,6 +709,10 @@ void jitc_sync_device() {
             cuda_check(cuCtxSynchronize());
         }
     }
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+    if (tl.ts_amd)
+        jitc_amd_sync_device(tl.ts_amd);
 #endif
 
     if (tl.ts_llvm) {
@@ -843,6 +927,16 @@ KernelHistoryEntry *KernelHistory::get() {
             k.event_start = k.event_end = 0;
         } else
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+        if (jitc_is_amd(k.backend)) {
+            hip_check(hipEventElapsedTime(&k.execution_time,
+                                          (hipEvent_t) k.event_start,
+                                          (hipEvent_t) k.event_end));
+            hip_check(hipEventDestroy((hipEvent_t) k.event_start));
+            hip_check(hipEventDestroy((hipEvent_t) k.event_end));
+            k.event_start = k.event_end = 0;
+        } else
+#endif
 #if defined(DRJIT_ENABLE_METAL)
         if (jitc_is_metal(k.backend)) {
             k.execution_time =
@@ -874,6 +968,12 @@ void KernelHistory::clear() {
         if (jitc_is_cuda(k.backend)) {
             cuEventDestroy((CUevent) k.event_start);
             cuEventDestroy((CUevent) k.event_end);
+        } else
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        if (jitc_is_amd(k.backend)) {
+            hip_check(hipEventDestroy((hipEvent_t) k.event_start));
+            hip_check(hipEventDestroy((hipEvent_t) k.event_end));
         } else
 #endif
 #if defined(DRJIT_ENABLE_METAL)

--- a/src/internal.h
+++ b/src/internal.h
@@ -15,9 +15,13 @@
 #if defined(DRJIT_ENABLE_CUDA)
 #  include "cuda.h"
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+#  include "amd_api.h"
+#endif
 #include "llvm.h"
 #include "alloc.h"
 #include "io.h"
+#include <algorithm>
 #include <string.h>
 #include <new>
 #include <nanothread/nanothread.h>
@@ -276,10 +280,10 @@ struct alignas(64) Variable {
     uint32_t kind : 7;
 
     /// Backend associated with this variable
-    uint32_t backend : 2;
+    uint32_t backend : 3;
 
     /// Variable type (Bool/Int/Float/....)
-    uint32_t type : 5;
+    uint32_t type : 4;
 
     /// Is this a pointer variable that tracks a pending write? It holds a side
     /// effect reference that keeps the target marked dirty until it expires.
@@ -425,7 +429,7 @@ struct VariableKey {
         memcpy((void *) this, (const void *) &v.scope, 32);
         uint32_t array_length =
             (v.is_array() || v.coop_vec) ? (uint32_t) v.array_length : 0u;
-        // The bitfields kind:7|backend:2|type:5|write_ptr:1|written:1 occupy
+        // The bitfields kind:7|backend:3|type:4|write_ptr:1|written:1 occupy
         // bits 0..15 of the 32-bit word immediately after 'scratch' (LSB-first
         // packing), which is exactly the layout 'packed' wants. Reading the raw
         // word and masking avoids extracting and re-assembling each field
@@ -605,6 +609,95 @@ struct CUDADevice {
 
         if (threads_out)
             *threads_out = warps_per_block * warp_size;
+    }
+};
+#endif
+
+#if defined(DRJIT_ENABLE_AMD)
+/// Caches basic information about an AMD/HIP device
+struct AMDDevice {
+    /// Raw HIP device ID
+    int id = -1;
+
+    /// HIP device handle
+    hipDevice_t device = 0;
+
+    /// HIP context associated with this device
+    hipCtx_t context = nullptr;
+
+    /// HIPRT context, created lazily by the AMD trace compiler
+    void *hiprt_context = nullptr;
+
+    /// Lazily JIT-compiled modules owned by this device
+    std::vector<hipModule_t> modules;
+
+    /// Associated HIP stream handle
+    hipStream_t stream = nullptr;
+
+    /// A HIP event for synchronization purposes
+    hipEvent_t event = nullptr;
+
+    /// A HIP event for synchronization with external streams
+    hipEvent_t sync_stream_event = nullptr;
+
+    /// Compute unit count
+    uint32_t multi_processor_count = 0;
+
+    /// Wavefront size
+    uint32_t wavefront_size = 32;
+
+    /// Maximum threads per block
+    uint32_t max_threads_per_block = 1024;
+
+    /// Max. bytes of shared memory per block
+    uint32_t shared_memory_bytes = 0;
+
+    /// Cached AMDGPU architecture string, e.g. "gfx1201" (owned)
+    char *arch = nullptr;
+
+    /// Cached human-readable device name (owned)
+    char *name = nullptr;
+
+    void get_launch_config(uint32_t *blocks_out, uint32_t *threads_out,
+                           uint32_t size, uint32_t max_threads = 1024,
+                           uint32_t max_blocks_per_cu = 0) const {
+        uint32_t wave_size = wavefront_size ? wavefront_size : 32,
+                 wave_count = (size + wave_size - 1) / wave_size,
+                 max_waves_per_block = (max_threads + wave_size - 1) / wave_size,
+                 cu_count = std::max(1u, multi_processor_count);
+
+        uint32_t block_count, waves_per_block;
+        if (wave_count <= cu_count) {
+            block_count = wave_count;
+            waves_per_block = 1;
+        } else {
+            block_count = cu_count;
+            waves_per_block = (wave_count + block_count - 1) / block_count;
+
+            if (waves_per_block > max_waves_per_block) {
+                block_count =
+                    (wave_count + max_waves_per_block - 1) / max_waves_per_block;
+                if (block_count < cu_count * 4)
+                    block_count =
+                        (block_count + cu_count - 1) / cu_count * cu_count;
+
+                uint32_t max_blocks = max_blocks_per_cu * cu_count;
+                if (max_blocks && block_count > max_blocks) {
+                    block_count = max_blocks;
+                    waves_per_block = max_waves_per_block;
+                } else {
+                    waves_per_block =
+                        (wave_count + block_count - 1) / block_count;
+                    block_count =
+                        (wave_count + waves_per_block - 1) / waves_per_block;
+                }
+            }
+        }
+
+        if (blocks_out)
+            *blocks_out = block_count;
+        if (threads_out)
+            *threads_out = waves_per_block * wave_size;
     }
 };
 #endif
@@ -836,6 +929,37 @@ struct ThreadStateBase {
     /// OptiX pipeline associated with the next kernel launch
     OptixPipelineData *optix_pipeline = nullptr;
     OptixShaderBindingTable *optix_sbt = nullptr;
+#endif
+
+    /// ---------------------------- AMD-specific -----------------------------
+
+#if defined(DRJIT_ENABLE_AMD)
+    /// Raw HIP device ID
+    int amd_raw_device = -1;
+
+    /// HIP device handle
+    hipDevice_t amd_device = 0;
+
+    /// HIP context handle
+    hipCtx_t amd_context = nullptr;
+
+    /// Associated HIP stream handle
+    hipStream_t amd_stream = nullptr;
+
+    /// A HIP event for synchronization purposes
+    hipEvent_t amd_event = nullptr;
+
+    /// A HIP event for synchronization with external streams
+    hipEvent_t amd_sync_stream_event = nullptr;
+
+    /// AMDGPU architecture string, e.g. "gfx1201" (non-owning)
+    const char *amd_arch = nullptr;
+
+    /// Wavefront size
+    uint32_t amd_wavefront_size = 32;
+
+    /// Maximum threads per block
+    uint32_t amd_max_threads = 1024;
 #endif
 
     /// ---------------------------- Metal-specific ----------------------------
@@ -1130,6 +1254,11 @@ struct State {
     std::vector<CUDADevice> devices;
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+    /// Available AMD/HIP devices
+    std::vector<AMDDevice> amd_devices;
+#endif
+
 #if defined(DRJIT_ENABLE_METAL)
     /// Available Metal devices (Apple Silicon only)
     std::vector<MetalDevice> metal_devices;
@@ -1212,6 +1341,9 @@ struct ThreadLocal {
 #if defined(DRJIT_ENABLE_CUDA)
     ThreadState *ts_cuda = nullptr;
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+    ThreadState *ts_amd = nullptr;
+#endif
 #if defined(DRJIT_ENABLE_METAL)
     ThreadState *ts_metal = nullptr;
 #endif
@@ -1234,6 +1366,9 @@ struct ThreadLocal {
 #if defined(DRJIT_ENABLE_CUDA)
 #  define thread_state_cuda (tls.ts_cuda)
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+#  define thread_state_amd  (tls.ts_amd)
+#endif
 #if defined(DRJIT_ENABLE_METAL)
 #  define thread_state_metal (tls.ts_metal)
 #endif
@@ -1247,11 +1382,20 @@ JIT_INLINE ThreadLocal &jitc_thread_local() { return *std::launder(&tls); }
 extern ThreadState *jitc_init_thread_state(JitBackend backend);
 
 inline ThreadState *thread_state(JitBackend backend) {
+    if (unlikely(backend == JitBackend::None && default_backend != JitBackend::None))
+        backend = default_backend;
+
     ThreadState *result;
     switch (backend) {
 #if defined(DRJIT_ENABLE_CUDA)
         case JitBackend::CUDA:
             result = thread_state_cuda;
+            break;
+#endif
+
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:
+            result = thread_state_amd;
             break;
 #endif
 
@@ -1304,6 +1448,21 @@ extern void jitc_shutdown(int light);
 extern void jitc_cuda_set_device(int device);
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+/// Set the currently active AMD device & stream
+extern bool jitc_amd_init();
+extern void jitc_amd_shutdown();
+extern void jitc_amd_set_device(int device);
+extern void jitc_amd_sync_thread(ThreadState *ts);
+extern void jitc_amd_sync_device(ThreadState *ts);
+extern JitEvent jitc_amd_event_create(bool enable_timing);
+extern void jitc_amd_event_destroy(JitEvent event);
+extern void jitc_amd_event_record(JitEvent event);
+extern int jitc_amd_event_query(JitEvent event);
+extern void jitc_amd_event_wait(JitEvent event);
+extern float jitc_amd_event_elapsed_time(JitEvent start, JitEvent end);
+#endif
+
 /// Wait for all computation on the current stream to finish
 extern void jitc_sync_thread();
 extern void jitc_sync_thread(ThreadState *stream);
@@ -1328,6 +1487,14 @@ template <typename T> inline bool jitc_is_cuda(T b) {
 #endif
 }
 
+template <typename T> inline bool jitc_is_amd(T b) {
+#if defined(DRJIT_ENABLE_AMD)
+    return (JitBackend) b == JitBackend::AMD;
+#else
+    (void) b; return false;
+#endif
+}
+
 template <typename T> inline bool jitc_is_metal(T b) {
 #if defined(DRJIT_ENABLE_METAL)
     return (JitBackend) b == JitBackend::Metal;
@@ -1340,9 +1507,9 @@ template <typename T> inline bool jitc_is_llvm(T b) {
     return (JitBackend) b == JitBackend::LLVM;
 }
 
-/// Returns true if the given backend uses GPU device memory (CUDA or Metal)
+/// Returns true if the given backend uses GPU device memory
 template <typename T> inline bool jitc_is_gpu(T b) {
-    return jitc_is_cuda(b) || jitc_is_metal(b);
+    return jitc_is_cuda(b) || jitc_is_amd(b) || jitc_is_metal(b);
 }
 
 /// Search for a shared library and dlopen it if possible
@@ -1505,6 +1672,9 @@ struct EventData {
 #if defined(DRJIT_ENABLE_CUDA)
         CUevent cuda_event;
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+        hipEvent_t amd_event;
+#endif
         Task* llvm_task;
 #if defined(DRJIT_ENABLE_METAL)
         // For Metal we store a (id<MTLSharedEvent>, value) pair encoded into
@@ -1523,6 +1693,11 @@ struct EventData {
 #if defined(DRJIT_ENABLE_CUDA)
         if (jitc_is_cuda(backend))
             cuda_event = nullptr;
+        else
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        if (jitc_is_amd(backend))
+            amd_event = nullptr;
         else
 #endif
 #if defined(DRJIT_ENABLE_METAL)

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -77,6 +77,7 @@ static uint32_t compute_padding(const CacheFileHeader &header) {
 static const char *jitc_cache_suffix(JitBackend backend) {
     switch (backend) {
         case JitBackend::CUDA:  return "cuda";
+        case JitBackend::AMD:   return "amd";
         case JitBackend::Metal: return "metal";
         default:                return "llvm";
     }
@@ -85,6 +86,7 @@ static const char *jitc_cache_suffix(JitBackend backend) {
 static const wchar_t *jitc_cache_suffix_w(JitBackend backend) {
     switch (backend) {
         case JitBackend::CUDA:  return L"cuda";
+        case JitBackend::AMD:   return L"amd";
         case JitBackend::Metal: return L"metal";
         default:                return L"llvm";
     }
@@ -476,10 +478,24 @@ void jitc_kernel_free(int device_id, const Kernel &kernel) {
     } else {
 #if defined(DRJIT_ENABLE_METAL)
         if ((state.backends & (1u << (uint32_t) JitBackend::CUDA)) == 0 &&
+            (state.backends & (1u << (uint32_t) JitBackend::AMD)) == 0 &&
             (state.backends & (1u << (uint32_t) JitBackend::Metal)) != 0) {
             // Metal kernel.
             extern void jitc_metal_kernel_free(Kernel &);
             jitc_metal_kernel_free(const_cast<Kernel &>(kernel));
+            return;
+        }
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        if ((state.backends & (1u << (uint32_t) JitBackend::CUDA)) == 0 &&
+            (state.backends & (1u << (uint32_t) JitBackend::Metal)) == 0 &&
+            (state.backends & (1u << (uint32_t) JitBackend::AMD)) != 0) {
+            // AMD/HIP kernel.
+            const AMDDevice &device = state.amd_devices.at(device_id);
+            hip_check(hipCtxSetCurrent(device.context));
+            if (kernel.amd.mod && !kernel.amd.hiprt_owned)
+                hip_check(hipModuleUnload(kernel.amd.mod));
+            free(kernel.data);
             return;
         }
 #endif

--- a/src/io.h
+++ b/src/io.h
@@ -10,6 +10,9 @@
 #pragma once
 
 #include "hash.h"
+#if defined(DRJIT_ENABLE_AMD)
+#  include "amd_api.h"
+#endif
 
 using LLVMKernelFunction = void (*)(uint64_t start, uint64_t end, uint32_t thread_id, void **ptr);
 #if defined(DRJIT_ENABLE_CUDA)
@@ -104,6 +107,23 @@ struct Kernel {
             /// slot (even if call_table_vft is potentially NULL).
             bool has_call_table;
         } metal;
+#endif
+
+#if defined(DRJIT_ENABLE_AMD)
+        /// 5. AMD/HIP
+        struct {
+            /// Compiled HIP module
+            hipModule_t mod;
+
+            /// Main kernel entry point
+            hipFunction_t func;
+
+            /// Preferred block size
+            uint32_t block_size;
+
+            /// Module ownership remains with HIPRT's compiler cache
+            bool hiprt_owned;
+        } amd;
 #endif
     };
 };

--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -20,6 +20,9 @@
 #if defined(DRJIT_ENABLE_METAL)
 #  include "metal.h"
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+#  include "amd_api.h"
+#endif
 
 // Try to use huge pages for allocations > 2M (only on Linux)
 #if defined(__linux__)
@@ -132,6 +135,13 @@ void* jitc_malloc(JitBackend backend, size_t size, bool shared) {
     }
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+    if (jitc_is_amd(backend)) {
+        ts = thread_state(backend);
+        device = ts->device;
+    }
+#endif
+
 #if defined(DRJIT_ENABLE_METAL)
     if (jitc_is_metal(backend)) {
         ts = thread_state(backend);
@@ -156,6 +166,25 @@ void* jitc_malloc(JitBackend backend, size_t size, bool shared) {
             }
         }
     }
+
+#if defined(DRJIT_ENABLE_AMD)
+    if (!ptr && jitc_is_amd(backend) &&
+        state.alloc_allocated[(int) backend] > state.alloc_usage[(int) backend]) {
+        jitc_sync_thread(ts);
+
+        lock_guard guard(state.alloc_free_lock);
+        auto it = state.alloc_free.find(ai);
+
+        if (it != state.alloc_free.end()) {
+            std::vector<void *> &list = it.value();
+            if (!list.empty()) {
+                ptr = list.back();
+                list.pop_back();
+                descr = "reused after sync";
+            }
+        }
+    }
+#endif
 
     // Otherwise, allocate memory
     if (unlikely(!ptr)) {
@@ -187,6 +216,19 @@ void* jitc_malloc(JitBackend backend, size_t size, bool shared) {
                         ret = cuMemAlloc((CUdeviceptr*) &ptr, size);
 
                     if (ret)
+                        ptr = nullptr;
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+                } else if (jitc_is_amd(backend)) {
+                    hipError_t ret;
+
+                    hip_check(hipCtxSetCurrent(ts->amd_context));
+                    if (shared)
+                        ret = hipHostMalloc(&ptr, size);
+                    else
+                        ret = hipMalloc(&ptr, size);
+
+                    if (ret != hipSuccess)
                         ptr = nullptr;
 #endif
                 }
@@ -273,6 +315,9 @@ void jitc_free(void *ptr) {
 #if defined(DRJIT_ENABLE_CUDA)
         case JitBackend::CUDA: ts = tl.ts_cuda; break;
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD: ts = tl.ts_amd; break;
+#endif
 #if defined(DRJIT_ENABLE_METAL)
         case JitBackend::Metal: ts = tl.ts_metal; break;
 #endif
@@ -286,18 +331,27 @@ void jitc_free(void *ptr) {
     if (shared && !ts) // Leak shared allocation if Dr.Jit has already shut down
         return;
 
-    // A freed Metal buffer is not safe to reuse (by other threads) until the
-    // current thread has committed its command buffer, so park it until then
-    // (see ThreadState::free_next).
-    bool submit_deferred = !shared && backend == JitBackend::Metal && ts;
+    // Metal submits command buffers explicitly, so regular device allocations
+    // only become reusable once the current command buffer has been committed.
+    bool submit_deferred = !shared && ts && backend == JitBackend::Metal;
+
+    // HIP allocations are not stream-ordered by the Dr.Jit allocator. Return
+    // them to the cache from a stream callback so later reuse cannot race with
+    // already-queued kernels.
+    bool amd_deferred = !shared && ts && backend == JitBackend::AMD;
 
     // Free regular/host allocations immediately. Shared allocations are parked
     // until their GPU work completes; Metal device allocations until submission.
-    if (backend == JitBackend::None || (!shared && !submit_deferred)) {
+    if (backend == JitBackend::None ||
+        (!shared && !submit_deferred && !amd_deferred)) {
         jitc_malloc_release(info, ptr);
     } else {
         ThreadState *as = ts->actual_state();
-        (shared ? as->free_later : as->free_next).push_back({ info, ptr });
+        (shared || amd_deferred ? as->free_later : as->free_next)
+            .push_back({ info, ptr });
+
+        if (backend == JitBackend::AMD)
+            as->flush_deferred_free();
     }
 
     jitc_trace("jit_free(" DRJIT_PTR ", backend=%s, shared=%i, device=%i, size=%zu)",
@@ -422,6 +476,22 @@ void* jitc_malloc_migrate(void *ptr, JitBackend dst_backend, int move) {
         }
     }
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+    if (jitc_is_amd(gpu_backend)) {
+        hip_check(hipCtxSetCurrent(ts->amd_context));
+        if (src_backend == JitBackend::None) {
+            // Stage host -> device copies through a shared buffer
+            void *tmp = jitc_malloc(JitBackend::AMD, size, /*shared=*/true);
+            memcpy(tmp, ptr, size);
+            hip_check(hipMemcpyAsync(ptr_new, tmp, size, hipMemcpyDefault,
+                                     ts->amd_stream));
+            jitc_free(tmp);
+        } else {
+            hip_check(hipMemcpyAsync(ptr_new, ptr, size, hipMemcpyDefault,
+                                     ts->amd_stream));
+        }
+    }
+#endif
     (void) ts;
 
     if (move)
@@ -496,6 +566,22 @@ void jitc_flush_malloc_cache(bool warn) {
                 } else {
                     for (void *ptr : entries)
                         cuda_check(cuMemFree((CUdeviceptr) ptr));
+                }
+                continue;
+            }
+#endif
+
+#if defined(DRJIT_ENABLE_AMD)
+            if (jitc_is_amd(backend) &&
+                (state.backends & (1u << (uint32_t) JitBackend::AMD))) {
+                const AMDDevice &dev = state.amd_devices[device];
+                hip_check(hipCtxSetCurrent(dev.context));
+                if (shared) {
+                    for (void *ptr : entries)
+                        hip_check(hipHostFree(ptr));
+                } else {
+                    for (void *ptr : entries)
+                        hip_check(hipFree(ptr));
                 }
                 continue;
             }

--- a/src/malloc.h
+++ b/src/malloc.h
@@ -16,20 +16,20 @@
 
 using AllocInfo = uint64_t;
 
-/// Bit layout: [size : 53][shared : 1][backend : 2][device : 8]
+/// Bit layout: [size : 52][shared : 1][backend : 3][device : 8]
 inline AllocInfo alloc_info_encode(size_t size, JitBackend backend, bool shared,
                                    int device) {
-    return (((uint64_t) size)    << 11) |
-           (((uint64_t) shared)  << 10) |
+    return (((uint64_t) size)    << 12) |
+           (((uint64_t) shared)  << 11) |
            (((uint64_t) backend) <<  8) |
             ((uint64_t) device);
 }
 
 inline drjit::tuple<size_t, JitBackend, bool, int>
 alloc_info_decode(AllocInfo v) {
-    return drjit::make_tuple((size_t)     (v >> 11),
-                             (JitBackend)((v >>  8) & 0x3),
-                             (bool)      ((v >> 10) & 0x1),
+    return drjit::make_tuple((size_t)     (v >> 12),
+                             (JitBackend)((v >>  8) & 0x7),
+                             (bool)      ((v >> 11) & 0x1),
                              (int)       ( v        & 0xFF));
 }
 
@@ -46,6 +46,7 @@ inline const char *jitc_backend_name(JitBackend b) {
         case JitBackend::None:  return "host";
         case JitBackend::LLVM:  return "LLVM";
         case JitBackend::CUDA:  return "CUDA";
+        case JitBackend::AMD:   return "AMD";
         case JitBackend::Metal: return "Metal";
         default: return "?";
     }

--- a/src/record_ts.cpp
+++ b/src/record_ts.cpp
@@ -2535,6 +2535,18 @@ struct DisabledThreadState final : ThreadState {
         this->memory_pool        = internal->memory_pool;
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+        this->amd_raw_device        = internal->amd_raw_device;
+        this->amd_device            = internal->amd_device;
+        this->amd_context           = internal->amd_context;
+        this->amd_stream            = internal->amd_stream;
+        this->amd_event             = internal->amd_event;
+        this->amd_sync_stream_event = internal->amd_sync_stream_event;
+        this->amd_arch              = internal->amd_arch;
+        this->amd_wavefront_size    = internal->amd_wavefront_size;
+        this->amd_max_threads       = internal->amd_max_threads;
+#endif
+
         this->backend         = internal->backend;
         this->scope           = internal->scope;
         this->call_self_value = internal->call_self_value;
@@ -2717,6 +2729,21 @@ void jitc_freeze_start(JitBackend backend, const uint32_t *inputs,
     if (jitc_is_cuda(backend)) {
         thread_state_cuda = record_ts;
         set_disabled_thread_state(&thread_state_llvm, backend);
+#if defined(DRJIT_ENABLE_AMD)
+        set_disabled_thread_state(&thread_state_amd, backend);
+#endif
+#if defined(DRJIT_ENABLE_METAL)
+        set_disabled_thread_state(&thread_state_metal, backend);
+#endif
+    } else
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+    if (jitc_is_amd(backend)) {
+        thread_state_amd = record_ts;
+        set_disabled_thread_state(&thread_state_llvm, backend);
+#if defined(DRJIT_ENABLE_CUDA)
+        set_disabled_thread_state(&thread_state_cuda, backend);
+#endif
 #if defined(DRJIT_ENABLE_METAL)
         set_disabled_thread_state(&thread_state_metal, backend);
 #endif
@@ -2728,6 +2755,9 @@ void jitc_freeze_start(JitBackend backend, const uint32_t *inputs,
 #if defined(DRJIT_ENABLE_CUDA)
         set_disabled_thread_state(&thread_state_cuda, backend);
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+        set_disabled_thread_state(&thread_state_amd, backend);
+#endif
         set_disabled_thread_state(&thread_state_llvm, backend);
     } else
 #endif
@@ -2735,6 +2765,9 @@ void jitc_freeze_start(JitBackend backend, const uint32_t *inputs,
         thread_state_llvm = record_ts;
 #if defined(DRJIT_ENABLE_CUDA)
         set_disabled_thread_state(&thread_state_cuda, backend);
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        set_disabled_thread_state(&thread_state_amd, backend);
 #endif
 #if defined(DRJIT_ENABLE_METAL)
         set_disabled_thread_state(&thread_state_metal, backend);
@@ -2772,6 +2805,21 @@ Recording *jitc_freeze_stop(JitBackend backend, const uint32_t *outputs,
         if (jitc_is_cuda(backend)) {
             thread_state_cuda = internal;
             unset_disabled_thread_state(&thread_state_llvm);
+#if defined(DRJIT_ENABLE_AMD)
+            unset_disabled_thread_state(&thread_state_amd);
+#endif
+#if defined(DRJIT_ENABLE_METAL)
+            unset_disabled_thread_state(&thread_state_metal);
+#endif
+        } else
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        if (jitc_is_amd(backend)) {
+            thread_state_amd = internal;
+            unset_disabled_thread_state(&thread_state_llvm);
+#if defined(DRJIT_ENABLE_CUDA)
+            unset_disabled_thread_state(&thread_state_cuda);
+#endif
 #if defined(DRJIT_ENABLE_METAL)
             unset_disabled_thread_state(&thread_state_metal);
 #endif
@@ -2783,6 +2831,9 @@ Recording *jitc_freeze_stop(JitBackend backend, const uint32_t *outputs,
 #if defined(DRJIT_ENABLE_CUDA)
             unset_disabled_thread_state(&thread_state_cuda);
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+            unset_disabled_thread_state(&thread_state_amd);
+#endif
             unset_disabled_thread_state(&thread_state_llvm);
         } else
 #endif
@@ -2790,6 +2841,9 @@ Recording *jitc_freeze_stop(JitBackend backend, const uint32_t *outputs,
             thread_state_llvm = internal;
 #if defined(DRJIT_ENABLE_CUDA)
             unset_disabled_thread_state(&thread_state_cuda);
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+            unset_disabled_thread_state(&thread_state_amd);
 #endif
 #if defined(DRJIT_ENABLE_METAL)
             unset_disabled_thread_state(&thread_state_metal);
@@ -2836,6 +2890,21 @@ void jitc_freeze_abort(JitBackend backend) {
         if (jitc_is_cuda(backend)) {
             thread_state_cuda = internal;
             unset_disabled_thread_state(&thread_state_llvm);
+#if defined(DRJIT_ENABLE_AMD)
+            unset_disabled_thread_state(&thread_state_amd);
+#endif
+#if defined(DRJIT_ENABLE_METAL)
+            unset_disabled_thread_state(&thread_state_metal);
+#endif
+        } else
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        if (jitc_is_amd(backend)) {
+            thread_state_amd = internal;
+            unset_disabled_thread_state(&thread_state_llvm);
+#if defined(DRJIT_ENABLE_CUDA)
+            unset_disabled_thread_state(&thread_state_cuda);
+#endif
 #if defined(DRJIT_ENABLE_METAL)
             unset_disabled_thread_state(&thread_state_metal);
 #endif
@@ -2847,6 +2916,9 @@ void jitc_freeze_abort(JitBackend backend) {
 #if defined(DRJIT_ENABLE_CUDA)
             unset_disabled_thread_state(&thread_state_cuda);
 #endif
+#if defined(DRJIT_ENABLE_AMD)
+            unset_disabled_thread_state(&thread_state_amd);
+#endif
             unset_disabled_thread_state(&thread_state_llvm);
         } else
 #endif
@@ -2854,6 +2926,9 @@ void jitc_freeze_abort(JitBackend backend) {
             thread_state_llvm = internal;
 #if defined(DRJIT_ENABLE_CUDA)
             unset_disabled_thread_state(&thread_state_cuda);
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+            unset_disabled_thread_state(&thread_state_amd);
 #endif
 #if defined(DRJIT_ENABLE_METAL)
             unset_disabled_thread_state(&thread_state_metal);

--- a/src/record_ts.h
+++ b/src/record_ts.h
@@ -403,6 +403,18 @@ public:
         this->memory_pool        = internal->memory_pool;
 #endif
 
+#if defined(DRJIT_ENABLE_AMD)
+        this->amd_raw_device        = internal->amd_raw_device;
+        this->amd_device            = internal->amd_device;
+        this->amd_context           = internal->amd_context;
+        this->amd_stream            = internal->amd_stream;
+        this->amd_event             = internal->amd_event;
+        this->amd_sync_stream_event = internal->amd_sync_stream_event;
+        this->amd_arch              = internal->amd_arch;
+        this->amd_wavefront_size    = internal->amd_wavefront_size;
+        this->amd_max_threads       = internal->amd_max_threads;
+#endif
+
         this->backend         = internal->backend;
         this->scope           = internal->scope;
         this->call_self_value = internal->call_self_value;

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -717,8 +717,11 @@ uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
     ThreadLocal &tl = jitc_thread_local();
 
     // Use the default backend if the variable doesn't specify one
-    if (unlikely(v.backend == (uint32_t) JitBackend::None))
+    if (unlikely(v.backend == (uint32_t) JitBackend::None)) {
         v.backend = (uint32_t) tl.def_backend;
+    } else {
+        tl.def_backend = (JitBackend) v.backend;
+    }
 
 #if defined(DRJIT_ENABLE_METAL)
     // Metal does not support double precision
@@ -745,6 +748,9 @@ uint32_t jitc_var_new(Variable &v, bool disable_lvn) {
     switch ((JitBackend) v.backend) {
 #if defined(DRJIT_ENABLE_CUDA)
         case JitBackend::CUDA:  ts = tl.ts_cuda;  break;
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        case JitBackend::AMD:   ts = tl.ts_amd;   break;
 #endif
 #if defined(DRJIT_ENABLE_METAL)
         case JitBackend::Metal: ts = tl.ts_metal; break;
@@ -1551,6 +1557,10 @@ uint32_t jitc_var_eval_force(uint32_t index, Variable &v_, void **ptr_out) {
 #if defined(DRJIT_ENABLE_CUDA)
         if (tl.ts_cuda)
             tl.ts_cuda->notify_init_undefined(result);
+#endif
+#if defined(DRJIT_ENABLE_AMD)
+        if (tl.ts_amd)
+            tl.ts_amd->notify_init_undefined(result);
 #endif
 #if defined(DRJIT_ENABLE_METAL)
         if (tl.ts_metal)


### PR DESCRIPTION
PR description:

Adds a first AMD/HIP JIT runtime backend to Dr.Jit Core, following the existing CUDA backend shape where possible while keeping backend-specific behavior behind explicit conditionals.

- Implements HIP runtime API loading, module compilation/evaluation, kernel dispatch, memory handling, streams/events, reductions, texture support, and recording support.

- Adds the public AMD backend entry point and internal backend plumbing needed by Dr.Jit and Mitsuba.

- Reuses CUDA-style runtime concepts where they map cleanly and leaves existing CUDA/LLVM paths intact.

Validation:

- Built as part of the Mitsuba AMD Release build on Windows using clang-cl and the ROCm wheel SDK.