### PR TITLE
Update ptr to variable map in call upload

### DIFF
--- a/src/call.cpp
+++ b/src/call.cpp
@@ -1225,6 +1225,10 @@ void jitc_call_upload(ThreadState *ts) {
     base_src->data = buf;
     base_src->size = total;
 
+#ifndef NDEBUG
+    state.ptr_to_variable.insert({ base_src->data, call_buffer.base_src });
+#endif
+
     jitc_var(call_buffer.base_v)->literal = (uint64_t) (uintptr_t) buf;
 
     for (CallData *call : calls_assembled)


### PR DESCRIPTION
It seems like the call upload function updated the variable's data pointer without updating the ptr_to_variable map, leaving the ptr_to_variable map in an outdated state (which in turn produced warnings during shutdown).

This PR adds the missing update.