### PR TITLE
Add time argument to Metal ray tracing

### DIFF
--- a/include/drjit-core/metal.h
+++ b/include/drjit-core/metal.h
@@ -80,6 +80,7 @@ extern JIT_EXPORT void *jit_metal_command_queue();
  *     Bit 1: bounding-box (custom-intersection) geometry present.
  *     Bit 2: curve geometry present.
  *     Bit 3: triangle backface culling required for at least one instance.
+ *     Bit 4: motion (instance motion) present.
  */
 extern JIT_EXPORT uint32_t jit_metal_configure_scene(
     void *acceleration_structure,
@@ -104,11 +105,11 @@ extern JIT_EXPORT uint32_t jit_metal_configure_scene(
  * clear them.
  *
  * \param n_args
- *     Number of ray input arguments. Must be 8, or 9 when a per-lane
+ *     Number of ray input arguments. Must be 9, or 10 when a per-lane
  *     visibility mask is supplied.
  *
  * \param args
- *     Array of 8 (or 9) JIT variable indices:
+ *     Array of 9 (or 10) JIT variable indices:
  *       [0] ox     (Float32) — ray origin X
  *       [1] oy     (Float32) — ray origin Y
  *       [2] oz     (Float32) — ray origin Z
@@ -117,7 +118,8 @@ extern JIT_EXPORT uint32_t jit_metal_configure_scene(
  *       [5] dz     (Float32) — ray direction Z
  *       [6] tmin   (Float32) — minimum ray distance
  *       [7] tmax   (Float32) — maximum ray distance
- *       [8] vmask  (UInt32)  — optional visibility mask
+ *       [8] time   (Float32) — ray evaluation time
+ *       [9] vmask  (UInt32)  — optional visibility mask
  *
  * \param mask
  *     JIT variable index of the active lane mask (Bool).

--- a/src/metal_core.mm
+++ b/src/metal_core.mm
@@ -1461,12 +1461,12 @@ void jitc_metal_profile_stop() {
 void jitc_metal_ray_trace(uint32_t n_args, uint32_t *args,
                           uint32_t mask, uint32_t *out,
                           uint32_t n_out, uint32_t scene, int shadow) {
-    if (n_args != 8 && n_args != 9)
-        jitc_raise("jit_metal_ray_trace(): expected 8 or 9 ray arguments, "
+    if (n_args != 9 && n_args != 10)
+        jitc_raise("jit_metal_ray_trace(): expected 9 or 10 ray arguments, "
                    "got %u.", n_args);
-    if (n_args == 9 && jitc_var_type(args[8]) != VarType::UInt32)
+    if (n_args == 10 && jitc_var_type(args[9]) != VarType::UInt32)
         jitc_raise("jit_metal_ray_trace(): the ray visibility mask "
-                   "(argument 9) must be of type UInt32.");
+                   "(argument 10) must be of type UInt32.");
     if (n_out != 8)
         jitc_raise("jit_metal_ray_trace(): expected 8 outputs, got %u.",
                    n_out);

--- a/src/metal_eval.cpp
+++ b/src/metal_eval.cpp
@@ -123,12 +123,22 @@ static bool jitc_metal_render_resource_handle(const Variable *v,
             MetalScene *scene = (MetalScene *) (uintptr_t) v->literal;
             metal_register_kernel_scene(scene);
             if (kind == ResourceKind::Accel) {
-                tname = "raytracing::instance_acceleration_structure";
+                bool motion = scene && (scene->geometry_types_mask & 0x10u) != 0;
+                tname = motion
+                    ? "raytracing::acceleration_structure<raytracing::instancing, raytracing::instance_motion>"
+                    : "raytracing::instance_acceleration_structure";
             } else {
                 bool curves = scene && (scene->geometry_types_mask & 0x4u) != 0;
-                tname = curves
-                    ? "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing, raytracing::curve_data>"
-                    : "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing>";
+                bool motion = scene && (scene->geometry_types_mask & 0x10u) != 0;
+                if (curves) {
+                    tname = motion
+                        ? "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing, raytracing::curve_data, raytracing::instance_motion>"
+                        : "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing, raytracing::curve_data>";
+                } else {
+                    tname = motion
+                        ? "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing, raytracing::instance_motion>"
+                        : "raytracing::intersection_function_table<raytracing::triangle_data, raytracing::instancing>";
+                }
             }
             break;
         }
@@ -795,21 +805,25 @@ static void jitc_metal_render(Variable *v) {
             Variable *dz   = jitc_var(td->indices[5]);
             Variable *tmin = jitc_var(td->indices[6]);
             Variable *tmax = jitc_var(td->indices[7]);
+            Variable *time = jitc_var(td->indices[8]);
 
             // Optional per-lane visibility mask, tested against the
             // per-instance mask of the TLAS entries
             Variable *rmask =
-                td->indices.size() > 8 ? jitc_var(td->indices[8]) : nullptr;
+                td->indices.size() > 9 ? jitc_var(td->indices[9]) : nullptr;
 
             bool has_ift_local = ift_h != nullptr;
             bool has_curves_local =
                 scene_local && (scene_local->geometry_types_mask & 0x4u) != 0;
             bool has_backface_culled_triangles_local =
                 scene_local && (scene_local->geometry_types_mask & 0x8u) != 0;
+            bool has_motion_local =
+                scene_local && (scene_local->geometry_types_mask & 0x10u) != 0;
             bool extended = has_ift_local || has_curves_local;
 
-            fmt("raytracing::intersector<raytracing::triangle_data, raytracing::instancing$s> _inter;\n",
-                has_curves_local ? ", raytracing::curve_data" : "");
+            fmt("raytracing::intersector<raytracing::triangle_data, raytracing::instancing$s$s> _inter;\n",
+                has_curves_local ? ", raytracing::curve_data" : "",
+                has_motion_local ? ", raytracing::instance_motion" : "");
 
             if (!extended)
                 put("_inter.assume_geometry_type(raytracing::geometry_type::triangle);\n");
@@ -829,20 +843,38 @@ static void jitc_metal_render(Variable *v) {
 
             // Route the intersect call to this trace's reconstructed accel
             // (+ IFT) reference variables.
-            if (has_ift_local) {
-                if (rmask)
-                    fmt("auto _hit = _inter.intersect(_r, $v, $v, $v);\n",
-                        accel_h, rmask, ift_h);
-                else
-                    fmt("auto _hit = _inter.intersect(_r, $v, $v);\n",
-                        accel_h, ift_h);
+            if (has_motion_local) {
+                if (has_ift_local) {
+                    if (rmask)
+                        fmt("auto _hit = _inter.intersect(_r, $v, $v, $v, $v);\n",
+                            accel_h, rmask, time, ift_h);
+                    else
+                        fmt("auto _hit = _inter.intersect(_r, $v, $v, $v);\n",
+                            accel_h, time, ift_h);
+                } else {
+                    if (rmask)
+                        fmt("auto _hit = _inter.intersect(_r, $v, $v, $v);\n",
+                            accel_h, rmask, time);
+                    else
+                        fmt("auto _hit = _inter.intersect(_r, $v, $v);\n",
+                            accel_h, time);
+                }
             } else {
-                if (rmask)
-                    fmt("auto _hit = _inter.intersect(_r, $v, $v);\n",
-                        accel_h, rmask);
-                else
-                    fmt("auto _hit = _inter.intersect(_r, $v);\n",
-                        accel_h);
+                if (has_ift_local) {
+                    if (rmask)
+                        fmt("auto _hit = _inter.intersect(_r, $v, $v, $v);\n",
+                            accel_h, rmask, ift_h);
+                    else
+                        fmt("auto _hit = _inter.intersect(_r, $v, $v);\n",
+                            accel_h, ift_h);
+                } else {
+                    if (rmask)
+                        fmt("auto _hit = _inter.intersect(_r, $v, $v);\n",
+                            accel_h, rmask);
+                    else
+                        fmt("auto _hit = _inter.intersect(_r, $v);\n",
+                            accel_h);
+                }
             }
 
             // Hit-result extraction.

--- a/tests/metal_triangle.mm
+++ b/tests/metal_triangle.mm
@@ -155,23 +155,23 @@ static void demo() {
               oy = Float(y) * (2.0f / res) - 1.0f,
               oz = -1.f;
         Float dx = 0.f, dy = 0.f, dz = 1.f;
-        Float mint = 0.f, maxt = 100.f;
+        Float mint = 0.f, maxt = 100.f, time = 0.f;
         Mask  mask = true;
 
         // =====================================================
         //  Trace all rays in a single batched launch
         // =====================================================
-        uint32_t ray_args[8] = {
+        uint32_t ray_args[9] = {
             ox.index(), oy.index(), oz.index(),
             dx.index(), dy.index(), dz.index(),
-            mint.index(), maxt.index()
+            mint.index(), maxt.index(), time.index()
         };
 
-        uint32_t out[7];
-        jit_metal_ray_trace(8, ray_args, mask.index(), out, 7, scene.index(), false);
+        uint32_t out[8];
+        jit_metal_ray_trace(9, ray_args, mask.index(), out, 8, scene.index(), false);
 
         Mask valid = Mask::steal(out[0]);
-        for (int k = 1; k < 7; ++k)
+        for (int k = 1; k < 8; ++k)
             jit_var_dec_ref(out[k]);
 
         // Convert the hit mask to a 0/1 image and read it back on the host.


### PR DESCRIPTION
Passes the time argument to the Metal ray tracing call. For Embree/OptiX this is already done, but Metal previously omitted this.