### PR TITLE
Add missing XXH3 state init

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -123,6 +123,8 @@ static XXH128_hash_t jitc_cache_checksum(const CacheFileHeader &header,
                                          uint32_t source_size,
                                          const char *compressed) {
     XXH3_state_t xxh_state;
+    xxh_state.seed = 0;
+    xxh_state.extSecret = nullptr;
     XXH3_128bits_reset_withSeed(&xxh_state, DRJIT_CACHE_CHECKSUM_SEED);
     XXH3_128bits_update(&xxh_state, &header, offsetof(CacheFileHeader, checksum));
     XXH3_128bits_update(&xxh_state, source, source_size);


### PR DESCRIPTION
The `XXH3_state_t` object needs to be explicitly initialized to 0, otherwise we run into possibly undefined behavior due to the use of uninitialized memory (see also https://xxhash.com/doc/v0.8.2/xxhash_8h.html#afc79de39f0cf7e8d395f131c0d9d568e). The macro appears to not be included in the version of xxhash we include, but we can directly set the same fields to zero:

```cpp
xxh_state.seed = 0;
xxh_state.extSecret = nullptr;
```