### PR TITLE
Add support for optix instance index

### DIFF
--- a/include/drjit-core/optix.h
+++ b/include/drjit-core/optix.h
@@ -106,6 +106,9 @@ enum class OptixHitObjectField: uint32_t {
     /// Instance ID of the hit object if it is an instanced object [UInt32]
     InstanceId,
 
+    /// Zero-based index of the instance in the IAS [UInt32]
+    InstanceIndex,
+
     /// Index of the primitive that was hit, i.e triangle ID [UInt32]
     PrimitiveIndex,
 
@@ -146,6 +149,7 @@ enum class OptixHitObjectField: uint32_t {
 enum OptixHitObjectField {
     OptixHitObjectFieldIsHit,
     OptixHitObjectFieldInstanceId,
+    OptixHitObjectFieldInstanceIndex,
     OptixHitObjectFieldPrimitiveIndex,
     OptixHitObjectFieldSBTDataPointer,
     OptixHitObjectFieldRayTMax,

--- a/src/cuda_eval.cpp
+++ b/src/cuda_eval.cpp
@@ -1385,6 +1385,10 @@ static void jitc_cuda_render_trace_field(const Variable *v, uint32_t i,
             fmt("    call ($v_out_$u), _optix_hitobject_get_instance_id, ();\n", v, r);
             break;
 
+        case OptixHitObjectField::InstanceIndex:
+            fmt("    call ($v_out_$u), _optix_hitobject_get_instance_idx, ();\n", v, r);
+            break;
+
         case OptixHitObjectField::PrimitiveIndex:
             fmt("    call ($v_out_$u), _optix_hitobject_get_primitive_idx, ();\n", v, r);
             break;

--- a/src/optix_core.cpp
+++ b/src/optix_core.cpp
@@ -642,6 +642,7 @@ void jitc_optix_ray_trace(uint32_t n_args, uint32_t *args,
         switch (hit_object_fields[i]) {
             case OptixHitObjectField::IsHit:
             case OptixHitObjectField::InstanceId:
+            case OptixHitObjectField::InstanceIndex:
             case OptixHitObjectField::PrimitiveIndex:
                 field_type = VarType::UInt32;
                 break;


### PR DESCRIPTION
This PR exposes the OptiX "instance_idx" field to DrJit. This was previously not exposed in the OptiX ray tracing routines.

The motivation to add this is to enable the implementation of a "batched" instancing plugin in Mitsuba 3. This would allow a single instance shape plugin to represent a collection of instances, which dramatically reduces JIT compilation cost for scenes with high instance counts.