### PR TITLE
Fix masked array write for booleans in LLVM

### DIFF
--- a/src/llvm_array.cpp
+++ b/src/llvm_array.cpp
@@ -257,11 +257,11 @@ void jitc_llvm_render_array_write(Variable *v, Variable *target,
                 v, value, ext, v, v);
         } else {
             fmt("    $v_5 = load $M, ptr $v_3, align $A\n"
-                "    $v_6 = select $V, $M $v$s, $V_5\n"
-                "    store $V_6, ptr $v_3, align $A\n",
+                "    $v_6 = select $V, $M $v$s, $M $v_5\n"
+                "    store $M $v_6, ptr $v_3, align $A\n",
                 v, v, v, v,
-                v, mask, v, value, ext, v,
-                v, v, v);
+                v, mask, v, value, ext, v, v,
+                v, v, v, v);
         }
     } else if (jitc_llvm_vector_width >= 8 && DRJIT_LLVM_OPTIMIZE_ARRAY_ACCESSES) {
         /// Check if the scatter can be reduced to a packet store
@@ -302,11 +302,11 @@ void jitc_llvm_render_array_write(Variable *v, Variable *target,
                 v, value, ext, v, v);
         } else {
             fmt("    $v_10 = load $M, ptr $v_8, align $A\n"
-                "    $v_11 = select $V, $M $v$s, $V_10\n"
-                "    store $V_11, ptr $v_8, align $A\n",
+                "    $v_11 = select $V, $M $v$s, $M $v_10\n"
+                "    store $M $v_11, ptr $v_8, align $A\n",
                 v, v, v, v,
-                v, mask, v, value, ext, v,
-                v, v, v);
+                v, mask, v, value, ext, v, v,
+                v, v, v, v);
         }
 
         fmt("    br label %l_$u_done\n\n", v->reg_index);


### PR DESCRIPTION
As it was, the generated IR for LLVM had a mismatch between the loaded memory type a boolean and it's register type when doing a masked array write to local memory.

This fix corrects the type used when selecting the value to write to memory.

A reproducer could be:

```python
import drjit as dr
from drjit.llvm import Bool, UInt32

mem = dr.alloc_local(Bool, 5, Bool(False))

idx = dr.arange(UInt32, 5)
mem.write(idx % 2 == 0, idx, idx % 2 == 0)

assert dr.allclose(idx % 2 == 0, mem[idx])
``` 

and caused the following LLVM compilation error:
```
drjit_862113d15d92f0ff2e90f067ed6ff024:40:63: error: '%p12_10' defined with type '<8 x i8>' but expected '<8 x i1>'
    %p12_11 = select <8 x i1> %p11, <8 x i8> %p12_e, <8 x i1> %p12_10
                                                              ^

Aborted                    (core dumped) /usr/bin/gpkg python "$@"
```