### PR TITLE
float bitwise-NOT codegen + gather symbolic-scope guard

### DIFF
--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -631,6 +631,9 @@ static void jitc_metal_render(Variable *v) {
             Variable *a = jitc_var(v->dep[0]);
             if ((VarType) v->type == VarType::Bool)
                 fmt("$t $v = !$v;\n", v, v, a);
+            else if (jitc_is_float(v))
+                fmt("$t $v = as_type<$t>(($b)(~as_type<$b>($v)));\n",
+                    v, v, v, v, v, a);
             else
                 fmt("$t $v = ~$v;\n", v, v, a);
             break;

--- a/src/op.cpp
+++ b/src/op.cpp
@@ -2016,6 +2016,12 @@ uint32_t jitc_var_gather(uint32_t src_, uint32_t index, uint32_t mask) {
                        "variable (r%u, kind=%s)!",
                        src_, var_kind_name[(int) src_v->kind]);
 
+        if (var_info.symbolic &&
+            !(jitc_flags() & (uint32_t) JitFlag::SymbolicScope))
+            jitc_raise(
+                "jit_var_gather(): input arrays are symbolic, but the "
+                "operation was issued outside of a symbolic recording session.");
+
         if (mask_v->is_literal() && mask_v->literal == 0) {
             var_info.type = src_info.type;
             result = jitc_make_zero(var_info);


### PR DESCRIPTION
Replaces #205. 4d8c1ae2fd6e7e1c789039d4046db2a9d80c697f was dropped because it was made obsolete by https://github.com/mitsuba-renderer/mitsuba3/commit/5a9d41249c19980f565f916a64cb5c7f5e93264c.

This PR contains two fixes:

## Metal codegen: bitwise NOT on floats

MSL has no `~` operator for floating-point types, but `VarKind::Not` emitted it unconditionally, producing invalid MSL whenever a non-Bool, non-integer variable needed a bitwise complement. Fixed by reinterpreting to the unsigned-int bit pattern, complementing, and reinterpreting back. This mirrors the And/Xor cases and the LLVM backend's handling.

Fixes https://github.com/mitsuba-renderer/mitsuba3/issues/1915.

## jit_var_gather: reject symbolic index/mask outside a recording session

`jit_var_scatter` already guards against symbolic inputs outside a symbolic recording session; `jit_var_gather` didn't. This allowed a gather to reference a symbolic loop-internal variable after its recording session closed (in my case: a differentiable scatter into an outside buffer inside a symbolic loop, replayed via a global AD traverse, which results in a gather to that object in the adjoint phase). On LLVM this aborts the process in `LLVMVerifyModule` ("Instruction does not dominate all uses!"). Fixed by adding the same guard to the gather, so it's now a clean RuntimeError everywhere. On CUDA the same operation did not abort. I did not verify whether the CUDA gradients were correct.

This one is never raised by mitsuba but still a nice to have safeguard in my opinion.

