### PR TITLE
Fix Metal intersection tags, float bitwise NOT, and symbolic gather guard

### DIFF
--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -631,6 +631,9 @@ static void jitc_metal_render(Variable *v) {
             Variable *a = jitc_var(v->dep[0]);
             if ((VarType) v->type == VarType::Bool)
                 fmt("$t $v = !$v;\n", v, v, a);
+            else if (jitc_is_float(v))
+                fmt("$t $v = as_type<$t>(($b)(~as_type<$b>($v)));\n",
+                    v, v, v, v, v, a);
             else
                 fmt("$t $v = ~$v;\n", v, v, a);
             break;

--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -131,8 +131,8 @@ static bool jitc_metal_render_resource_handle(const Variable *v,
             } else {
                 bool curves = scene && (scene->geometry_types_mask & 0x4u) != 0;
                 tname = curves
-                    ? "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing, raytracing::curve_data>"
-                    : "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing>";
+                    ? "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing, raytracing::world_space_data, raytracing::curve_data>"
+                    : "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing, raytracing::world_space_data>";
             }
             break;
         }
@@ -962,7 +962,8 @@ static void jitc_metal_render(Variable *v) {
                 scene_local && (scene_local->geometry_types_mask & 0x8u) != 0;
             bool extended = has_ift_local || has_curves_local;
 
-            fmt("raytracing::intersector<raytracing::triangle_data, raytracing::instancing$s> _inter;\n",
+            fmt("raytracing::intersector<raytracing::triangle_data, raytracing::instancing$s$s> _inter;\n",
+                has_ift_local ? ", raytracing::world_space_data" : "",
                 has_curves_local ? ", raytracing::curve_data" : "");
 
             if (!extended)

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -2016,6 +2016,12 @@ uint32_t jitc_var_gather(uint32_t src_, uint32_t index, uint32_t mask) {
                        "variable (r%u, kind=%s)!",
                        src_, var_kind_name[(int) src_v->kind]);
 
+        if (var_info.symbolic &&
+            !(jitc_flags() & (uint32_t) JitFlag::SymbolicScope))
+            jitc_raise(
+                "jit_var_gather(): input arrays are symbolic, but the "
+                "operation was issued outside of a symbolic recording session.");
+
         if (mask_v->is_literal() && mask_v->literal == 0) {
             var_info.type = src_info.type;
             result = jitc_make_zero(var_info);


### PR DESCRIPTION
Hi all,

this PR contains three fixes for drjit-core bugs fable found while updating my mitsuba fork to 3.9. The missing world_space_data tag is the most significant one, since it caused intersection misses on primitive shapes (e.g. sphere emitters) for me. Happy to split this into multiple PRs if you prefer.

## Metal codegen: missing world_space_data tag for custom intersectors

The custom-primitive intersection functions (sphere/disk/cylinder/ellipsoid, see resources/metal/) are declared with the MSL `world_space_data` intersection tag, since they operate on world-space rays. However, the codegen never included that tag in the `intersection_function_table<>` resource-handle type or in the `intersector<>` declaration at the trace-ray call site.

Per the MSL spec, an intersection function may only be used with a table/intersector whose tag set is a superset of the function's tags — otherwise the behavior is undefined. In practice, the mismatch meant the functions received object-space ray data where they expected world-space values: a coordinate-frame mismatch that produced silent intersection misses rather than a compile or validation error.

Fixed by adding `raytracing::world_space_data` to both sites: unconditionally in the table's resource-handle type (which is only emitted when an IFT is bound at all), and gated on `has_ift_local` at the intersector declaration, so triangle-only scenes are unaffected. The SDF-grid intersection function correctly omits the tag (it works on the object-space ray) and remains valid under a table with a superset of its tags.

## Metal codegen: bitwise NOT on floats

MSL has no `~` operator for floating-point types, but `VarKind::Not` emitted it unconditionally, producing invalid MSL whenever a non-Bool, non-integer variable needed a bitwise complement. Fixed by reinterpreting to the unsigned-int bit pattern, complementing, and reinterpreting back — mirroring the And/Xor cases directly above and the LLVM backend's handling.

## jit_var_gather: reject symbolic index/mask outside a recording session

`jit_var_scatter` already guards against symbolic inputs outside a symbolic recording session; `jit_var_gather` didn't. This allowed a gather to reference a symbolic loop-internal variable after its recording session closed (in my case: a differentiable scatter into an object outside a loop, replayed via a global AD traverse). On LLVM this aborts the process in `LLVMVerifyModule` ("Instruction does not dominate all uses!"). Fixed by adding the same guard scatter has, so it's now a clean RuntimeError everywhere. On CUDA the same operation did not abort; I did not verify whether the CUDA gradients were correct.






